### PR TITLE
Preserve proto field name when serializing to struct proto

### DIFF
--- a/src/viam/utils.py
+++ b/src/viam/utils.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, SupportsFloat
 
-from google.protobuf.json_format import MessageToDict
+from google.protobuf.json_format import MessageToDict, ParseDict
 from google.protobuf.message import Message
 from google.protobuf.struct_pb2 import ListValue, Struct, Value
 
@@ -106,15 +106,26 @@ def resource_names_for_component(
 
 def message_to_struct(message: Message) -> Struct:
     struct = Struct()
-    struct.update(MessageToDict(message, preserving_proto_field_name=True))
+    struct.update(
+        MessageToDict(
+            message,
+            including_default_value_fields=True,
+            preserving_proto_field_name=True,
+        ),
+    )
     return struct
 
 
-def struct_to_dict(struct: Struct) -> Dict[str, Any]:
-    return {key: value_to_primitive(value) for (key, value) in struct.fields.items()}
+def struct_to_message(struct: Struct, message: Message) -> Message:
+    dct = struct_to_dict(struct)
+    return ParseDict(dct, message)
 
 
 def dict_to_struct(obj: Dict[str, Any]) -> Struct:
     struct = Struct()
     struct.update(obj)
     return struct
+
+
+def struct_to_dict(struct: Struct) -> Dict[str, Any]:
+    return {key: value_to_primitive(value) for (key, value) in struct.fields.items()}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,10 @@
-from google.protobuf.struct_pb2 import Struct, ListValue, Value
 import pytest
+from google.protobuf.json_format import ParseError
+from google.protobuf.struct_pb2 import ListValue, Struct, Value
 
-from viam.proto.api.common import ActuatorStatus
-from viam.utils import dict_to_struct, message_to_struct, primitive_to_value, struct_to_dict, value_to_primitive
+from viam.proto.api.common import ActuatorStatus, ResourceName
+from viam.utils import (dict_to_struct, message_to_struct, primitive_to_value,
+                        struct_to_dict, struct_to_message, value_to_primitive)
 
 
 def test_primitive_to_value():
@@ -97,19 +99,62 @@ def test_value_to_primitive():
     assert prim == b'viamtest'.decode()
 
 
-def test_message_to_struct():
+@pytest.mark.parametrize(
+    'input,expected',
+    [
+        (ActuatorStatus(is_moving=False), Struct(fields={'is_moving': Value(bool_value=False)})),
+        (ActuatorStatus(is_moving=True), Struct(fields={'is_moving': Value(bool_value=True)})),
+        (
+            Struct(fields={
+                'foo': Value(string_value='bar'),
+                'one': Value(number_value=1),
+            }),
+            Struct(fields={
+                'foo': Value(string_value='bar'),
+                'one': Value(number_value=1),
+            }),
+        ),
+    ]
+)
+def test_message_to_struct(input, expected):
+    assert message_to_struct(input) == expected
+
+
+def test_message_to_struct_keys():
     status = ActuatorStatus(is_moving=True)
-    struct = Struct(fields={'is_moving': Value(bool_value=True)})
-    assert message_to_struct(status) == struct
+    struct = message_to_struct(status)
+    key = list(struct.keys())[0]
+    assert key == 'is_moving'
 
+
+@pytest.mark.parametrize(
+    'input,empty_msg,expected',
+    [
+        (message_to_struct(ActuatorStatus(is_moving=True)), ActuatorStatus(), ActuatorStatus(is_moving=True)),
+        (Struct(fields={'is_moving': Value(bool_value=True)}), ActuatorStatus(), ActuatorStatus(is_moving=True)),
+        (message_to_struct(ActuatorStatus(is_moving=False)), ActuatorStatus(), ActuatorStatus(is_moving=False)),
+        (Struct(fields={'is_moving': Value(bool_value=False)}), ActuatorStatus(), ActuatorStatus(is_moving=False)),
+        (Struct(fields={'isMoving': Value(bool_value=True)}), ActuatorStatus(), ActuatorStatus(is_moving=True)),
+        (Struct(fields={'isMoving': Value(bool_value=False)}), ActuatorStatus(), ActuatorStatus(is_moving=False)),
+        (Struct(
+            fields={
+                'namespace': Value(string_value='rdk'),
+                'type': Value(string_value='component'),
+                'subtype': Value(string_value='arm'),
+                'name': Value(string_value='arm1')
+            }),
+         ResourceName(),
+         ResourceName(namespace='rdk', type='component', subtype='arm', name='arm1')),
+    ]
+)
+def test_struct_to_message(input, empty_msg, expected):
+    assert struct_to_message(input, empty_msg) == expected
+
+
+def test_struct_to_message_error():
     struct = Struct(fields={'IsMoving': Value(bool_value=True)})
-    assert message_to_struct(status) != struct
-
-    struct = Struct(fields={
-        'foo': Value(string_value='bar'),
-        'one': Value(number_value=1),
-    })
-    assert message_to_struct(struct) == struct
+    with pytest.raises(ParseError):
+        struct_to_message(struct, ActuatorStatus())
 
 
 def test_dict_to_struct():


### PR DESCRIPTION
When deserializing from structs in proto messages, the RDK and frontend UI both assume that field names are in snake_case (which is how the proto field names are defined). Python does camelCase right now.
So python and other SDKs should follow suit