### PR TITLE
Grammar fix for VisionClient docs.

### DIFF
--- a/src/viam/services/vision.py
+++ b/src/viam/services/vision.py
@@ -53,7 +53,7 @@ class VisionClient:
         return list(response.detector_names)
 
     async def add_detector(self, detector: DetectorConfig):
-        """Add a new detector to the service. Returns nothing is successful, and an error if not.
+        """Add a new detector to the service. Returns nothing if successful, and an error if not.
         Registers a new detector just as if you had put it in the original "register_detectors" field
         in the robot config. Available types and their parameters can be found in the 
         vision service documentation.


### PR DESCRIPTION
Based on feedback from the friends event: 

```
under add_detector at https://python.viam.dev/autoapi/viam/services/vision/index.html#module-contents it has "Returns nothing is successful" -- should be "if"
```

Source: https://docs.google.com/spreadsheets/d/1JFU7UeSmASmFHQxG_dUzmAAHG_BGrP5j9mZJODcWJqM/edit#gid=1541320107