### PR TITLE
[RSDK-199] Add timeouts to components

### DIFF
--- a/examples/server/v1/client.py
+++ b/examples/server/v1/client.py
@@ -23,7 +23,7 @@ async def client():
         print("\n#### ARM ####")
         arm = Arm.from_robot(robot, "arm0")
         await arm.move_to_position(Pose(x=0, y=1, z=2, o_x=3, o_y=4, o_z=5, theta=6))
-        position = await arm.get_end_position()
+        position = await asyncio.wait_for(arm.get_end_position(), 1)
         print(f"Arm position is: {position}")
 
         print("\n#### BASE ####")

--- a/examples/server/v1/client.py
+++ b/examples/server/v1/client.py
@@ -23,7 +23,7 @@ async def client():
         print("\n#### ARM ####")
         arm = Arm.from_robot(robot, "arm0")
         await arm.move_to_position(Pose(x=0, y=1, z=2, o_x=3, o_y=4, o_z=5, theta=6))
-        position = await asyncio.wait_for(arm.get_end_position(), 1)
+        position = await arm.get_end_position()
         print(f"Arm position is: {position}")
 
         print("\n#### BASE ####")

--- a/examples/server/v1/components.py
+++ b/examples/server/v1/components.py
@@ -65,14 +65,8 @@ class ExampleArm(Arm):
         self.is_stopped = True
         super().__init__(name)
 
-    @run_with_operation
     async def get_end_position(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> Pose:
-        operation = self.get_operation(kwargs)
-        print("starting")
-        print(await operation.is_cancelled())
         await asyncio.sleep(3)
-        print("ending")
-        print(await operation.is_cancelled())
         return self.position
 
     async def move_to_position(

--- a/examples/server/v1/components.py
+++ b/examples/server/v1/components.py
@@ -66,7 +66,6 @@ class ExampleArm(Arm):
         super().__init__(name)
 
     async def get_end_position(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> Pose:
-        await asyncio.sleep(3)
         return self.position
 
     async def move_to_position(

--- a/examples/server/v1/components.py
+++ b/examples/server/v1/components.py
@@ -65,7 +65,14 @@ class ExampleArm(Arm):
         self.is_stopped = True
         super().__init__(name)
 
+    @run_with_operation
     async def get_end_position(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> Pose:
+        operation = self.get_operation(kwargs)
+        print("starting")
+        print(await operation.is_cancelled())
+        await asyncio.sleep(3)
+        print("ending")
+        print(await operation.is_cancelled())
         return self.position
 
     async def move_to_position(

--- a/src/viam/components/arm/arm.py
+++ b/src/viam/components/arm/arm.py
@@ -20,8 +20,8 @@ class Arm(ComponentBase):
     @abc.abstractmethod
     async def get_end_position(
         self,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
         **kwargs,
     ) -> Pose:
@@ -37,8 +37,8 @@ class Arm(ComponentBase):
         self,
         pose: Pose,
         world_state: Optional[WorldState] = None,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
         **kwargs,
     ):
@@ -58,8 +58,8 @@ class Arm(ComponentBase):
     async def move_to_joint_positions(
         self,
         positions: JointPositions,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
         **kwargs,
     ):
@@ -75,8 +75,8 @@ class Arm(ComponentBase):
     @abc.abstractmethod
     async def get_joint_positions(
         self,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
         **kwargs,
     ) -> JointPositions:
@@ -91,8 +91,8 @@ class Arm(ComponentBase):
     @abc.abstractmethod
     async def stop(
         self,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
         **kwargs,
     ):

--- a/src/viam/components/arm/arm.py
+++ b/src/viam/components/arm/arm.py
@@ -18,7 +18,13 @@ class Arm(ComponentBase):
     """
 
     @abc.abstractmethod
-    async def get_end_position(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> Pose:
+    async def get_end_position(
+        self,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> Pose:
         """
         Get the current position of the end of the arm expressed as a Pose.
 
@@ -28,7 +34,13 @@ class Arm(ComponentBase):
 
     @abc.abstractmethod
     async def move_to_position(
-        self, pose: Pose, world_state: Optional[WorldState] = None, extra: Optional[Dict[str, Any]] = None, **kwargs
+        self,
+        pose: Pose,
+        world_state: Optional[WorldState] = None,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+        **kwargs,
     ):
         """
         Move the end of the arm to the Pose specified in `pose`.
@@ -43,7 +55,14 @@ class Arm(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def move_to_joint_positions(self, positions: JointPositions, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def move_to_joint_positions(
+        self,
+        positions: JointPositions,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
         """
         Move each joint on the arm to the corresponding angle specified in `positions`.
 
@@ -54,7 +73,13 @@ class Arm(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def get_joint_positions(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> JointPositions:
+    async def get_joint_positions(
+        self,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> JointPositions:
         """
         Get the JointPositions representing the current position of the arm.
 
@@ -64,7 +89,13 @@ class Arm(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def stop(self, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def stop(
+        self,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
         """
         Stop all motion of the arm. It is assumed that the arm stops immediately.
         """

--- a/src/viam/components/arm/client.py
+++ b/src/viam/components/arm/client.py
@@ -33,8 +33,8 @@ class ArmClient(Arm):
 
     async def get_end_position(
         self,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
     ) -> Pose:
         if extra is None:
@@ -47,8 +47,8 @@ class ArmClient(Arm):
         self,
         pose: Pose,
         world_state: Optional[WorldState] = None,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
     ):
         if extra is None:
@@ -58,8 +58,8 @@ class ArmClient(Arm):
 
     async def get_joint_positions(
         self,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
     ) -> JointPositions:
         if extra is None:
@@ -71,8 +71,8 @@ class ArmClient(Arm):
     async def move_to_joint_positions(
         self,
         positions: JointPositions,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
     ):
         if extra is None:
@@ -82,8 +82,8 @@ class ArmClient(Arm):
 
     async def stop(
         self,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
     ):
         if extra is None:

--- a/src/viam/components/arm/client.py
+++ b/src/viam/components/arm/client.py
@@ -91,5 +91,10 @@ class ArmClient(Arm):
         request = StopRequest(name=self.name, extra=dict_to_struct(extra))
         await self.client.Stop(request, timeout=timeout)
 
-    async def do_command(self, command: Dict[str, Any]) -> Dict[str, Any]:
-        return await do_command(self.channel, self.name, command)
+    async def do_command(
+        self,
+        command: Dict[str, Any],
+        *,
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        return await do_command(self.channel, self.name, command, timeout=timeout)

--- a/src/viam/components/arm/client.py
+++ b/src/viam/components/arm/client.py
@@ -31,11 +31,11 @@ class ArmClient(Arm):
         self.client = ArmServiceStub(channel)
         super().__init__(name)
 
-    async def get_end_position(self, extra: Optional[Dict[str, Any]] = None) -> Pose:
+    async def get_end_position(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None) -> Pose:
         if extra is None:
             extra = {}
         request = GetEndPositionRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetEndPositionResponse = await self.client.GetEndPosition(request)
+        response: GetEndPositionResponse = await self.client.GetEndPosition(request, timeout=timeout)
         return response.pose
 
     async def move_to_position(

--- a/src/viam/components/arm/client.py
+++ b/src/viam/components/arm/client.py
@@ -31,7 +31,12 @@ class ArmClient(Arm):
         self.client = ArmServiceStub(channel)
         super().__init__(name)
 
-    async def get_end_position(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None) -> Pose:
+    async def get_end_position(
+        self,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+    ) -> Pose:
         if extra is None:
             extra = {}
         request = GetEndPositionRequest(name=self.name, extra=dict_to_struct(extra))
@@ -43,30 +48,48 @@ class ArmClient(Arm):
         pose: Pose,
         world_state: Optional[WorldState] = None,
         extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
     ):
         if extra is None:
             extra = {}
         request = MoveToPositionRequest(name=self.name, to=pose, world_state=world_state, extra=dict_to_struct(extra))
-        await self.client.MoveToPosition(request)
+        await self.client.MoveToPosition(request, timeout=timeout)
 
-    async def get_joint_positions(self, extra: Optional[Dict[str, Any]] = None) -> JointPositions:
+    async def get_joint_positions(
+        self,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+    ) -> JointPositions:
         if extra is None:
             extra = {}
         request = GetJointPositionsRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetJointPositionsResponse = await self.client.GetJointPositions(request)
+        response: GetJointPositionsResponse = await self.client.GetJointPositions(request, timeout=timeout)
         return response.positions
 
-    async def move_to_joint_positions(self, positions: JointPositions, extra: Optional[Dict[str, Any]] = None):
+    async def move_to_joint_positions(
+        self,
+        positions: JointPositions,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+    ):
         if extra is None:
             extra = {}
         request = MoveToJointPositionsRequest(name=self.name, positions=positions, extra=dict_to_struct(extra))
-        await self.client.MoveToJointPositions(request)
+        await self.client.MoveToJointPositions(request, timeout=timeout)
 
-    async def stop(self, extra: Optional[Dict[str, Any]] = None):
+    async def stop(
+        self,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+    ):
         if extra is None:
             extra = {}
         request = StopRequest(name=self.name, extra=dict_to_struct(extra))
-        await self.client.Stop(request)
+        await self.client.Stop(request, timeout=timeout)
 
     async def do_command(self, command: Dict[str, Any]) -> Dict[str, Any]:
         return await do_command(self.channel, self.name, command)

--- a/src/viam/components/arm/service.py
+++ b/src/viam/components/arm/service.py
@@ -34,7 +34,8 @@ class ArmService(ArmServiceBase, ComponentServiceBase[Arm]):
             arm = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        position = await arm.get_end_position(extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        position = await arm.get_end_position(extra=struct_to_dict(request.extra), timeout=timeout)
         response = GetEndPositionResponse(pose=position)
         await stream.send_message(response)
 
@@ -46,7 +47,8 @@ class ArmService(ArmServiceBase, ComponentServiceBase[Arm]):
             arm = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await arm.move_to_position(request.to, request.world_state, extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await arm.move_to_position(request.to, request.world_state, extra=struct_to_dict(request.extra), timeout=timeout)
         response = MoveToPositionResponse()
         await stream.send_message(response)
 
@@ -58,7 +60,8 @@ class ArmService(ArmServiceBase, ComponentServiceBase[Arm]):
             arm = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        positions = await arm.get_joint_positions(extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        positions = await arm.get_joint_positions(extra=struct_to_dict(request.extra), timeout=timeout)
         response = GetJointPositionsResponse(positions=positions)
         await stream.send_message(response)
 
@@ -70,7 +73,8 @@ class ArmService(ArmServiceBase, ComponentServiceBase[Arm]):
             arm = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await arm.move_to_joint_positions(request.positions, extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await arm.move_to_joint_positions(request.positions, extra=struct_to_dict(request.extra), timeout=timeout)
         response = MoveToJointPositionsResponse()
         await stream.send_message(response)
 
@@ -82,6 +86,7 @@ class ArmService(ArmServiceBase, ComponentServiceBase[Arm]):
             arm = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await arm.stop(extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await arm.stop(extra=struct_to_dict(request.extra), timeout=timeout)
         response = StopResponse()
         await stream.send_message(response)

--- a/src/viam/components/audio_input/audio_input.py
+++ b/src/viam/components/audio_input/audio_input.py
@@ -50,7 +50,7 @@ class AudioInput(ComponentBase, MediaSource[Audio]):
             )
 
     @abc.abstractmethod
-    async def stream(self) -> AudioStream:
+    async def stream(self, **kwargs) -> AudioStream:
         """Stream audio samples from the audio input of the underlying robot
 
         Returns:
@@ -59,7 +59,7 @@ class AudioInput(ComponentBase, MediaSource[Audio]):
         ...
 
     @abc.abstractmethod
-    async def get_properties(self) -> Properties:
+    async def get_properties(self, **kwargs) -> Properties:
         """Get the properties of the audio input of the underlying robot
 
         Returns:

--- a/src/viam/components/audio_input/audio_input.py
+++ b/src/viam/components/audio_input/audio_input.py
@@ -1,6 +1,7 @@
 import abc
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import Optional
 
 from google.protobuf.duration_pb2 import Duration
 from typing_extensions import Self
@@ -50,7 +51,7 @@ class AudioInput(ComponentBase, MediaSource[Audio]):
             )
 
     @abc.abstractmethod
-    async def stream(self, **kwargs) -> AudioStream:
+    async def stream(self, *, timeout: Optional[float] = None, **kwargs) -> AudioStream:
         """Stream audio samples from the audio input of the underlying robot
 
         Returns:
@@ -59,7 +60,7 @@ class AudioInput(ComponentBase, MediaSource[Audio]):
         ...
 
     @abc.abstractmethod
-    async def get_properties(self, **kwargs) -> Properties:
+    async def get_properties(self, *, timeout: Optional[float] = None, **kwargs) -> Properties:
         """Get the properties of the audio input of the underlying robot
 
         Returns:

--- a/src/viam/components/audio_input/client.py
+++ b/src/viam/components/audio_input/client.py
@@ -52,5 +52,5 @@ class AudioInputClient(AudioInput):
         response: PropertiesResponse = await self.client.Properties(request, timeout=timeout)
         return AudioInput.Properties.from_proto(response)
 
-    async def do_command(self, command: Dict[str, Any]) -> Dict[str, Any]:
-        return await do_command(self.channel, self.name, command)
+    async def do_command(self, command: Dict[str, Any], *, timeout: Optional[float] = None) -> Dict[str, Any]:
+        return await do_command(self.channel, self.name, command, timeout=timeout)

--- a/src/viam/components/audio_input/service.py
+++ b/src/viam/components/audio_input/service.py
@@ -36,7 +36,8 @@ class AudioInputService(AudioInputServiceBase, ComponentServiceBase[AudioInput])
         except ComponentNotFoundError as e:
             raise e.grpc_error
 
-        audio_stream = await audio_input.stream()
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        audio_stream = await audio_input.stream(timeout=timeout)
         first_chunk = await audio_stream.__anext__()
         await stream.send_message(ChunksResponse(info=first_chunk.info))
         await stream.send_message(ChunksResponse(chunk=first_chunk.chunk))
@@ -51,7 +52,8 @@ class AudioInputService(AudioInputServiceBase, ComponentServiceBase[AudioInput])
             audio_input = self.get_component(request.name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        response = (await audio_input.get_properties()).proto
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        response = (await audio_input.get_properties(timeout=timeout)).proto
         await stream.send_message(response)
 
     async def Record(self, stream: Stream[RecordRequest, HttpBody]) -> None:

--- a/src/viam/components/base/base.py
+++ b/src/viam/components/base/base.py
@@ -17,7 +17,15 @@ class Base(ComponentBase):
     """
 
     @abc.abstractmethod
-    async def move_straight(self, distance: int, velocity: float, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def move_straight(
+        self,
+        distance: int,
+        velocity: float,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
         """
         Move the base in a straight line the given `distance`, expressed in millimeters,
         at the given `velocity`, expressed in millimeters per second.
@@ -33,7 +41,15 @@ class Base(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def spin(self, angle: float, velocity: float, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def spin(
+        self,
+        angle: float,
+        velocity: float,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
         """
         Spin the base in place `angle` degrees, at the given angular `velocity`,
         expressed in degrees per second.
@@ -49,7 +65,15 @@ class Base(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def set_power(self, linear: Vector3, angular: Vector3, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def set_power(
+        self,
+        linear: Vector3,
+        angular: Vector3,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
         """Set the linear and angular velocity of the Base
         When `linear` is 0, the the base will spin.
         When `angular` is 0, the the base will move in a straight line.
@@ -66,7 +90,15 @@ class Base(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def set_velocity(self, linear: Vector3, angular: Vector3, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def set_velocity(
+        self,
+        linear: Vector3,
+        angular: Vector3,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
         """
         Set the linear and angular velocities of the base.
 
@@ -77,7 +109,13 @@ class Base(ComponentBase):
         """
 
     @abc.abstractmethod
-    async def stop(self, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def stop(
+        self,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
         """
         Stop the base.
         """

--- a/src/viam/components/base/base.py
+++ b/src/viam/components/base/base.py
@@ -21,8 +21,8 @@ class Base(ComponentBase):
         self,
         distance: int,
         velocity: float,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
         **kwargs,
     ):
@@ -45,8 +45,8 @@ class Base(ComponentBase):
         self,
         angle: float,
         velocity: float,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
         **kwargs,
     ):
@@ -69,8 +69,8 @@ class Base(ComponentBase):
         self,
         linear: Vector3,
         angular: Vector3,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
         **kwargs,
     ):
@@ -94,8 +94,8 @@ class Base(ComponentBase):
         self,
         linear: Vector3,
         angular: Vector3,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
         **kwargs,
     ):
@@ -111,8 +111,8 @@ class Base(ComponentBase):
     @abc.abstractmethod
     async def stop(
         self,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
         **kwargs,
     ):

--- a/src/viam/components/base/client.py
+++ b/src/viam/components/base/client.py
@@ -26,7 +26,14 @@ class BaseClient(Base):
         self.client = BaseServiceStub(channel)
         super().__init__(name)
 
-    async def move_straight(self, distance: int, velocity: float, extra: Optional[Dict[str, Any]] = None):
+    async def move_straight(
+        self,
+        distance: int,
+        velocity: float,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+    ):
         if extra is None:
             extra = {}
         request = MoveStraightRequest(
@@ -35,9 +42,16 @@ class BaseClient(Base):
             mm_per_sec=velocity,
             extra=dict_to_struct(extra),
         )
-        await self.client.MoveStraight(request)
+        await self.client.MoveStraight(request, timeout=timeout)
 
-    async def spin(self, angle: float, velocity: float, extra: Optional[Dict[str, Any]] = None):
+    async def spin(
+        self,
+        angle: float,
+        velocity: float,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+    ):
         if extra is None:
             extra = {}
         request = SpinRequest(
@@ -46,9 +60,16 @@ class BaseClient(Base):
             degs_per_sec=velocity,
             extra=dict_to_struct(extra),
         )
-        await self.client.Spin(request)
+        await self.client.Spin(request, timeout=timeout)
 
-    async def set_power(self, linear: Vector3, angular: Vector3, extra: Optional[Dict[str, Any]] = None):
+    async def set_power(
+        self,
+        linear: Vector3,
+        angular: Vector3,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+    ):
         if extra is None:
             extra = {}
         request = SetPowerRequest(
@@ -57,19 +78,36 @@ class BaseClient(Base):
             angular=angular,
             extra=dict_to_struct(extra),
         )
-        await self.client.SetPower(request)
+        await self.client.SetPower(request, timeout=timeout)
 
-    async def set_velocity(self, linear: Vector3, angular: Vector3, extra: Optional[Dict[str, Any]] = None):
+    async def set_velocity(
+        self,
+        linear: Vector3,
+        angular: Vector3,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+    ):
         if extra is None:
             extra = {}
         request = SetVelocityRequest(name=self.name, linear=linear, angular=angular, extra=dict_to_struct(extra))
-        await self.client.SetVelocity(request)
+        await self.client.SetVelocity(request, timeout=timeout)
 
-    async def stop(self, extra: Optional[Dict[str, Any]] = None):
+    async def stop(
+        self,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+    ):
         if extra is None:
             extra = {}
         request = StopRequest(name=self.name, extra=dict_to_struct(extra))
-        await self.client.Stop(request)
+        await self.client.Stop(request, timeout=timeout)
 
-    async def do_command(self, command: Dict[str, Any]) -> Dict[str, Any]:
-        return await do_command(self.channel, self.name, command)
+    async def do_command(
+        self,
+        command: Dict[str, Any],
+        *,
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        return await do_command(self.channel, self.name, command, timeout=timeout)

--- a/src/viam/components/base/client.py
+++ b/src/viam/components/base/client.py
@@ -30,8 +30,8 @@ class BaseClient(Base):
         self,
         distance: int,
         velocity: float,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
     ):
         if extra is None:
@@ -48,8 +48,8 @@ class BaseClient(Base):
         self,
         angle: float,
         velocity: float,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
     ):
         if extra is None:
@@ -66,8 +66,8 @@ class BaseClient(Base):
         self,
         linear: Vector3,
         angular: Vector3,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
     ):
         if extra is None:
@@ -84,8 +84,8 @@ class BaseClient(Base):
         self,
         linear: Vector3,
         angular: Vector3,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
     ):
         if extra is None:
@@ -95,8 +95,8 @@ class BaseClient(Base):
 
     async def stop(
         self,
-        extra: Optional[Dict[str, Any]] = None,
         *,
+        extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
     ):
         if extra is None:

--- a/src/viam/components/base/service.py
+++ b/src/viam/components/base/service.py
@@ -66,7 +66,7 @@ class BaseService(BaseServiceBase, ComponentServiceBase[Base]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await base.set_power(request.linear, request.angular, struct_to_dict(request.extra), timeout=timeout)
+        await base.set_power(request.linear, request.angular, extra=struct_to_dict(request.extra), timeout=timeout)
         response = SetPowerResponse()
         await stream.send_message(response)
 
@@ -79,7 +79,7 @@ class BaseService(BaseServiceBase, ComponentServiceBase[Base]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await base.set_velocity(request.linear, request.angular, struct_to_dict(request.extra), timeout=timeout)
+        await base.set_velocity(request.linear, request.angular, extra=struct_to_dict(request.extra), timeout=timeout)
         await stream.send_message(SetVelocityResponse())
 
     async def Stop(self, stream: Stream[StopRequest, StopResponse]) -> None:

--- a/src/viam/components/base/service.py
+++ b/src/viam/components/base/service.py
@@ -34,7 +34,13 @@ class BaseService(BaseServiceBase, ComponentServiceBase[Base]):
             base = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await base.move_straight(distance=request.distance_mm, velocity=request.mm_per_sec, extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await base.move_straight(
+            distance=request.distance_mm,
+            velocity=request.mm_per_sec,
+            extra=struct_to_dict(request.extra),
+            timeout=timeout,
+        )
         response = MoveStraightResponse()
         await stream.send_message(response)
 
@@ -46,7 +52,8 @@ class BaseService(BaseServiceBase, ComponentServiceBase[Base]):
             base = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await base.spin(angle=request.angle_deg, velocity=request.degs_per_sec, extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await base.spin(angle=request.angle_deg, velocity=request.degs_per_sec, extra=struct_to_dict(request.extra), timeout=timeout)
         response = SpinResponse()
         await stream.send_message(response)
 
@@ -58,7 +65,8 @@ class BaseService(BaseServiceBase, ComponentServiceBase[Base]):
             base = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await base.set_power(request.linear, request.angular, struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await base.set_power(request.linear, request.angular, struct_to_dict(request.extra), timeout=timeout)
         response = SetPowerResponse()
         await stream.send_message(response)
 
@@ -70,7 +78,8 @@ class BaseService(BaseServiceBase, ComponentServiceBase[Base]):
             base = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await base.set_velocity(request.linear, request.angular, struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await base.set_velocity(request.linear, request.angular, struct_to_dict(request.extra), timeout=timeout)
         await stream.send_message(SetVelocityResponse())
 
     async def Stop(self, stream: Stream[StopRequest, StopResponse]) -> None:
@@ -81,6 +90,7 @@ class BaseService(BaseServiceBase, ComponentServiceBase[Base]):
             base = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await base.stop(extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await base.stop(extra=struct_to_dict(request.extra), timeout=timeout)
         response = StopResponse()
         await stream.send_message(response)

--- a/src/viam/components/board/board.py
+++ b/src/viam/components/board/board.py
@@ -34,7 +34,7 @@ class Board(ComponentBase):
         """
 
         @abc.abstractmethod
-        async def read(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> int:
+        async def read(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> int:
             """
             Read the current value.
 
@@ -51,7 +51,7 @@ class Board(ComponentBase):
         """
 
         @abc.abstractmethod
-        async def value(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> int:
+        async def value(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> int:
             """
             Get the current value of the interrupt,
             which is based on the type of interrupt.
@@ -99,13 +99,10 @@ class Board(ComponentBase):
     class GPIOPin(ComponentBase):
         """
         Abstract representation of an individual GPIO pin on a board
-
-        Args:
-            ComponentBase (_type_): _description_
         """
 
         @abc.abstractmethod
-        async def set(self, high: bool, extra: Optional[Dict[str, Any]] = None, **kwargs):
+        async def set(self, high: bool, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs):
             """
             Set the pin to either low or high.
 
@@ -115,7 +112,7 @@ class Board(ComponentBase):
             ...
 
         @abc.abstractmethod
-        async def get(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> bool:
+        async def get(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> bool:
             """
             Get the high/low state of the pin.
 
@@ -125,7 +122,7 @@ class Board(ComponentBase):
             ...
 
         @abc.abstractmethod
-        async def get_pwm(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> float:
+        async def get_pwm(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> float:
             """
             Get the pin's given duty cycle.
 
@@ -135,7 +132,7 @@ class Board(ComponentBase):
             ...
 
         @abc.abstractmethod
-        async def set_pwm(self, duty_cycle: float, extra: Optional[Dict[str, Any]] = None, **kwargs):
+        async def set_pwm(self, duty_cycle: float, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs):
             """
             Set the pin to the given `duty_cycle`.
 
@@ -145,7 +142,7 @@ class Board(ComponentBase):
             ...
 
         @abc.abstractmethod
-        async def get_pwm_frequency(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> int:
+        async def get_pwm_frequency(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> int:
             """
             Get the PWM frequency of the pin.
 
@@ -155,7 +152,14 @@ class Board(ComponentBase):
             ...
 
         @abc.abstractmethod
-        async def set_pwm_frequency(self, frequency: int, extra: Optional[Dict[str, Any]] = None, **kwargs):
+        async def set_pwm_frequency(
+            self,
+            frequency: int,
+            extra: Optional[Dict[str, Any]] = None,
+            *,
+            timeout: Optional[float] = None,
+            **kwargs,
+        ):
             """
             Set the pin to the given PWM `frequency` (in Hz).
             When `frequency` is 0, it will use the board's default PWM frequency.
@@ -225,7 +229,7 @@ class Board(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def status(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> BoardStatus:
+    async def status(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> BoardStatus:
         """
         Return the current status of the board.
 

--- a/src/viam/components/board/board.py
+++ b/src/viam/components/board/board.py
@@ -7,7 +7,6 @@ from viam.proto.common import BoardStatus
 
 from ..component_base import ComponentBase
 
-
 PostProcessor = Callable[[int], int]
 
 
@@ -34,7 +33,7 @@ class Board(ComponentBase):
         """
 
         @abc.abstractmethod
-        async def read(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> int:
+        async def read(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> int:
             """
             Read the current value.
 
@@ -51,7 +50,7 @@ class Board(ComponentBase):
         """
 
         @abc.abstractmethod
-        async def value(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> int:
+        async def value(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> int:
             """
             Get the current value of the interrupt,
             which is based on the type of interrupt.
@@ -102,7 +101,7 @@ class Board(ComponentBase):
         """
 
         @abc.abstractmethod
-        async def set(self, high: bool, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs):
+        async def set(self, high: bool, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs):
             """
             Set the pin to either low or high.
 
@@ -112,7 +111,7 @@ class Board(ComponentBase):
             ...
 
         @abc.abstractmethod
-        async def get(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> bool:
+        async def get(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> bool:
             """
             Get the high/low state of the pin.
 
@@ -122,7 +121,7 @@ class Board(ComponentBase):
             ...
 
         @abc.abstractmethod
-        async def get_pwm(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> float:
+        async def get_pwm(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> float:
             """
             Get the pin's given duty cycle.
 
@@ -132,7 +131,7 @@ class Board(ComponentBase):
             ...
 
         @abc.abstractmethod
-        async def set_pwm(self, duty_cycle: float, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs):
+        async def set_pwm(self, duty_cycle: float, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs):
             """
             Set the pin to the given `duty_cycle`.
 
@@ -142,7 +141,7 @@ class Board(ComponentBase):
             ...
 
         @abc.abstractmethod
-        async def get_pwm_frequency(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> int:
+        async def get_pwm_frequency(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> int:
             """
             Get the PWM frequency of the pin.
 
@@ -155,8 +154,8 @@ class Board(ComponentBase):
         async def set_pwm_frequency(
             self,
             frequency: int,
-            extra: Optional[Dict[str, Any]] = None,
             *,
+            extra: Optional[Dict[str, Any]] = None,
             timeout: Optional[float] = None,
             **kwargs,
         ):
@@ -229,7 +228,7 @@ class Board(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def status(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> BoardStatus:
+    async def status(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> BoardStatus:
         """
         Return the current status of the board.
 

--- a/src/viam/components/board/client.py
+++ b/src/viam/components/board/client.py
@@ -32,11 +32,11 @@ class AnalogReaderClient(Board.AnalogReader):
         self.board = board
         super().__init__(name)
 
-    async def read(self, extra: Optional[Dict[str, Any]] = None) -> int:
+    async def read(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None) -> int:
         if extra is None:
             extra = {}
         request = ReadAnalogReaderRequest(board_name=self.board.name, analog_reader_name=self.name, extra=dict_to_struct(extra))
-        response: ReadAnalogReaderResponse = await self.board.client.ReadAnalogReader(request)
+        response: ReadAnalogReaderResponse = await self.board.client.ReadAnalogReader(request, timeout=timeout)
         return response.value
 
 
@@ -45,11 +45,11 @@ class DigitalInterruptClient(Board.DigitalInterrupt):
         self.board = board
         super().__init__(name)
 
-    async def value(self, extra: Optional[Dict[str, Any]] = None) -> int:
+    async def value(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None) -> int:
         if extra is None:
             extra = {}
         request = GetDigitalInterruptValueRequest(board_name=self.board.name, digital_interrupt_name=self.name, extra=dict_to_struct(extra))
-        response: GetDigitalInterruptValueResponse = await self.board.client.GetDigitalInterruptValue(request)
+        response: GetDigitalInterruptValueResponse = await self.board.client.GetDigitalInterruptValue(request, timeout=timeout)
         return response.value
 
     async def tick(self, high: bool, nanos: int):
@@ -67,44 +67,44 @@ class GPIOPinClient(Board.GPIOPin):
         self.board = board
         super().__init__(name)
 
-    async def get(self, extra: Optional[Dict[str, Any]] = None) -> bool:
+    async def get(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None) -> bool:
         if extra is None:
             extra = {}
         request = GetGPIORequest(name=self.board.name, pin=self.name, extra=dict_to_struct(extra))
-        response: GetGPIOResponse = await self.board.client.GetGPIO(request)
+        response: GetGPIOResponse = await self.board.client.GetGPIO(request, timeout=timeout)
         return response.high
 
-    async def set(self, high: bool, extra: Optional[Dict[str, Any]] = None):
+    async def set(self, high: bool, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None):
         if extra is None:
             extra = {}
         request = SetGPIORequest(name=self.board.name, pin=self.name, high=high, extra=dict_to_struct(extra))
-        await self.board.client.SetGPIO(request)
+        await self.board.client.SetGPIO(request, timeout=timeout)
 
-    async def get_pwm(self, extra: Optional[Dict[str, Any]] = None) -> float:
+    async def get_pwm(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None) -> float:
         if extra is None:
             extra = {}
         request = PWMRequest(name=self.board.name, pin=self.name, extra=dict_to_struct(extra))
-        response: PWMResponse = await self.board.client.PWM(request)
+        response: PWMResponse = await self.board.client.PWM(request, timeout=timeout)
         return response.duty_cycle_pct
 
-    async def set_pwm(self, duty_cycle: float, extra: Optional[Dict[str, Any]] = None):
+    async def set_pwm(self, duty_cycle: float, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None):
         if extra is None:
             extra = {}
         request = SetPWMRequest(name=self.board.name, pin=self.name, duty_cycle_pct=duty_cycle, extra=dict_to_struct(extra))
-        await self.board.client.SetPWM(request)
+        await self.board.client.SetPWM(request, timeout=timeout)
 
-    async def get_pwm_frequency(self, extra: Optional[Dict[str, Any]] = None) -> int:
+    async def get_pwm_frequency(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None) -> int:
         if extra is None:
             extra = {}
         request = PWMFrequencyRequest(name=self.board.name, pin=self.name, extra=dict_to_struct(extra))
-        response: PWMFrequencyResponse = await self.board.client.PWMFrequency(request)
+        response: PWMFrequencyResponse = await self.board.client.PWMFrequency(request, timeout=timeout)
         return response.frequency_hz
 
-    async def set_pwm_frequency(self, frequency: int, extra: Optional[Dict[str, Any]] = None):
+    async def set_pwm_frequency(self, frequency: int, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None):
         if extra is None:
             extra = {}
         request = SetPWMFrequencyRequest(name=self.board.name, pin=self.name, frequency_hz=frequency, extra=dict_to_struct(extra))
-        await self.board.client.SetPWMFrequency(request)
+        await self.board.client.SetPWMFrequency(request, timeout=timeout)
 
 
 class BoardClient(Board):
@@ -142,11 +142,11 @@ class BoardClient(Board):
             self._digital_interrupt_names = names
         return self._digital_interrupt_names
 
-    async def status(self, extra: Optional[Dict[str, Any]] = None) -> BoardStatus:
+    async def status(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None) -> BoardStatus:
         if extra is None:
             extra = {}
         request = StatusRequest(name=self.name, extra=dict_to_struct(extra))
-        response: StatusResponse = await self.client.Status(request)
+        response: StatusResponse = await self.client.Status(request, timeout=timeout)
         return response.status
 
     async def model_attributes(self) -> Board.Attributes:

--- a/src/viam/components/board/client.py
+++ b/src/viam/components/board/client.py
@@ -2,6 +2,7 @@ from multiprocessing import Queue
 from typing import Any, Dict, List, Optional
 
 from grpclib.client import Channel
+
 from viam.components.generic.client import do_command
 from viam.proto.common import BoardStatus
 from viam.proto.component.board import (
@@ -32,7 +33,7 @@ class AnalogReaderClient(Board.AnalogReader):
         self.board = board
         super().__init__(name)
 
-    async def read(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None) -> int:
+    async def read(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> int:
         if extra is None:
             extra = {}
         request = ReadAnalogReaderRequest(board_name=self.board.name, analog_reader_name=self.name, extra=dict_to_struct(extra))
@@ -45,7 +46,7 @@ class DigitalInterruptClient(Board.DigitalInterrupt):
         self.board = board
         super().__init__(name)
 
-    async def value(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None) -> int:
+    async def value(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> int:
         if extra is None:
             extra = {}
         request = GetDigitalInterruptValueRequest(board_name=self.board.name, digital_interrupt_name=self.name, extra=dict_to_struct(extra))
@@ -67,40 +68,40 @@ class GPIOPinClient(Board.GPIOPin):
         self.board = board
         super().__init__(name)
 
-    async def get(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None) -> bool:
+    async def get(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> bool:
         if extra is None:
             extra = {}
         request = GetGPIORequest(name=self.board.name, pin=self.name, extra=dict_to_struct(extra))
         response: GetGPIOResponse = await self.board.client.GetGPIO(request, timeout=timeout)
         return response.high
 
-    async def set(self, high: bool, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None):
+    async def set(self, high: bool, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None):
         if extra is None:
             extra = {}
         request = SetGPIORequest(name=self.board.name, pin=self.name, high=high, extra=dict_to_struct(extra))
         await self.board.client.SetGPIO(request, timeout=timeout)
 
-    async def get_pwm(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None) -> float:
+    async def get_pwm(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> float:
         if extra is None:
             extra = {}
         request = PWMRequest(name=self.board.name, pin=self.name, extra=dict_to_struct(extra))
         response: PWMResponse = await self.board.client.PWM(request, timeout=timeout)
         return response.duty_cycle_pct
 
-    async def set_pwm(self, duty_cycle: float, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None):
+    async def set_pwm(self, duty_cycle: float, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None):
         if extra is None:
             extra = {}
         request = SetPWMRequest(name=self.board.name, pin=self.name, duty_cycle_pct=duty_cycle, extra=dict_to_struct(extra))
         await self.board.client.SetPWM(request, timeout=timeout)
 
-    async def get_pwm_frequency(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None) -> int:
+    async def get_pwm_frequency(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> int:
         if extra is None:
             extra = {}
         request = PWMFrequencyRequest(name=self.board.name, pin=self.name, extra=dict_to_struct(extra))
         response: PWMFrequencyResponse = await self.board.client.PWMFrequency(request, timeout=timeout)
         return response.frequency_hz
 
-    async def set_pwm_frequency(self, frequency: int, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None):
+    async def set_pwm_frequency(self, frequency: int, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None):
         if extra is None:
             extra = {}
         request = SetPWMFrequencyRequest(name=self.board.name, pin=self.name, frequency_hz=frequency, extra=dict_to_struct(extra))
@@ -142,7 +143,7 @@ class BoardClient(Board):
             self._digital_interrupt_names = names
         return self._digital_interrupt_names
 
-    async def status(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None) -> BoardStatus:
+    async def status(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> BoardStatus:
         if extra is None:
             extra = {}
         request = StatusRequest(name=self.name, extra=dict_to_struct(extra))

--- a/src/viam/components/board/service.py
+++ b/src/viam/components/board/service.py
@@ -42,7 +42,8 @@ class BoardService(BoardServiceBase, ComponentServiceBase[Board]):
             board = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        status = await board.status(extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        status = await board.status(extra=struct_to_dict(request.extra), timeout=timeout)
         response = StatusResponse(status=status)
         await stream.send_message(response)
 
@@ -55,7 +56,8 @@ class BoardService(BoardServiceBase, ComponentServiceBase[Board]):
             pin = await board.gpio_pin_by_name(request.pin)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await pin.set(request.high, extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await pin.set(request.high, extra=struct_to_dict(request.extra), timeout=timeout)
         response = SetGPIOResponse()
         await stream.send_message(response)
 
@@ -68,7 +70,8 @@ class BoardService(BoardServiceBase, ComponentServiceBase[Board]):
             pin = await board.gpio_pin_by_name(request.pin)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        high = await pin.get(extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        high = await pin.get(extra=struct_to_dict(request.extra), timeout=timeout)
         response = GetGPIOResponse(high=high)
         await stream.send_message(response)
 
@@ -81,7 +84,8 @@ class BoardService(BoardServiceBase, ComponentServiceBase[Board]):
             pin = await board.gpio_pin_by_name(request.pin)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        pwm = await pin.get_pwm(extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        pwm = await pin.get_pwm(extra=struct_to_dict(request.extra), timeout=timeout)
         response = PWMResponse(duty_cycle_pct=pwm)
         await stream.send_message(response)
 
@@ -94,7 +98,8 @@ class BoardService(BoardServiceBase, ComponentServiceBase[Board]):
             pin = await board.gpio_pin_by_name(request.pin)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await pin.set_pwm(request.duty_cycle_pct, extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await pin.set_pwm(request.duty_cycle_pct, extra=struct_to_dict(request.extra), timeout=timeout)
         response = SetPWMResponse()
         await stream.send_message(response)
 
@@ -107,7 +112,8 @@ class BoardService(BoardServiceBase, ComponentServiceBase[Board]):
             pin = await board.gpio_pin_by_name(request.pin)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        frequency = await pin.get_pwm_frequency(extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        frequency = await pin.get_pwm_frequency(extra=struct_to_dict(request.extra), timeout=timeout)
         response = PWMFrequencyResponse(frequency_hz=frequency)
         await stream.send_message(response)
 
@@ -120,7 +126,8 @@ class BoardService(BoardServiceBase, ComponentServiceBase[Board]):
             pin = await board.gpio_pin_by_name(request.pin)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await pin.set_pwm_frequency(request.frequency_hz, extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await pin.set_pwm_frequency(request.frequency_hz, extra=struct_to_dict(request.extra), timeout=timeout)
         response = SetPWMFrequencyResponse()
         await stream.send_message(response)
 
@@ -133,7 +140,8 @@ class BoardService(BoardServiceBase, ComponentServiceBase[Board]):
             analog_reader = await board.analog_reader_by_name(request.analog_reader_name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        value = await analog_reader.read(extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        value = await analog_reader.read(extra=struct_to_dict(request.extra), timeout=timeout)
         response = ReadAnalogReaderResponse(value=value)
         await stream.send_message(response)
 
@@ -146,6 +154,7 @@ class BoardService(BoardServiceBase, ComponentServiceBase[Board]):
             interrupt = await board.digital_interrupt_by_name(request.digital_interrupt_name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        value = await interrupt.value(extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        value = await interrupt.value(extra=struct_to_dict(request.extra), timeout=timeout)
         response = GetDigitalInterruptValueResponse(value=value)
         await stream.send_message(response)

--- a/src/viam/components/camera/camera.py
+++ b/src/viam/components/camera/camera.py
@@ -1,5 +1,5 @@
 import abc
-from typing import NamedTuple, Tuple, Union
+from typing import NamedTuple, Optional, Tuple, Union
 
 from PIL.Image import Image
 
@@ -31,7 +31,7 @@ class Camera(ComponentBase):
         """The distortion parameters of the camera"""
 
     @abc.abstractmethod
-    async def get_image(self, mime_type: str = CameraMimeType.PNG, **kwargs) -> Union[Image, RawImage]:
+    async def get_image(self, mime_type: str = CameraMimeType.PNG, *, timeout: Optional[float] = None, **kwargs) -> Union[Image, RawImage]:
         """Get the next image from the camera as an Image or RawImage.
         Be sure to close the image when finished.
 
@@ -44,7 +44,7 @@ class Camera(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def get_point_cloud(self, **kwargs) -> Tuple[bytes, str]:
+    async def get_point_cloud(self, *, timeout: Optional[float] = None, **kwargs) -> Tuple[bytes, str]:
         """
         Get the next point cloud from the camera. This will be
         returned as bytes with a mimetype describing
@@ -59,7 +59,7 @@ class Camera(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def get_properties(self, **kwargs) -> Properties:
+    async def get_properties(self, *, timeout: Optional[float] = None, **kwargs) -> Properties:
         """
         Get the camera intrinsic parameters and camera distortion parameters
 

--- a/src/viam/components/camera/client.py
+++ b/src/viam/components/camera/client.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 from grpclib.client import Channel
 from PIL import Image
@@ -29,9 +29,9 @@ class CameraClient(Camera):
         self.client = CameraServiceStub(channel)
         super().__init__(name)
 
-    async def get_image(self, mime_type: str = CameraMimeType.PNG) -> Union[Image.Image, RawImage]:
+    async def get_image(self, mime_type: str = CameraMimeType.PNG, *, timeout: Optional[float] = None) -> Union[Image.Image, RawImage]:
         request = GetImageRequest(name=self.name, mime_type=mime_type)
-        response: GetImageResponse = await self.client.GetImage(request)
+        response: GetImageResponse = await self.client.GetImage(request, timeout=timeout)
         try:
             mimetype = CameraMimeType(response.mime_type)
             if mimetype == CameraMimeType.RAW:
@@ -43,14 +43,14 @@ class CameraClient(Camera):
 
         return Image.open(BytesIO(response.image), formats=["JPEG", "PNG"])
 
-    async def get_point_cloud(self) -> Tuple[bytes, str]:
+    async def get_point_cloud(self, *, timeout: Optional[float] = None) -> Tuple[bytes, str]:
         request = GetPointCloudRequest(name=self.name, mime_type=CameraMimeType.PCD)
-        response: GetPointCloudResponse = await self.client.GetPointCloud(request)
+        response: GetPointCloudResponse = await self.client.GetPointCloud(request, timeout=timeout)
         return (response.point_cloud, response.mime_type)
 
-    async def get_properties(self) -> Camera.Properties:
-        response: GetPropertiesResponse = await self.client.GetProperties(GetPropertiesRequest(name=self.name))
+    async def get_properties(self, *, timeout: Optional[float] = None) -> Camera.Properties:
+        response: GetPropertiesResponse = await self.client.GetProperties(GetPropertiesRequest(name=self.name), timeout=timeout)
         return Camera.Properties(response.supports_pcd, response.intrinsic_parameters, response.distortion_parameters)
 
-    async def do_command(self, command: Dict[str, Any]) -> Dict[str, Any]:
-        return await do_command(self.channel, self.name, command)
+    async def do_command(self, command: Dict[str, Any], *, timeout: Optional[float] = None) -> Dict[str, Any]:
+        return await do_command(self.channel, self.name, command, timeout=timeout)

--- a/src/viam/components/camera/service.py
+++ b/src/viam/components/camera/service.py
@@ -33,7 +33,9 @@ class CameraService(CameraServiceBase, ComponentServiceBase[Camera]):
             camera = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        image = await camera.get_image(request.mime_type)
+
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        image = await camera.get_image(request.mime_type, timeout=timeout)
         try:
             try:
                 mimetype = CameraMimeType(request.mime_type)
@@ -62,7 +64,8 @@ class CameraService(CameraServiceBase, ComponentServiceBase[Camera]):
             mimetype = CameraMimeType(request.mime_type)
         except ValueError:
             mimetype = CameraMimeType.JPEG
-        image = await camera.get_image(mimetype)
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        image = await camera.get_image(mimetype, timeout=timeout)
         try:
             img = mimetype.encode_image(image)
         finally:
@@ -78,7 +81,8 @@ class CameraService(CameraServiceBase, ComponentServiceBase[Camera]):
             camera = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        pc, mimetype = await camera.get_point_cloud()
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        pc, mimetype = await camera.get_point_cloud(timeout=timeout)
         response = GetPointCloudResponse(mime_type=mimetype, point_cloud=pc)
         await stream.send_message(response)
 
@@ -90,7 +94,8 @@ class CameraService(CameraServiceBase, ComponentServiceBase[Camera]):
             camera = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        properties = await camera.get_properties()
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        properties = await camera.get_properties(timeout=timeout)
         response = GetPropertiesResponse(
             supports_pcd=properties.supports_pcd,
             intrinsic_parameters=properties.intrinsic_parameters,

--- a/src/viam/components/component_base.py
+++ b/src/viam/components/component_base.py
@@ -1,5 +1,5 @@
 import abc
-from typing import TYPE_CHECKING, Any, Dict, Mapping, cast
+from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, cast
 
 from typing_extensions import Self
 
@@ -69,7 +69,7 @@ class ComponentBase(abc.ABC):
         """
         return kwargs.get(Operation.ARG_NAME, Operation._noop())
 
-    async def do_command(self, command: Dict[str, Any], **kwargs) -> Dict[str, Any]:
+    async def do_command(self, command: Dict[str, Any], *, timeout: Optional[float] = None, **kwargs) -> Dict[str, Any]:
         """Send/Receive arbitrary commands
 
         Args:

--- a/src/viam/components/gantry/client.py
+++ b/src/viam/components/gantry/client.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 from grpclib.client import Channel
+
 from viam.components.generic.client import do_command
 from viam.proto.common import WorldState
 from viam.proto.component.gantry import (
@@ -27,36 +28,38 @@ class GantryClient(Gantry):
         self.client = GantryServiceStub(channel)
         super().__init__(name)
 
-    async def get_position(self, extra: Optional[Dict[str, Any]] = None) -> List[float]:
+    async def get_position(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[float]:
         if extra is None:
             extra = {}
         request = GetPositionRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetPositionResponse = await self.client.GetPosition(request)
+        response: GetPositionResponse = await self.client.GetPosition(request, timeout=timeout)
         return list(response.positions_mm)
 
     async def move_to_position(
         self,
         positions: List[float],
         world_state: Optional[WorldState] = None,
+        *,
         extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
     ):
         if extra is None:
             extra = {}
         request = MoveToPositionRequest(name=self.name, positions_mm=positions, world_state=world_state, extra=dict_to_struct(extra))
-        await self.client.MoveToPosition(request)
+        await self.client.MoveToPosition(request, timeout=timeout)
 
-    async def get_lengths(self, extra: Optional[Dict[str, Any]] = None) -> List[float]:
+    async def get_lengths(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[float]:
         if extra is None:
             extra = {}
         request = GetLengthsRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetLengthsResponse = await self.client.GetLengths(request)
+        response: GetLengthsResponse = await self.client.GetLengths(request, timeout=timeout)
         return list(response.lengths_mm)
 
-    async def stop(self, extra: Optional[Dict[str, Any]] = None):
+    async def stop(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None):
         if extra is None:
             extra = {}
         request = StopRequest(name=self.name, extra=dict_to_struct(extra))
-        await self.client.Stop(request)
+        await self.client.Stop(request, timeout=timeout)
 
     async def do_command(self, command: Dict[str, Any]) -> Dict[str, Any]:
         return await do_command(self.channel, self.name, command)

--- a/src/viam/components/gantry/gantry.py
+++ b/src/viam/components/gantry/gantry.py
@@ -17,7 +17,7 @@ class Gantry(ComponentBase):
     """
 
     @abc.abstractmethod
-    async def get_position(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> List[float]:
+    async def get_position(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[float]:
         """
         Get the position in millimeters.
 
@@ -28,7 +28,13 @@ class Gantry(ComponentBase):
 
     @abc.abstractmethod
     async def move_to_position(
-        self, positions: List[float], world_state: Optional[WorldState] = None, extra: Optional[Dict[str, Any]] = None, **kwargs
+        self,
+        positions: List[float],
+        world_state: Optional[WorldState] = None,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
     ):
         """
         Move the gantry to a new position.
@@ -42,7 +48,7 @@ class Gantry(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def get_lengths(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> List[float]:
+    async def get_lengths(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[float]:
         """
         Get the lengths of the axes of the gantry in millimeters.
 
@@ -52,7 +58,7 @@ class Gantry(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def stop(self, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def stop(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs):
         """
         Stop all motion of the gantry. It is assumed that the gantry stops immediately.
         """

--- a/src/viam/components/gantry/service.py
+++ b/src/viam/components/gantry/service.py
@@ -1,4 +1,5 @@
 from grpclib.server import Stream
+
 from viam.components.service_base import ComponentServiceBase
 from viam.errors import ComponentNotFoundError
 from viam.proto.component.gantry import (
@@ -32,7 +33,8 @@ class GantryService(GantryServiceBase, ComponentServiceBase[Gantry]):
             gantry = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        position = await gantry.get_position(extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        position = await gantry.get_position(extra=struct_to_dict(request.extra), timeout=timeout)
         response = GetPositionResponse(positions_mm=position)
         await stream.send_message(response)
 
@@ -44,7 +46,8 @@ class GantryService(GantryServiceBase, ComponentServiceBase[Gantry]):
             gantry = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await gantry.move_to_position(list(request.positions_mm), request.world_state, struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await gantry.move_to_position(list(request.positions_mm), request.world_state, extra=struct_to_dict(request.extra), timeout=timeout)
         response = MoveToPositionResponse()
         await stream.send_message(response)
 
@@ -56,7 +59,8 @@ class GantryService(GantryServiceBase, ComponentServiceBase[Gantry]):
             gantry = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        lengths = await gantry.get_lengths(extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        lengths = await gantry.get_lengths(extra=struct_to_dict(request.extra), timeout=timeout)
         response = GetLengthsResponse(lengths_mm=lengths)
         await stream.send_message(response)
 
@@ -68,6 +72,7 @@ class GantryService(GantryServiceBase, ComponentServiceBase[Gantry]):
             gantry = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await gantry.stop(extra=struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await gantry.stop(extra=struct_to_dict(request.extra), timeout=timeout)
         response = StopResponse()
         await stream.send_message(response)

--- a/src/viam/components/generic/service.py
+++ b/src/viam/components/generic/service.py
@@ -30,7 +30,8 @@ class GenericService(GenericServiceBase, ComponentServiceBase[ComponentBase]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         try:
-            result = await component.do_command(struct_to_dict(request.command))
+            timeout = stream.deadline.time_remaining() if stream.deadline else None
+            result = await component.do_command(struct_to_dict(request.command), timeout=timeout)
         except NotImplementedError:
             raise GRPCError(Status.UNIMPLEMENTED, f"`DO` command is unimplemented for component named: {name}")
         response = DoCommandResponse(result=dict_to_struct(result))

--- a/src/viam/components/gripper/client.py
+++ b/src/viam/components/gripper/client.py
@@ -1,8 +1,15 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from grpclib.client import Channel
+
 from viam.components.generic.client import do_command
-from viam.proto.component.gripper import GrabRequest, GrabResponse, GripperServiceStub, OpenRequest, StopRequest
+from viam.proto.component.gripper import (
+    GrabRequest,
+    GrabResponse,
+    GripperServiceStub,
+    OpenRequest,
+    StopRequest,
+)
 
 from .gripper import Gripper
 
@@ -17,18 +24,18 @@ class GripperClient(Gripper):
         self.client = GripperServiceStub(channel)
         super().__init__(name)
 
-    async def open(self):
+    async def open(self, *, timeout: Optional[float] = None):
         request = OpenRequest(name=self.name)
-        await self.client.Open(request)
+        await self.client.Open(request, timeout=timeout)
 
-    async def grab(self) -> bool:
+    async def grab(self, *, timeout: Optional[float] = None) -> bool:
         request = GrabRequest(name=self.name)
-        response: GrabResponse = await self.client.Grab(request)
+        response: GrabResponse = await self.client.Grab(request, timeout=timeout)
         return response.success
 
-    async def stop(self):
+    async def stop(self, *, timeout: Optional[float] = None):
         request = StopRequest(name=self.name)
-        await self.client.Stop(request)
+        await self.client.Stop(request, timeout=timeout)
 
-    async def do_command(self, command: Dict[str, Any]) -> Dict[str, Any]:
-        return await do_command(self.channel, self.name, command)
+    async def do_command(self, command: Dict[str, Any], *, timeout: Optional[float] = None) -> Dict[str, Any]:
+        return await do_command(self.channel, self.name, command, timeout=timeout)

--- a/src/viam/components/gripper/gripper.py
+++ b/src/viam/components/gripper/gripper.py
@@ -1,8 +1,8 @@
 import abc
-
-from viam.errors import NotSupportedError
+from typing import Optional
 
 from viam.components.component_base import ComponentBase
+from viam.errors import NotSupportedError
 
 
 class Gripper(ComponentBase):
@@ -15,14 +15,14 @@ class Gripper(ComponentBase):
     """
 
     @abc.abstractmethod
-    async def open(self, **kwargs):
+    async def open(self, *, timeout: Optional[float] = None, **kwargs):
         """
         Open the gripper.
         """
         ...
 
     @abc.abstractmethod
-    async def grab(self, **kwargs) -> bool:
+    async def grab(self, *, timeout: Optional[float] = None, **kwargs) -> bool:
         """
         Instruct the gripper to grab.
 
@@ -32,7 +32,7 @@ class Gripper(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def stop(self, **kwargs):
+    async def stop(self, *, timeout: Optional[float] = None, **kwargs):
         """
         Stop the gripper. It is assumed the gripper stops immediately.
         """

--- a/src/viam/components/gripper/service.py
+++ b/src/viam/components/gripper/service.py
@@ -1,4 +1,5 @@
 from grpclib.server import Stream
+
 from viam.components.service_base import ComponentServiceBase
 from viam.errors import ComponentNotFoundError
 from viam.proto.component.gripper import (
@@ -29,7 +30,8 @@ class GripperService(GripperServiceBase, ComponentServiceBase[Gripper]):
             gripper = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await gripper.open()
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await gripper.open(timeout=timeout)
         response = OpenResponse()
         await stream.send_message(response)
 
@@ -41,7 +43,8 @@ class GripperService(GripperServiceBase, ComponentServiceBase[Gripper]):
             gripper = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        grabbed = await gripper.grab()
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        grabbed = await gripper.grab(timeout=timeout)
         response = GrabResponse(success=grabbed)
         await stream.send_message(response)
 
@@ -52,5 +55,6 @@ class GripperService(GripperServiceBase, ComponentServiceBase[Gripper]):
             gripper = self.get_component(request.name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await gripper.stop()
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await gripper.stop(timeout=timeout)
         await stream.send_message(StopResponse())

--- a/src/viam/components/input/input.py
+++ b/src/viam/components/input/input.py
@@ -136,7 +136,7 @@ class Controller(ComponentBase):
     """
 
     @abc.abstractmethod
-    async def get_controls(self, **kwargs) -> List[Control]:
+    async def get_controls(self, *, timeout: Optional[float] = None, **kwargs) -> List[Control]:
         """
         Returns a list of Controls provided by the Controller
 
@@ -146,7 +146,7 @@ class Controller(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def get_events(self, **kwargs) -> Dict[Control, Event]:
+    async def get_events(self, *, timeout: Optional[float] = None, **kwargs) -> Dict[Control, Event]:
         """
         Returns the most recent Event for each input
         (which should be the current state)
@@ -171,7 +171,7 @@ class Controller(ComponentBase):
         """
         ...
 
-    async def trigger_event(self, event: Event, **kwargs):
+    async def trigger_event(self, event: Event, *, timeout: Optional[float] = None, **kwargs):
         """Directly send an Event (such as a button press) from external code
 
         Args:

--- a/src/viam/components/motor/client.py
+++ b/src/viam/components/motor/client.py
@@ -31,56 +31,102 @@ class MotorClient(Motor):
         self.client = MotorServiceStub(channel)
         super().__init__(name)
 
-    async def set_power(self, power: float, extra: Optional[Dict[str, Any]] = None):
+    async def set_power(
+        self,
+        power: float,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ):
         if extra is None:
             extra = {}
         request = SetPowerRequest(name=self.name, power_pct=power, extra=dict_to_struct(extra))
-        await self.client.SetPower(request)
+        await self.client.SetPower(request, timeout=timeout)
 
-    async def go_for(self, rpm: float, revolutions: float, extra: Optional[Dict[str, Any]] = None):
+    async def go_for(
+        self,
+        rpm: float,
+        revolutions: float,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ):
         if extra is None:
             extra = {}
         request = GoForRequest(name=self.name, rpm=rpm, revolutions=revolutions, extra=dict_to_struct(extra))
-        await self.client.GoFor(request)
+        await self.client.GoFor(request, timeout=timeout)
 
-    async def go_to(self, rpm: float, position_revolutions: float, extra: Optional[Dict[str, Any]] = None):
+    async def go_to(
+        self,
+        rpm: float,
+        position_revolutions: float,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ):
         if extra is None:
             extra = {}
         request = GoToRequest(name=self.name, rpm=rpm, position_revolutions=position_revolutions, extra=dict_to_struct(extra))
-        await self.client.GoTo(request)
+        await self.client.GoTo(request, timeout=timeout)
 
-    async def reset_zero_position(self, offset: float, extra: Optional[Dict[str, Any]] = None):
+    async def reset_zero_position(
+        self,
+        offset: float,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ):
         if extra is None:
             extra = {}
         request = ResetZeroPositionRequest(name=self.name, offset=offset, extra=dict_to_struct(extra))
-        await self.client.ResetZeroPosition(request)
+        await self.client.ResetZeroPosition(request, timeout=timeout)
 
-    async def get_position(self, extra: Optional[Dict[str, Any]] = None) -> float:
+    async def get_position(
+        self,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ) -> float:
         if extra is None:
             extra = {}
         request = GetPositionRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetPositionResponse = await self.client.GetPosition(request)
+        response: GetPositionResponse = await self.client.GetPosition(request, timeout=timeout)
         return response.position
 
-    async def get_properties(self, extra: Optional[Dict[str, Any]] = None) -> Motor.Properties:
+    async def get_properties(
+        self,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ) -> Motor.Properties:
         if extra is None:
             extra = {}
         request = GetPropertiesRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetPropertiesResponse = await self.client.GetProperties(request)
+        response: GetPropertiesResponse = await self.client.GetProperties(request, timeout=timeout)
         return Motor.Properties(position_reporting=response.position_reporting)
 
-    async def stop(self, extra: Optional[Dict[str, Any]] = None):
+    async def stop(
+        self,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ):
         if extra is None:
             extra = {}
         request = StopRequest(name=self.name, extra=dict_to_struct(extra))
-        await self.client.Stop(request)
+        await self.client.Stop(request, timeout=timeout)
 
-    async def is_powered(self, extra: Optional[Dict[str, Any]] = None) -> Tuple[bool, float]:
+    async def is_powered(
+        self,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ) -> Tuple[bool, float]:
         if extra is None:
             extra = {}
         request = IsPoweredRequest(name=self.name, extra=dict_to_struct(extra))
-        response: IsPoweredResponse = await self.client.IsPowered(request)
+        response: IsPoweredResponse = await self.client.IsPowered(request, timeout=timeout)
         return response.is_on, response.power_pct
 
-    async def do_command(self, command: Dict[str, Any]) -> Dict[str, Any]:
-        return await do_command(self.channel, self.name, command)
+    async def do_command(self, command: Dict[str, Any], *, timeout: Optional[float] = None) -> Dict[str, Any]:
+        return await do_command(self.channel, self.name, command, timeout=timeout)

--- a/src/viam/components/motor/motor.py
+++ b/src/viam/components/motor/motor.py
@@ -21,7 +21,14 @@ class Motor(ComponentBase):
     """
 
     @abc.abstractmethod
-    async def set_power(self, power: float, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def set_power(
+        self,
+        power: float,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
         """
         Sets the "percentage" of power the motor should employ between -1 and 1.
         When `power` is negative, the rotation will be in the backward direction.
@@ -33,7 +40,15 @@ class Motor(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def go_for(self, rpm: float, revolutions: float, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def go_for(
+        self,
+        rpm: float,
+        revolutions: float,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
         """
         Spin the motor the specified number of `revolutions` at specified `rpm`.
         When `rpm` or `revolutions` is a negative value, the rotation will be in the backward direction.
@@ -48,7 +63,15 @@ class Motor(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def go_to(self, rpm: float, position_revolutions: float, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def go_to(
+        self,
+        rpm: float,
+        position_revolutions: float,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
         """
         Spin the motor to the specified position (provided in revolutions from home/zero),
         at the specified speed, in revolutions per minute.
@@ -62,7 +85,14 @@ class Motor(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def reset_zero_position(self, offset: float, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def reset_zero_position(
+        self,
+        offset: float,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
         """
         Set the current position (modified by `offset`) to be the new zero (home) position.
 
@@ -72,7 +102,13 @@ class Motor(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def get_position(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> float:
+    async def get_position(
+        self,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> float:
         """
         Report the position of the motor based on its encoder.
         The value returned is the number of revolutions relative to its zero position.
@@ -84,7 +120,13 @@ class Motor(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def get_properties(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> Properties:
+    async def get_properties(
+        self,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> Properties:
         """
         Report a dictionary mapping optional properties to
         whether it is supported by this motor.
@@ -95,14 +137,26 @@ class Motor(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def stop(self, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def stop(
+        self,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
         """
         Stop the motor immediately, without any gradual step down.
         """
         ...
 
     @abc.abstractmethod
-    async def is_powered(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> Tuple[bool, float]:
+    async def is_powered(
+        self,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> Tuple[bool, float]:
         """
         Returns whether or not the motor is currently running.
 

--- a/src/viam/components/motor/service.py
+++ b/src/viam/components/motor/service.py
@@ -40,7 +40,8 @@ class MotorService(MotorServiceBase, ComponentServiceBase[Motor]):
             motor = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await motor.set_power(request.power_pct, struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await motor.set_power(request.power_pct, extra=struct_to_dict(request.extra), timeout=timeout)
         await stream.send_message(SetPowerResponse())
 
     async def GoFor(self, stream: Stream[GoForRequest, GoForResponse]) -> None:
@@ -51,7 +52,8 @@ class MotorService(MotorServiceBase, ComponentServiceBase[Motor]):
             motor = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await motor.go_for(request.rpm, request.revolutions, struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await motor.go_for(request.rpm, request.revolutions, extra=struct_to_dict(request.extra), timeout=timeout)
         await stream.send_message(GoForResponse())
 
     async def GoTo(self, stream: Stream[GoToRequest, GoToResponse]) -> None:
@@ -62,7 +64,8 @@ class MotorService(MotorServiceBase, ComponentServiceBase[Motor]):
             motor = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await motor.go_to(request.rpm, request.position_revolutions, struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await motor.go_to(request.rpm, request.position_revolutions, extra=struct_to_dict(request.extra), timeout=timeout)
         await stream.send_message(GoToResponse())
 
     async def ResetZeroPosition(self, stream: Stream[ResetZeroPositionRequest, ResetZeroPositionResponse]) -> None:
@@ -73,7 +76,8 @@ class MotorService(MotorServiceBase, ComponentServiceBase[Motor]):
             motor = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await motor.reset_zero_position(request.offset, struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await motor.reset_zero_position(request.offset, extra=struct_to_dict(request.extra), timeout=timeout)
         await stream.send_message(ResetZeroPositionResponse())
 
     async def GetPosition(self, stream: Stream[GetPositionRequest, GetPositionResponse]) -> None:
@@ -84,7 +88,8 @@ class MotorService(MotorServiceBase, ComponentServiceBase[Motor]):
             motor = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        position = await motor.get_position(struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        position = await motor.get_position(extra=struct_to_dict(request.extra), timeout=timeout)
         await stream.send_message(GetPositionResponse(position=position))
 
     async def GetProperties(self, stream: Stream[GetPropertiesRequest, GetPropertiesResponse]) -> None:
@@ -95,7 +100,8 @@ class MotorService(MotorServiceBase, ComponentServiceBase[Motor]):
             motor = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        properties = await motor.get_properties(struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        properties = await motor.get_properties(extra=struct_to_dict(request.extra), timeout=timeout)
         response = GetPropertiesResponse(**properties.__dict__)
         await stream.send_message(response)
 
@@ -107,7 +113,8 @@ class MotorService(MotorServiceBase, ComponentServiceBase[Motor]):
             motor = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        await motor.stop(struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await motor.stop(extra=struct_to_dict(request.extra), timeout=timeout)
         response = StopResponse()
         await stream.send_message(response)
 
@@ -119,5 +126,6 @@ class MotorService(MotorServiceBase, ComponentServiceBase[Motor]):
             motor = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        is_powered, power_pct = await motor.is_powered(struct_to_dict(request.extra))
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        is_powered, power_pct = await motor.is_powered(extra=struct_to_dict(request.extra), timeout=timeout)
         await stream.send_message(IsPoweredResponse(is_on=is_powered, power_pct=power_pct))

--- a/src/viam/components/movement_sensor/client.py
+++ b/src/viam/components/movement_sensor/client.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Mapping, Tuple
+from typing import Any, Dict, Mapping, Optional, Tuple
 
 from grpclib.client import Channel
 
@@ -32,43 +32,43 @@ class MovementSensorClient(MovementSensor):
         self.client = MovementSensorServiceStub(channel)
         super().__init__(name)
 
-    async def get_position(self) -> Tuple[GeoPoint, float]:
+    async def get_position(self, *, timeout: Optional[float] = None) -> Tuple[GeoPoint, float]:
         request = GetPositionRequest(name=self.name)
-        response: GetPositionResponse = await self.client.GetPosition(request)
+        response: GetPositionResponse = await self.client.GetPosition(request, timeout=timeout)
         return response.coordinate, response.altitude_mm
 
-    async def get_linear_velocity(self) -> Vector3:
+    async def get_linear_velocity(self, *, timeout: Optional[float] = None) -> Vector3:
         request = GetLinearVelocityRequest(name=self.name)
-        response: GetLinearVelocityResponse = await self.client.GetLinearVelocity(request)
+        response: GetLinearVelocityResponse = await self.client.GetLinearVelocity(request, timeout=timeout)
         return response.linear_velocity
 
-    async def get_angular_velocity(self) -> Vector3:
+    async def get_angular_velocity(self, *, timeout: Optional[float] = None) -> Vector3:
         request = GetAngularVelocityRequest(name=self.name)
-        response: GetAngularVelocityResponse = await self.client.GetAngularVelocity(request)
+        response: GetAngularVelocityResponse = await self.client.GetAngularVelocity(request, timeout=timeout)
         return response.angular_velocity
 
-    async def get_compass_heading(self) -> float:
+    async def get_compass_heading(self, *, timeout: Optional[float] = None) -> float:
         request = GetCompassHeadingRequest(name=self.name)
-        response: GetCompassHeadingResponse = await self.client.GetCompassHeading(request)
+        response: GetCompassHeadingResponse = await self.client.GetCompassHeading(request, timeout=timeout)
         return response.value
 
-    async def get_orientation(self) -> Orientation:
+    async def get_orientation(self, *, timeout: Optional[float] = None) -> Orientation:
         request = GetOrientationRequest(name=self.name)
-        response: GetOrientationResponse = await self.client.GetOrientation(request)
+        response: GetOrientationResponse = await self.client.GetOrientation(request, timeout=timeout)
         return response.orientation
 
-    async def get_properties(self) -> MovementSensor.Properties:
+    async def get_properties(self, *, timeout: Optional[float] = None) -> MovementSensor.Properties:
         request = GetPropertiesRequest(name=self.name)
-        response: GetPropertiesResponse = await self.client.GetProperties(request)
+        response: GetPropertiesResponse = await self.client.GetProperties(request, timeout=timeout)
         return response
 
-    async def get_accuracy(self) -> Mapping[str, float]:
+    async def get_accuracy(self, *, timeout: Optional[float] = None) -> Mapping[str, float]:
         request = GetAccuracyRequest(name=self.name)
-        response: GetAccuracyResponse = await self.client.GetAccuracy(request)
+        response: GetAccuracyResponse = await self.client.GetAccuracy(request, timeout=timeout)
         return response.accuracy_mm
 
-    async def get_readings(self) -> Mapping[str, Any]:
-        return await super().get_readings()
+    async def get_readings(self, *, timeout: Optional[float] = None) -> Mapping[str, Any]:
+        return await super().get_readings(timeout=timeout)
 
-    async def do_command(self, command: Dict[str, Any]) -> Dict[str, Any]:
-        return await do_command(self.channel, self.name, command)
+    async def do_command(self, command: Dict[str, Any], *, timeout: Optional[float] = None) -> Dict[str, Any]:
+        return await do_command(self.channel, self.name, command, timeout=timeout)

--- a/src/viam/components/movement_sensor/movement_sensor.py
+++ b/src/viam/components/movement_sensor/movement_sensor.py
@@ -1,6 +1,6 @@
 import abc
 import asyncio
-from typing import Any, Mapping, Tuple
+from typing import Any, Mapping, Optional, Tuple
 
 from viam.proto.common import GeoPoint, Orientation, Vector3
 from viam.proto.component.movementsensor import GetPropertiesResponse
@@ -18,7 +18,7 @@ class MovementSensor(Sensor):
     Properties = GetPropertiesResponse
 
     @abc.abstractmethod
-    async def get_position(self, **kwargs) -> Tuple[GeoPoint, float]:
+    async def get_position(self, *, timeout: Optional[float] = None, **kwargs) -> Tuple[GeoPoint, float]:
         """Get the current GeoPoint (latitude, longitude) and altitude (mm)
 
         Returns:
@@ -27,7 +27,7 @@ class MovementSensor(Sensor):
         ...
 
     @abc.abstractmethod
-    async def get_linear_velocity(self, **kwargs) -> Vector3:
+    async def get_linear_velocity(self, *, timeout: Optional[float] = None, **kwargs) -> Vector3:
         """Get the current linear velocity as a `Vector3` with x, y, and z axes represented in mm/sec
 
         Returns:
@@ -36,7 +36,7 @@ class MovementSensor(Sensor):
         ...
 
     @abc.abstractmethod
-    async def get_angular_velocity(self, **kwargs) -> Vector3:
+    async def get_angular_velocity(self, *, timeout: Optional[float] = None, **kwargs) -> Vector3:
         """Get the current angular velocity as a `Vector3` with x, y, and z axes represented in radians/sec
 
         Returns:
@@ -45,7 +45,7 @@ class MovementSensor(Sensor):
         ...
 
     @abc.abstractmethod
-    async def get_compass_heading(self, **kwargs) -> float:
+    async def get_compass_heading(self, *, timeout: Optional[float] = None, **kwargs) -> float:
         """Get the current compass heading in degrees
 
         Returns:
@@ -54,7 +54,7 @@ class MovementSensor(Sensor):
         ...
 
     @abc.abstractmethod
-    async def get_orientation(self, **kwargs) -> Orientation:
+    async def get_orientation(self, *, timeout: Optional[float] = None, **kwargs) -> Orientation:
         """Get the current orientation
 
         Returns:
@@ -63,7 +63,7 @@ class MovementSensor(Sensor):
         ...
 
     @abc.abstractmethod
-    async def get_properties(self, **kwargs) -> Properties:
+    async def get_properties(self, *, timeout: Optional[float] = None, **kwargs) -> Properties:
         """Get the supported properties of this sensor
 
         Returns:
@@ -72,7 +72,7 @@ class MovementSensor(Sensor):
         ...
 
     @abc.abstractmethod
-    async def get_accuracy(self, **kwargs) -> Mapping[str, float]:
+    async def get_accuracy(self, *, timeout: Optional[float] = None, **kwargs) -> Mapping[str, float]:
         """Get the accuracy of the various sensors
 
         Returns:
@@ -80,7 +80,7 @@ class MovementSensor(Sensor):
         """
         ...
 
-    async def get_readings(self, **kwargs) -> Mapping[str, Any]:
+    async def get_readings(self, *, timeout: Optional[float] = None, **kwargs) -> Mapping[str, Any]:
         """Obtain the measurements/data specific to this sensor.
 
         Returns:
@@ -95,11 +95,11 @@ class MovementSensor(Sensor):
             }
         """
         ((pos, alt), lv, av, comp, orient) = await asyncio.gather(
-            self.get_position(),
-            self.get_linear_velocity(),
-            self.get_angular_velocity(),
-            self.get_compass_heading(),
-            self.get_orientation(),
+            self.get_position(timeout=timeout),
+            self.get_linear_velocity(timeout=timeout),
+            self.get_angular_velocity(timeout=timeout),
+            self.get_compass_heading(timeout=timeout),
+            self.get_orientation(timeout=timeout),
         )
         return {
             "position": pos,

--- a/src/viam/components/movement_sensor/service.py
+++ b/src/viam/components/movement_sensor/service.py
@@ -37,7 +37,8 @@ class MovementSensorService(MovementSensorServiceBase, ComponentServiceBase[Move
             sensor = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        velocity = await sensor.get_linear_velocity()
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        velocity = await sensor.get_linear_velocity(timeout=timeout)
         response = GetLinearVelocityResponse(linear_velocity=velocity)
         await stream.send_message(response)
 
@@ -49,7 +50,8 @@ class MovementSensorService(MovementSensorServiceBase, ComponentServiceBase[Move
             sensor = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        velocity = await sensor.get_angular_velocity()
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        velocity = await sensor.get_angular_velocity(timeout=timeout)
         response = GetAngularVelocityResponse(angular_velocity=velocity)
         await stream.send_message(response)
 
@@ -61,7 +63,8 @@ class MovementSensorService(MovementSensorServiceBase, ComponentServiceBase[Move
             sensor = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        heading = await sensor.get_compass_heading()
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        heading = await sensor.get_compass_heading(timeout=timeout)
         response = GetCompassHeadingResponse(value=heading)
         await stream.send_message(response)
 
@@ -73,7 +76,8 @@ class MovementSensorService(MovementSensorServiceBase, ComponentServiceBase[Move
             sensor = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        orientation = await sensor.get_orientation()
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        orientation = await sensor.get_orientation(timeout=timeout)
         response = GetOrientationResponse(orientation=orientation)
         await stream.send_message(response)
 
@@ -85,7 +89,8 @@ class MovementSensorService(MovementSensorServiceBase, ComponentServiceBase[Move
             sensor = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        point, alt = await sensor.get_position()
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        point, alt = await sensor.get_position(timeout=timeout)
         response = GetPositionResponse(coordinate=point, altitude_mm=alt)
         await stream.send_message(response)
 
@@ -97,7 +102,8 @@ class MovementSensorService(MovementSensorServiceBase, ComponentServiceBase[Move
             sensor = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        response = await sensor.get_properties()
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        response = await sensor.get_properties(timeout=timeout)
         await stream.send_message(response)
 
     async def GetAccuracy(self, stream: Stream[GetAccuracyRequest, GetAccuracyResponse]) -> None:
@@ -108,6 +114,7 @@ class MovementSensorService(MovementSensorServiceBase, ComponentServiceBase[Move
             sensor = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        accuracy = await sensor.get_accuracy()
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        accuracy = await sensor.get_accuracy(timeout=timeout)
         response = GetAccuracyResponse(accuracy_mm=accuracy)
         await stream.send_message(response)

--- a/src/viam/components/pose_tracker/client.py
+++ b/src/viam/components/pose_tracker/client.py
@@ -1,9 +1,14 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from grpclib.client import Channel
+
 from viam.components.generic.client import do_command
 from viam.proto.common import PoseInFrame
-from viam.proto.component.posetracker import GetPosesRequest, GetPosesResponse, PoseTrackerServiceStub
+from viam.proto.component.posetracker import (
+    GetPosesRequest,
+    GetPosesResponse,
+    PoseTrackerServiceStub,
+)
 
 from .pose_tracker import PoseTracker
 
@@ -18,13 +23,13 @@ class PoseTrackerClient(PoseTracker):
         self.client = PoseTrackerServiceStub(channel)
         super().__init__(name)
 
-    async def get_poses(self, body_names: List[str]) -> Dict[str, PoseInFrame]:
+    async def get_poses(self, body_names: List[str], *, timeout: Optional[float] = None) -> Dict[str, PoseInFrame]:
         request = GetPosesRequest(
             name=self.name,
             body_names=body_names,
         )
-        response: GetPosesResponse = await self.client.GetPoses(request)
+        response: GetPosesResponse = await self.client.GetPoses(request, timeout=timeout)
         return {key: response.body_poses[key] for key in response.body_poses.keys()}
 
-    async def do_command(self, command: Dict[str, Any]) -> Dict[str, Any]:
-        return await do_command(self.channel, self.name, command)
+    async def do_command(self, command: Dict[str, Any], *, timeout: Optional[float] = None) -> Dict[str, Any]:
+        return await do_command(self.channel, self.name, command, timeout=timeout)

--- a/src/viam/components/pose_tracker/pose_tracker.py
+++ b/src/viam/components/pose_tracker/pose_tracker.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from viam.proto.common import PoseInFrame
 
@@ -16,7 +16,7 @@ class PoseTracker(ComponentBase):
     """
 
     @abc.abstractmethod
-    async def get_poses(self, body_names: List[str], **kwargs) -> Dict[str, PoseInFrame]:
+    async def get_poses(self, body_names: List[str], *, timeout: Optional[float] = None, **kwargs) -> Dict[str, PoseInFrame]:
         """
         Returns the current pose of each body tracked by the pose tracker.
 

--- a/src/viam/components/sensor/client.py
+++ b/src/viam/components/sensor/client.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Mapping
+from typing import Any, Dict, Mapping, Optional
 
 from grpclib.client import Channel
 
@@ -23,10 +23,10 @@ class SensorClient(Sensor):
         self.client = SensorServiceStub(channel)
         super().__init__(name)
 
-    async def get_readings(self) -> Mapping[str, Any]:
+    async def get_readings(self, *, timeout: Optional[float] = None) -> Mapping[str, Any]:
         request = GetReadingsRequest(name=self.name)
-        response: GetReadingsResponse = await self.client.GetReadings(request)
+        response: GetReadingsResponse = await self.client.GetReadings(request, timeout=timeout)
         return sensor_readings_value_to_native(response.readings)
 
-    async def do_command(self, command: Dict[str, Any]) -> Dict[str, Any]:
-        return await do_command(self.channel, self.name, command)
+    async def do_command(self, command: Dict[str, Any], *, timeout: Optional[float] = None) -> Dict[str, Any]:
+        return await do_command(self.channel, self.name, command, timeout=timeout)

--- a/src/viam/components/sensor/sensor.py
+++ b/src/viam/components/sensor/sensor.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Mapping
+from typing import Any, Mapping, Optional
 
 from ..component_base import ComponentBase
 
@@ -14,7 +14,7 @@ class Sensor(ComponentBase):
     """
 
     @abc.abstractmethod
-    async def get_readings(self, **kwargs) -> Mapping[str, Any]:
+    async def get_readings(self, *, timeout: Optional[float] = None, **kwargs) -> Mapping[str, Any]:
         """
         Obtain the measurements/data specific to this sensor.
 

--- a/src/viam/components/sensor/service.py
+++ b/src/viam/components/sensor/service.py
@@ -27,6 +27,7 @@ class SensorService(SensorServiceBase, ComponentServiceBase[Sensor]):
             sensor = self.get_component(name)
         except ComponentNotFoundError as e:
             raise e.grpc_error
-        readings = await sensor.get_readings()
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        readings = await sensor.get_readings(timeout=timeout)
         response = GetReadingsResponse(readings=sensor_readings_native_to_value(readings))
         await stream.send_message(response)

--- a/src/viam/components/servo/client.py
+++ b/src/viam/components/servo/client.py
@@ -1,8 +1,15 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from grpclib.client import Channel
+
 from viam.components.generic.client import do_command
-from viam.proto.component.servo import GetPositionRequest, GetPositionResponse, MoveRequest, ServoServiceStub, StopRequest
+from viam.proto.component.servo import (
+    GetPositionRequest,
+    GetPositionResponse,
+    MoveRequest,
+    ServoServiceStub,
+    StopRequest,
+)
 
 from .servo import Servo
 
@@ -17,18 +24,18 @@ class ServoClient(Servo):
         self.client = ServoServiceStub(channel)
         super().__init__(name)
 
-    async def get_position(self) -> int:
+    async def get_position(self, *, timeout: Optional[float] = None) -> int:
         request = GetPositionRequest(name=self.name)
-        response: GetPositionResponse = await self.client.GetPosition(request)
+        response: GetPositionResponse = await self.client.GetPosition(request, timeout=timeout)
         return response.position_deg
 
-    async def move(self, angle: int):
+    async def move(self, angle: int, *, timeout: Optional[float] = None):
         request = MoveRequest(name=self.name, angle_deg=angle)
-        await self.client.Move(request)
+        await self.client.Move(request, timeout=timeout)
 
-    async def stop(self):
+    async def stop(self, *, timeout: Optional[float] = None):
         request = StopRequest(name=self.name)
-        await self.client.Stop(request)
+        await self.client.Stop(request, timeout=timeout)
 
-    async def do_command(self, command: Dict[str, Any]) -> Dict[str, Any]:
-        return await do_command(self.channel, self.name, command)
+    async def do_command(self, command: Dict[str, Any], *, timeout: Optional[float] = None) -> Dict[str, Any]:
+        return await do_command(self.channel, self.name, command, timeout=timeout)

--- a/src/viam/components/servo/servo.py
+++ b/src/viam/components/servo/servo.py
@@ -1,4 +1,5 @@
 import abc
+from typing import Optional
 
 from viam.errors import NotSupportedError
 
@@ -17,7 +18,7 @@ class Servo(ComponentBase):
     name: str
 
     @abc.abstractmethod
-    async def move(self, angle: int, **kwargs):
+    async def move(self, angle: int, *, timeout: Optional[float] = None, **kwargs):
         """
         Move the servo to the provided angle.
 
@@ -27,7 +28,7 @@ class Servo(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def get_position(self, **kwargs) -> int:
+    async def get_position(self, *, timeout: Optional[float] = None, **kwargs) -> int:
         """
         Get the current angle (degrees) of the servo.
 
@@ -37,7 +38,7 @@ class Servo(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def stop(self, **kwargs):
+    async def stop(self, *, timeout: Optional[float] = None, **kwargs):
         """
         Stop the servo. It is assumed that the servo stops immediately.
         """

--- a/src/viam/rpc/server.py
+++ b/src/viam/rpc/server.py
@@ -48,7 +48,7 @@ class Server(ResourceManager):
         if address:
             host = address[0]
             port = address[1]
-        msg = "[gRPC Request] " + f'{host or "xxxx"}:{port or "xxxx"} - ' + f"{event.method_name}"
+        msg = f"[gRPC Request] {host or 'xxxx'}:{port or 'xxxx'} - {event.method_name}"
         LOGGER.info(msg)
 
     async def serve(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+import pytest
+
+
+def loose_approx(val):
+    return pytest.approx(val, rel=val * 1e-3)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,4 +2,4 @@ import pytest
 
 
 def loose_approx(val):
-    return pytest.approx(val, rel=val * 1e-3)
+    return pytest.approx(val, rel=val * 1e-2)

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -702,20 +702,24 @@ class MockPoseTracker(PoseTracker):
             pose_map[str(idx)] = pose
         self.poses_result = pose_map
         self.name = name
+        self.timeout: Optional[float] = None
 
-    async def get_poses(self, body_names: List[str], **kwargs) -> Dict[str, PoseInFrame]:
+    async def get_poses(self, body_names: List[str], *, timeout: Optional[float] = None, **kwargs) -> Dict[str, PoseInFrame]:
         result: Dict[str, PoseInFrame] = {}
         for name, pose in self.poses_result.items():
             result[name] = pose.to_pose_in_frame(name)
+        self.timeout = timeout
         return result
 
 
 class MockSensor(Sensor):
     def __init__(self, name: str, result: Mapping[str, Any] = {"a": 0, "b": {"foo": "bar"}, "c": [1, 8, 2], "d": "Hello world!"}):
         self.readings = result
+        self.timeout: Optional[float] = None
         super().__init__(name)
 
-    async def get_readings(self, **kwargs) -> Mapping[str, Any]:
+    async def get_readings(self, *, timeout: Optional[float] = None, **kwargs) -> Mapping[str, Any]:
+        self.timeout = timeout
         return self.readings
 
 
@@ -723,17 +727,21 @@ class MockServo(Servo):
     def __init__(self, name: str):
         self.angle = 0
         self.is_stopped = True
+        self.timeout: Optional[float] = None
         super().__init__(name)
 
-    async def move(self, angle: int, **kwargs):
+    async def move(self, angle: int, *, timeout: Optional[float] = None, **kwargs):
         self.angle = angle
         self.is_stopped = False
+        self.timeout = timeout
 
-    async def get_position(self, **kwargs) -> int:
+    async def get_position(self, *, timeout: Optional[float] = None, **kwargs) -> int:
+        self.timeout = timeout
         return self.angle
 
-    async def stop(self, **kwargs):
+    async def stop(self, *, timeout: Optional[float] = None, **kwargs):
         self.is_stopped = True
+        self.timeout = timeout
 
     async def is_moving(self) -> bool:
         return not self.is_stopped

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -59,6 +59,7 @@ class MockArm(Arm):
         self.joint_positions = JointPositions(values=[0, 0, 0, 0, 0, 0])
         self.is_stopped = True
         self.extra = None
+        self.timeout: Optional[float] = None
         super().__init__(name)
 
     async def get_end_position(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> Pose:
@@ -81,8 +82,9 @@ class MockArm(Arm):
         self.is_stopped = False
         self.extra = extra
 
-    async def stop(self, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def stop(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs):
         self.is_stopped = True
+        self.timeout = timeout
         self.extra = extra
 
     async def is_moving(self) -> bool:

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -62,30 +62,44 @@ class MockArm(Arm):
         self.timeout: Optional[float] = None
         super().__init__(name)
 
-    async def get_end_position(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> Pose:
+    async def get_end_position(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> Pose:
         self.extra = extra
+        self.timeout = timeout
         return self.position
 
     async def move_to_position(
-        self, pose: Pose, world_state: Optional[WorldState] = None, extra: Optional[Dict[str, Any]] = None, **kwargs
+        self,
+        pose: Pose,
+        world_state: Optional[WorldState] = None,
+        extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
+        **kwargs,
     ):
         self.position = pose
         self.is_stopped = False
         self.extra = extra
+        self.timeout = timeout
 
-    async def get_joint_positions(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> JointPositions:
+    async def get_joint_positions(
+        self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs
+    ) -> JointPositions:
         self.extra = extra
+        self.timeout = timeout
         return self.joint_positions
 
-    async def move_to_joint_positions(self, positions: JointPositions, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def move_to_joint_positions(
+        self, positions: JointPositions, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs
+    ):
         self.joint_positions = positions
         self.is_stopped = False
         self.extra = extra
+        self.timeout = timeout
 
     async def stop(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs):
         self.is_stopped = True
-        self.timeout = timeout
         self.extra = extra
+        self.timeout = timeout
 
     async def is_moving(self) -> bool:
         return not self.is_stopped
@@ -97,7 +111,7 @@ class MockAudioInput(AudioInput):
         self.properties = properties
         self.timeout: Optional[float] = None
 
-    async def stream(self, **kwargs) -> AudioStream:
+    async def stream(self, *, timeout: Optional[float] = None, **kwargs) -> AudioStream:
         async def read() -> AsyncIterator[Audio]:
             for i in range(10):
                 yield Audio(
@@ -109,6 +123,7 @@ class MockAudioInput(AudioInput):
                     AudioChunk(data=f"{i}".encode("utf-8"), length=182),
                 )
 
+        self.timeout = timeout
         return MediaStreamWithIterator(read())
 
     async def get_properties(self, *, timeout: Optional[float] = None) -> AudioInput.Properties:
@@ -129,7 +144,9 @@ class MockBase(Base):
         self.timeout: Optional[float] = None
         super().__init__(name)
 
-    async def move_straight(self, distance: int, velocity: float, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def move_straight(
+        self, distance: int, velocity: float, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs
+    ):
         if distance == 0 or velocity == 0:
             return await self.stop()
 
@@ -140,6 +157,7 @@ class MockBase(Base):
 
         self.stopped = False
         self.extra = extra
+        self.timeout = timeout
 
     async def move_arc(
         self,
@@ -147,6 +165,8 @@ class MockBase(Base):
         velocity: float,
         angle: float,
         extra: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
         **kwargs,
     ):
         if distance == 0:
@@ -164,8 +184,11 @@ class MockBase(Base):
 
         self.stopped = False
         self.extra = extra
+        self.timeout = timeout
 
-    async def spin(self, angle: float, velocity: float, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def spin(
+        self, angle: float, velocity: float, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs
+    ):
         if angle == 0 or velocity == 0:
             return await self.stop()
 
@@ -176,13 +199,19 @@ class MockBase(Base):
 
         self.stopped = False
         self.extra = extra
+        self.timeout = timeout
 
-    async def set_velocity(self, linear: Vector3, angular: Vector3, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def set_velocity(
+        self, linear: Vector3, angular: Vector3, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs
+    ):
         self.linear_vel = linear
         self.angular_vel = angular
         self.extra = extra
+        self.timeout = timeout
 
-    async def set_power(self, linear: Vector3, angular: Vector3, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def set_power(
+        self, linear: Vector3, angular: Vector3, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs
+    ):
         self.linear_pwr = linear
         self.angular_pwr = angular
         self.extra = extra
@@ -199,10 +228,12 @@ class MockBase(Base):
 class MockAnalogReader(Board.AnalogReader):
     def __init__(self, name: str, value: int):
         self.value = value
+        self.timeout: Optional[float] = None
         super().__init__(name)
 
-    async def read(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> int:
+    async def read(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> int:
         self.extra = extra
+        self.timeout = timeout
         return self.value
 
 
@@ -213,10 +244,12 @@ class MockDigitalInterrupt(Board.DigitalInterrupt):
         self.num_ticks = 0
         self.callbacks: List[Queue] = []
         self.post_processors: List[PostProcessor] = []
+        self.timeout: Optional[float] = None
         super().__init__(name)
 
-    async def value(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> int:
+    async def value(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> int:
         self.extra = extra
+        self.timeout = timeout
         return self.num_ticks
 
     async def tick(self, high: bool, nanos: int):
@@ -236,31 +269,38 @@ class MockGPIOPin(Board.GPIOPin):
         self.high = False
         self.pwm = 0.0
         self.pwm_freq = 0
+        self.timeout: Optional[float] = None
         super().__init__(name)
 
-    async def get(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> bool:
+    async def get(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> bool:
         self.extra = extra
+        self.timeout = timeout
         return self.high
 
-    async def set(self, high: bool, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def set(self, high: bool, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs):
         self.high = high
         self.extra = extra
+        self.timeout = timeout
 
-    async def get_pwm(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> float:
+    async def get_pwm(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> float:
         self.extra = extra
+        self.timeout = timeout
         return self.pwm
 
-    async def set_pwm(self, duty_cycle: float, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def set_pwm(self, duty_cycle: float, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs):
         self.pwm = duty_cycle
         self.extra = extra
+        self.timeout = timeout
 
-    async def get_pwm_frequency(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> int:
+    async def get_pwm_frequency(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> int:
         self.extra = extra
+        self.timeout = timeout
         return self.pwm_freq
 
-    async def set_pwm_frequency(self, frequency: int, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def set_pwm_frequency(self, frequency: int, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs):
         self.pwm_freq = frequency
         self.extra = extra
+        self.timeout = timeout
 
 
 class MockBoard(Board):
@@ -274,6 +314,7 @@ class MockBoard(Board):
         self.analog_readers = analog_readers
         self.digital_interrupts = digital_interrupts
         self.gpios = gpio_pins
+        self.timeout: Optional[float] = None
         super().__init__(name)
 
     async def analog_reader_by_name(self, name: str) -> Board.AnalogReader:
@@ -300,8 +341,9 @@ class MockBoard(Board):
     async def digital_interrupt_names(self) -> List[str]:
         return [key for key in self.digital_interrupts.keys()]
 
-    async def status(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> BoardStatus:
+    async def status(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> BoardStatus:
         self.extra = extra
+        self.timeout = timeout
         return BoardStatus(
             analogs={name: AnalogStatus(value=await analog.read()) for (name, analog) in self.analog_readers.items()},
             digital_interrupts={name: DigitalInterruptStatus(value=await di.value()) for (name, di) in self.digital_interrupts.items()},

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -649,26 +649,34 @@ class MockMovementSensor(MovementSensor):
         self.orientation = orientation
         self.properties = properties
         self.accuracy = accuracy
+        self.timeout: Optional[float] = None
 
-    async def get_position(self, **kwargs) -> Tuple[GeoPoint, float]:
+    async def get_position(self, *, timeout: Optional[float] = None, **kwargs) -> Tuple[GeoPoint, float]:
+        self.timeout = timeout
         return (self.coordinates, self.altitude)
 
-    async def get_linear_velocity(self, **kwargs) -> Vector3:
+    async def get_linear_velocity(self, *, timeout: Optional[float] = None, **kwargs) -> Vector3:
+        self.timeout = timeout
         return self.lin_vel
 
-    async def get_angular_velocity(self, **kwargs) -> Vector3:
+    async def get_angular_velocity(self, *, timeout: Optional[float] = None, **kwargs) -> Vector3:
+        self.timeout = timeout
         return self.ang_vel
 
-    async def get_compass_heading(self, **kwargs) -> float:
+    async def get_compass_heading(self, *, timeout: Optional[float] = None, **kwargs) -> float:
+        self.timeout = timeout
         return self.heading
 
-    async def get_orientation(self, **kwargs) -> Orientation:
+    async def get_orientation(self, *, timeout: Optional[float] = None, **kwargs) -> Orientation:
+        self.timeout = timeout
         return self.orientation
 
-    async def get_properties(self, **kwargs) -> MovementSensor.Properties:
+    async def get_properties(self, *, timeout: Optional[float] = None, **kwargs) -> MovementSensor.Properties:
+        self.timeout = timeout
         return self.properties
 
-    async def get_accuracy(self, **kwargs) -> Mapping[str, float]:
+    async def get_accuracy(self, *, timeout: Optional[float] = None, **kwargs) -> Mapping[str, float]:
+        self.timeout = timeout
         return self.accuracy
 
 

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -518,46 +518,109 @@ class MockMotor(Motor):
         self.power = 0
         self.powered = False
         self.extra = None
+        self.timeout: Optional[float] = None
         super().__init__(name)
 
-    async def set_power(self, power: float, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def set_power(
+        self,
+        power: float,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
         self.power = power
         self.powered = power != 0
         self.extra = extra
+        self.timeout = timeout
 
-    async def go_for(self, rpm: float, revolutions: float, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def go_for(
+        self,
+        rpm: float,
+        revolutions: float,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
         if rpm > 0:
             self.position += revolutions
         if rpm < 0:
             self.position -= revolutions
         self.powered = False
         self.extra = extra
+        self.timeout = timeout
 
-    async def go_to(self, rpm: float, position_revolutions: float, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def go_to(
+        self,
+        rpm: float,
+        position_revolutions: float,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
         if rpm != 0:
             self.position = position_revolutions
         self.powered = False
         self.extra = extra
+        self.timeout = timeout
 
-    async def reset_zero_position(self, offset: float, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def reset_zero_position(
+        self,
+        offset: float,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
         self.offset = offset
         self.powered = False
         self.extra = extra
+        self.timeout = timeout
 
-    async def get_position(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> float:
+    async def get_position(
+        self,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> float:
         self.extra = extra
+        self.timeout = timeout
         return self.position
 
-    async def get_properties(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> Motor.Properties:
+    async def get_properties(
+        self,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> Motor.Properties:
         self.extra = extra
+        self.timeout = timeout
         return Motor.Properties(position_reporting=True)
 
-    async def stop(self, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def stop(
+        self,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
         await self.set_power(0)
+        self.timeout = timeout
         self.extra = extra
 
-    async def is_powered(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> Tuple[bool, float]:
+    async def is_powered(
+        self,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> Tuple[bool, float]:
         self.extra = extra
+        self.timeout = timeout
         return self.powered, self.power
 
     async def is_moving(self) -> bool:

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -469,8 +469,10 @@ class MockInputController(Controller):
         super().__init__(name)
         self.events: Dict[Control, Event] = {}
         self.callbacks: Dict[Control, Dict[EventType, Optional[ControlFunction]]] = {}
+        self.timeout: Optional[float] = None
 
-    async def get_controls(self, **kwargs) -> List[Control]:
+    async def get_controls(self, *, timeout: Optional[float] = None, **kwargs) -> List[Control]:
+        self.timeout = timeout
         return [
             Control.ABSOLUTE_X,
             Control.ABSOLUTE_Y,
@@ -495,14 +497,16 @@ class MockInputController(Controller):
             Control.BUTTON_E_STOP,
         ]
 
-    async def get_events(self, **kwargs) -> Dict[Control, Event]:
+    async def get_events(self, *, timeout: Optional[float] = None, **kwargs) -> Dict[Control, Event]:
+        self.timeout = timeout
         return self.events
 
     def register_control_callback(self, control: Control, triggers: List[EventType], function: Optional[ControlFunction], **kwargs):
         self.callbacks[control] = {trigger: function for trigger in triggers}
 
-    async def trigger_event(self, event: Event, **kwargs):
+    async def trigger_event(self, event: Event, *, timeout: Optional[float] = None, **kwargs):
         self.events[event.control] = event
+        self.timeout = timeout
         callback = self.callbacks.get(event.control, {}).get(event.event)
         if callback:
             callback(event)

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -95,6 +95,7 @@ class MockAudioInput(AudioInput):
     def __init__(self, name: str, properties: AudioInput.Properties):
         super().__init__(name)
         self.properties = properties
+        self.timeout: Optional[float] = None
 
     async def stream(self, **kwargs) -> AudioStream:
         async def read() -> AsyncIterator[Audio]:
@@ -110,7 +111,8 @@ class MockAudioInput(AudioInput):
 
         return MediaStreamWithIterator(read())
 
-    async def get_properties(self) -> AudioInput.Properties:
+    async def get_properties(self, *, timeout: Optional[float] = None) -> AudioInput.Properties:
+        self.timeout = timeout
         return self.properties
 
 

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -362,9 +362,13 @@ class MockCamera(Camera):
             IntrinsicParameters(width_px=1, height_px=2, focal_x_px=3, focal_y_px=4, center_x_px=5, center_y_px=6),
             DistortionParameters(model="no_distortion"),
         )
+        self.timeout: Optional[float] = None
         super().__init__(name)
 
-    async def get_image(self, mime_type: str = CameraMimeType.PNG, **kwargs) -> Union[Image.Image, RawImage]:
+    async def get_image(
+        self, mime_type: str = CameraMimeType.PNG, *, timeout: Optional[float] = None, **kwargs
+    ) -> Union[Image.Image, RawImage]:
+        self.timeout = timeout
         if not CameraMimeType.is_supported(mime_type) or mime_type == CameraMimeType.RAW:
             return RawImage(
                 data=self.image.convert("RGBA").tobytes("raw", "RGBA"),
@@ -374,10 +378,12 @@ class MockCamera(Camera):
             )
         return self.image.copy()
 
-    async def get_point_cloud(self, **kwargs) -> Tuple[bytes, str]:
+    async def get_point_cloud(self, *, timeout: Optional[float] = None, **kwargs) -> Tuple[bytes, str]:
+        self.timeout = timeout
         return self.point_cloud, CameraMimeType.PCD.value
 
-    async def get_properties(self, **kwargs) -> Camera.Properties:
+    async def get_properties(self, *, timeout: Optional[float] = None, **kwargs) -> Camera.Properties:
+        self.timeout = timeout
         return self.props
 
 

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -430,7 +430,11 @@ class MockGantry(Gantry):
 
 
 class MockGeneric(GenericComponent):
-    async def do_command(self, command: Dict[str, Any], **kwargs) -> Dict[str, Any]:
+
+    timeout: Optional[float] = None
+
+    async def do_command(self, command: Dict[str, Any], *, timeout: Optional[float] = None, **kwargs) -> Dict[str, Any]:
+        self.timeout = timeout
         return {key: True for key in command.keys()}
 
 

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -442,19 +442,23 @@ class MockGripper(Gripper):
     def __init__(self, name: str):
         self.opened = False
         self.is_stopped = True
+        self.timeout: Optional[float] = None
         super().__init__(name)
 
-    async def open(self, **kwargs):
+    async def open(self, *, timeout: Optional[float] = None, **kwargs):
         self.opened = True
         self.is_stopped = False
+        self.timeout = timeout
 
-    async def grab(self, **kwargs) -> bool:
+    async def grab(self, *, timeout: Optional[float] = None, **kwargs) -> bool:
         self.opened = False
         self.is_stopped = False
+        self.timeout = timeout
         return choice([True, False])
 
-    async def stop(self, **kwargs):
+    async def stop(self, *, timeout: Optional[float] = None, **kwargs):
         self.is_stopped = True
+        self.timeout = timeout
 
     async def is_moving(self) -> bool:
         return not self.is_stopped

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -126,6 +126,7 @@ class MockBase(Base):
         self.linear_vel = Vector3(x=0, y=0, z=0)
         self.angular_vel = Vector3(x=0, y=0, z=0)
         self.extra: Optional[Dict[str, Any]] = None
+        self.timeout: Optional[float] = None
         super().__init__(name)
 
     async def move_straight(self, distance: int, velocity: float, extra: Optional[Dict[str, Any]] = None, **kwargs):
@@ -186,9 +187,10 @@ class MockBase(Base):
         self.angular_pwr = angular
         self.extra = extra
 
-    async def stop(self, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def stop(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs):
         self.stopped = True
         self.extra = extra
+        self.timeout = timeout
 
     async def is_moving(self) -> bool:
         return not self.stopped

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -62,7 +62,7 @@ class MockArm(Arm):
         self.timeout: Optional[float] = None
         super().__init__(name)
 
-    async def get_end_position(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> Pose:
+    async def get_end_position(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> Pose:
         self.extra = extra
         self.timeout = timeout
         return self.position
@@ -82,21 +82,21 @@ class MockArm(Arm):
         self.timeout = timeout
 
     async def get_joint_positions(
-        self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs
+        self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs
     ) -> JointPositions:
         self.extra = extra
         self.timeout = timeout
         return self.joint_positions
 
     async def move_to_joint_positions(
-        self, positions: JointPositions, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs
+        self, positions: JointPositions, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs
     ):
         self.joint_positions = positions
         self.is_stopped = False
         self.extra = extra
         self.timeout = timeout
 
-    async def stop(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs):
+    async def stop(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs):
         self.is_stopped = True
         self.extra = extra
         self.timeout = timeout
@@ -145,7 +145,7 @@ class MockBase(Base):
         super().__init__(name)
 
     async def move_straight(
-        self, distance: int, velocity: float, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs
+        self, distance: int, velocity: float, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs
     ):
         if distance == 0 or velocity == 0:
             return await self.stop()
@@ -187,7 +187,7 @@ class MockBase(Base):
         self.timeout = timeout
 
     async def spin(
-        self, angle: float, velocity: float, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs
+        self, angle: float, velocity: float, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs
     ):
         if angle == 0 or velocity == 0:
             return await self.stop()
@@ -202,7 +202,7 @@ class MockBase(Base):
         self.timeout = timeout
 
     async def set_velocity(
-        self, linear: Vector3, angular: Vector3, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs
+        self, linear: Vector3, angular: Vector3, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs
     ):
         self.linear_vel = linear
         self.angular_vel = angular
@@ -210,13 +210,13 @@ class MockBase(Base):
         self.timeout = timeout
 
     async def set_power(
-        self, linear: Vector3, angular: Vector3, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs
+        self, linear: Vector3, angular: Vector3, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs
     ):
         self.linear_pwr = linear
         self.angular_pwr = angular
         self.extra = extra
 
-    async def stop(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs):
+    async def stop(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs):
         self.stopped = True
         self.extra = extra
         self.timeout = timeout
@@ -231,7 +231,7 @@ class MockAnalogReader(Board.AnalogReader):
         self.timeout: Optional[float] = None
         super().__init__(name)
 
-    async def read(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> int:
+    async def read(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> int:
         self.extra = extra
         self.timeout = timeout
         return self.value
@@ -247,7 +247,7 @@ class MockDigitalInterrupt(Board.DigitalInterrupt):
         self.timeout: Optional[float] = None
         super().__init__(name)
 
-    async def value(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> int:
+    async def value(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> int:
         self.extra = extra
         self.timeout = timeout
         return self.num_ticks
@@ -272,32 +272,32 @@ class MockGPIOPin(Board.GPIOPin):
         self.timeout: Optional[float] = None
         super().__init__(name)
 
-    async def get(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> bool:
+    async def get(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> bool:
         self.extra = extra
         self.timeout = timeout
         return self.high
 
-    async def set(self, high: bool, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs):
+    async def set(self, high: bool, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs):
         self.high = high
         self.extra = extra
         self.timeout = timeout
 
-    async def get_pwm(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> float:
+    async def get_pwm(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> float:
         self.extra = extra
         self.timeout = timeout
         return self.pwm
 
-    async def set_pwm(self, duty_cycle: float, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs):
+    async def set_pwm(self, duty_cycle: float, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs):
         self.pwm = duty_cycle
         self.extra = extra
         self.timeout = timeout
 
-    async def get_pwm_frequency(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> int:
+    async def get_pwm_frequency(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> int:
         self.extra = extra
         self.timeout = timeout
         return self.pwm_freq
 
-    async def set_pwm_frequency(self, frequency: int, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs):
+    async def set_pwm_frequency(self, frequency: int, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs):
         self.pwm_freq = frequency
         self.extra = extra
         self.timeout = timeout
@@ -341,7 +341,7 @@ class MockBoard(Board):
     async def digital_interrupt_names(self) -> List[str]:
         return [key for key in self.digital_interrupts.keys()]
 
-    async def status(self, extra: Optional[Dict[str, Any]] = None, *, timeout: Optional[float] = None, **kwargs) -> BoardStatus:
+    async def status(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> BoardStatus:
         self.extra = extra
         self.timeout = timeout
         return BoardStatus(
@@ -393,30 +393,37 @@ class MockGantry(Gantry):
         self.lengths = lengths
         self.is_stopped = True
         self.extra = None
+        self.timeout: Optional[float] = None
         super().__init__(name)
 
-    async def get_position(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> List[float]:
+    async def get_position(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[float]:
         self.extra = extra
+        self.timeout = timeout
         return self.position
 
     async def move_to_position(
         self,
         positions: List[float],
         world_state: Optional[WorldState] = None,
+        *,
         extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
         **kwargs,
     ):
         self.position = positions
         self.is_stopped = False
         self.extra = extra
+        self.timeout = timeout
 
-    async def get_lengths(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> List[float]:
+    async def get_lengths(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[float]:
         self.extra = extra
+        self.timeout = timeout
         return self.lengths
 
-    async def stop(self, extra: Optional[Dict[str, Any]] = None, **kwargs):
+    async def stop(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs):
         self.extra = extra
         self.is_stopped = True
+        self.timeout = timeout
 
     async def is_moving(self) -> bool:
         return not self.is_stopped

--- a/tests/test_arm.py
+++ b/tests/test_arm.py
@@ -20,6 +20,7 @@ from viam.proto.component.arm import (
 )
 from viam.utils import dict_to_struct, message_to_struct
 
+from . import loose_approx
 from .mocks.components import MockArm
 
 
@@ -130,7 +131,7 @@ class TestService:
             request = StopRequest(name=self.name)
             await client.Stop(request, timeout=4.4)
             assert self.arm.is_stopped is True
-            assert self.arm.timeout == pytest.approx(4.4, rel=1e-3)
+            assert self.arm.timeout == loose_approx(4.4)
 
     @pytest.mark.asyncio
     async def test_extra(self):
@@ -187,7 +188,7 @@ class TestClient:
             client = ArmClient(self.name, channel)
             await client.stop(timeout=1.82)
             assert self.arm.is_stopped is True
-            assert self.arm.timeout == pytest.approx(1.82, rel=1e-3)
+            assert self.arm.timeout == loose_approx(1.82)
 
     @pytest.mark.asyncio
     async def test_is_moving(self):

--- a/tests/test_arm.py
+++ b/tests/test_arm.py
@@ -125,10 +125,12 @@ class TestService:
     async def test_stop(self):
         async with ChannelFor([self.service]) as channel:
             assert self.arm.is_stopped is False
+            assert self.arm.timeout is None
             client = ArmServiceStub(channel)
             request = StopRequest(name=self.name)
-            await client.Stop(request)
+            await client.Stop(request, timeout=4.4)
             assert self.arm.is_stopped is True
+            assert self.arm.timeout == pytest.approx(4.4, rel=1e-3)
 
     @pytest.mark.asyncio
     async def test_extra(self):
@@ -181,9 +183,11 @@ class TestClient:
     async def test_stop(self):
         async with ChannelFor([self.service]) as channel:
             assert self.arm.is_stopped is False
+            assert self.arm.timeout is None
             client = ArmClient(self.name, channel)
-            await client.stop()
+            await client.stop(timeout=1.82)
             assert self.arm.is_stopped is True
+            assert self.arm.timeout == pytest.approx(1.82, rel=1e-3)
 
     @pytest.mark.asyncio
     async def test_is_moving(self):

--- a/tests/test_audio_input.py
+++ b/tests/test_audio_input.py
@@ -94,11 +94,13 @@ class TestService:
                     idx += 1
 
     @pytest.mark.asyncio
-    async def test_properties(self, audio_input: AudioInput, service: AudioInputService):
+    async def test_properties(self, audio_input: MockAudioInput, service: AudioInputService):
+        assert audio_input.timeout is None
         async with ChannelFor([service]) as channel:
             client = AudioInputServiceStub(channel)
-            response: PropertiesResponse = await client.Properties(PropertiesRequest(name=audio_input.name))
+            response: PropertiesResponse = await client.Properties(PropertiesRequest(name=audio_input.name), timeout=1.82)
             assert AudioInput.Properties.from_proto(response) == PROPERTIES
+            assert audio_input.timeout == pytest.approx(1.82, rel=1e-3)
 
     @pytest.mark.asyncio
     async def test_record(self, service: AudioInputService):
@@ -126,10 +128,12 @@ class TestClient:
                 idx += 1
 
     @pytest.mark.asyncio
-    async def test_get_properties(self, audio_input: AudioInput, service: AudioInputService):
+    async def test_get_properties(self, audio_input: MockAudioInput, service: AudioInputService):
+        assert audio_input.timeout is None
         async with ChannelFor([service]) as channel:
             client = AudioInputClient(audio_input.name, channel)
-            assert await client.get_properties() == PROPERTIES
+            assert await client.get_properties(timeout=4.4) == PROPERTIES
+            assert audio_input.timeout == pytest.approx(4.4, rel=1e-3)
 
     @pytest.mark.asyncio
     async def test_do(self, audio_input: AudioInput, service: AudioInputService, generic_service: GenericService):

--- a/tests/test_audio_input.py
+++ b/tests/test_audio_input.py
@@ -1,9 +1,9 @@
 import sys
 from datetime import timedelta
 from typing import Union
-from grpclib import GRPCError
 
 import pytest
+from grpclib import GRPCError
 from grpclib.testing import ChannelFor
 
 from viam.components.audio_input import AudioInput, AudioInputClient, AudioInputService
@@ -19,6 +19,7 @@ from viam.proto.component.audioinput import (
     SampleFormat,
 )
 
+from . import loose_approx
 from .mocks.components import MockAudioInput
 
 PROPERTIES = AudioInput.Properties(
@@ -100,7 +101,7 @@ class TestService:
             client = AudioInputServiceStub(channel)
             response: PropertiesResponse = await client.Properties(PropertiesRequest(name=audio_input.name), timeout=1.82)
             assert AudioInput.Properties.from_proto(response) == PROPERTIES
-            assert audio_input.timeout == pytest.approx(1.82, rel=1e-3)
+            assert audio_input.timeout == loose_approx(1.82)
 
     @pytest.mark.asyncio
     async def test_record(self, service: AudioInputService):
@@ -133,7 +134,7 @@ class TestClient:
         async with ChannelFor([service]) as channel:
             client = AudioInputClient(audio_input.name, channel)
             assert await client.get_properties(timeout=4.4) == PROPERTIES
-            assert audio_input.timeout == pytest.approx(4.4, rel=1e-3)
+            assert audio_input.timeout == loose_approx(4.4)
 
     @pytest.mark.asyncio
     async def test_do(self, audio_input: AudioInput, service: AudioInputService, generic_service: GenericService):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -194,6 +194,7 @@ class TestService:
             client = BaseServiceStub(channel)
 
             assert base.stopped is True
+            assert base.timeout is None
 
             request = MoveStraightRequest(
                 name=base.name,
@@ -202,8 +203,9 @@ class TestService:
             )
             await client.MoveStraight(request)
             assert base.stopped is False
-            await client.Stop(StopRequest(name=base.name))
+            await client.Stop(StopRequest(name=base.name), timeout=1.82)
             assert base.stopped is True
+            assert base.timeout == pytest.approx(1.82, rel=1e-3)
 
             request = MoveStraightRequest(
                 name=base.name,
@@ -295,6 +297,7 @@ class TestClient:
 
     @pytest.mark.asyncio
     async def test_stop(self, base: MockBase, service: BaseService):
+        assert base.timeout is None
         async with ChannelFor([service]) as channel:
             client = BaseClient(base.name, channel)
 
@@ -302,8 +305,9 @@ class TestClient:
 
             await client.move_straight(1, 1)
             assert base.stopped is False
-            await client.stop()
+            await client.stop(timeout=4.4)
             assert base.stopped is True
+            assert base.timeout == pytest.approx(4.4, rel=1e-3)
 
             await client.move_straight(1, 1)
             assert base.stopped is False

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -125,7 +125,7 @@ class TestBase:
     async def test_extra(self, base: MockBase):
         assert base.extra is None
         extra = {"foo": "bar", "baz": [1, 2, 3]}
-        await base.move_straight(1, 1, extra)
+        await base.move_straight(1, 1, extra=extra)
         assert base.extra == extra
 
 
@@ -346,5 +346,5 @@ class TestClient:
             assert base.extra is None
             client = BaseClient(base.name, channel)
             extra = {"foo": "bar", "baz": [1, 2, 3]}
-            await client.move_straight(1, 1, extra)
+            await client.move_straight(1, 1, extra=extra)
             assert base.extra == extra

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,6 +2,7 @@ from random import randint, random
 
 import pytest
 from grpclib.testing import ChannelFor
+
 from viam.components.base import BaseClient, Vector3, create_status
 from viam.components.base.service import BaseService
 from viam.components.generic.service import GenericService
@@ -18,6 +19,7 @@ from viam.proto.component.base import (
 )
 from viam.utils import dict_to_struct, message_to_struct
 
+from . import loose_approx
 from .mocks.components import MockBase
 
 
@@ -205,7 +207,7 @@ class TestService:
             assert base.stopped is False
             await client.Stop(StopRequest(name=base.name), timeout=1.82)
             assert base.stopped is True
-            assert base.timeout == pytest.approx(1.82, rel=1e-3)
+            assert base.timeout == loose_approx(1.82)
 
             request = MoveStraightRequest(
                 name=base.name,
@@ -307,7 +309,7 @@ class TestClient:
             assert base.stopped is False
             await client.stop(timeout=4.4)
             assert base.stopped is True
-            assert base.timeout == pytest.approx(4.4, rel=1e-3)
+            assert base.timeout == loose_approx(4.4)
 
             await client.move_straight(1, 1)
             assert base.stopped is False

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -1,7 +1,9 @@
 from typing import cast
+
 import pytest
 from grpclib import GRPCError
 from grpclib.testing import ChannelFor
+
 from viam.components.board import Board, BoardClient
 from viam.components.board.service import BoardService
 from viam.components.generic.service import GenericService
@@ -28,7 +30,12 @@ from viam.proto.component.board import (
 )
 from viam.utils import dict_to_struct
 
-from .mocks.components import MockAnalogReader, MockBoard, MockDigitalInterrupt, MockGPIOPin
+from .mocks.components import (
+    MockAnalogReader,
+    MockBoard,
+    MockDigitalInterrupt,
+    MockGPIOPin,
+)
 
 
 def approx(val: float):
@@ -99,7 +106,7 @@ class TestBoard:
     @pytest.mark.asyncio
     async def test_status(self, board: MockBoard):
         extra = {"foo": "bar", "baz": [1, 2, 3]}
-        status = await board.status(extra, timeout=1.82)
+        status = await board.status(extra=extra, timeout=1.82)
         assert status == BoardStatus(
             analogs={"reader1": AnalogStatus(value=3)},
             digital_interrupts={"interrupt1": DigitalInterruptStatus(value=0)},
@@ -324,7 +331,7 @@ class TestClient:
             client = BoardClient(name=board.name, channel=channel)
 
             extra = {"foo": "bar", "baz": [1, 2, 3]}
-            status = await client.status(extra, timeout=1.1)
+            status = await client.status(extra=extra, timeout=1.1)
             assert status == BoardStatus(
                 analogs={"reader1": AnalogStatus(value=3)},
                 digital_interrupts={"interrupt1": DigitalInterruptStatus(value=0)},
@@ -348,7 +355,7 @@ class TestGPIOPinClient:
             client = BoardClient(name=board.name, channel=channel)
             pin = await client.gpio_pin_by_name("pin1")
             extra = {"foo": "bar", "baz": [1, 2, 3]}
-            await pin.set(True, extra, timeout=1.82)
+            await pin.set(True, extra=extra, timeout=1.82)
 
             mock_pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert mock_pin.high is True
@@ -361,7 +368,7 @@ class TestGPIOPinClient:
             client = BoardClient(name=board.name, channel=channel)
             pin = await client.gpio_pin_by_name("pin1")
             extra = {"foo": "bar", "baz": [1, 2, 3]}
-            high = await pin.get(extra)
+            high = await pin.get(extra=extra)
             assert high is False
             mock_pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert mock_pin.extra == extra
@@ -373,7 +380,7 @@ class TestGPIOPinClient:
             client = BoardClient(name=board.name, channel=channel)
             pin = await client.gpio_pin_by_name("pin1")
             extra = {"foo": "bar", "baz": [1, 2, 3]}
-            await pin.set_pwm(12.3, extra, timeout=3.23)
+            await pin.set_pwm(12.3, extra=extra, timeout=3.23)
             mock_pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert mock_pin.pwm == 12.3
             assert mock_pin.extra == extra
@@ -385,7 +392,7 @@ class TestGPIOPinClient:
             client = BoardClient(name=board.name, channel=channel)
             pin = await client.gpio_pin_by_name("pin1")
             extra = {"foo": "bar", "baz": [1, 2, 3]}
-            pwm = await pin.get_pwm(extra, timeout=1.2345)
+            pwm = await pin.get_pwm(extra=extra, timeout=1.2345)
             assert pwm == 0.0
             mock_pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert mock_pin.extra == extra
@@ -397,7 +404,7 @@ class TestGPIOPinClient:
             client = BoardClient(name=board.name, channel=channel)
             pin = await client.gpio_pin_by_name("pin1")
             extra = {"foo": "bar", "baz": [1, 2, 3]}
-            await pin.set_pwm_frequency(123, extra, timeout=4.341)
+            await pin.set_pwm_frequency(123, extra=extra, timeout=4.341)
             mock_pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert mock_pin.pwm_freq == 123
             assert mock_pin.extra == extra
@@ -409,7 +416,7 @@ class TestGPIOPinClient:
             client = BoardClient(name=board.name, channel=channel)
             pin = await client.gpio_pin_by_name("pin1")
             extra = {"foo": "bar", "baz": [1, 2, 3]}
-            freq = await pin.get_pwm_frequency(extra)
+            freq = await pin.get_pwm_frequency(extra=extra)
             assert freq == 0
             mock_pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert mock_pin.extra == extra

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -31,6 +31,10 @@ from viam.utils import dict_to_struct
 from .mocks.components import MockAnalogReader, MockBoard, MockDigitalInterrupt, MockGPIOPin
 
 
+def approx(val: float):
+    return pytest.approx(val, rel=val * 1e-3)
+
+
 @pytest.fixture(scope="function")
 def board() -> MockBoard:
     return MockBoard(
@@ -95,12 +99,13 @@ class TestBoard:
     @pytest.mark.asyncio
     async def test_status(self, board: MockBoard):
         extra = {"foo": "bar", "baz": [1, 2, 3]}
-        status = await board.status(extra)
+        status = await board.status(extra, timeout=1.82)
         assert status == BoardStatus(
             analogs={"reader1": AnalogStatus(value=3)},
             digital_interrupts={"interrupt1": DigitalInterruptStatus(value=0)},
         )
         assert board.extra == extra
+        assert board.timeout == approx(1.82)
 
     @pytest.mark.asyncio
     async def test_model_attributes(self, board: MockBoard):
@@ -125,11 +130,12 @@ class TestService:
 
             extra = {"foo": "bar", "baz": [1, 2, 3]}
             request = ReadAnalogReaderRequest(board_name=board.name, analog_reader_name="reader1", extra=dict_to_struct(extra))
-            response: ReadAnalogReaderResponse = await client.ReadAnalogReader(request)
+            response: ReadAnalogReaderResponse = await client.ReadAnalogReader(request, timeout=4.4)
             assert response.value == 3
 
             reader = cast(MockAnalogReader, board.analog_readers["reader1"])
             assert reader.extra == extra
+            assert reader.timeout == approx(4.4)
 
     @pytest.mark.asyncio
     async def test_get_digital_interrupt_value(self, board: MockBoard, service: BoardService):
@@ -144,11 +150,12 @@ class TestService:
             request = GetDigitalInterruptValueRequest(
                 board_name=board.name, digital_interrupt_name="interrupt1", extra=dict_to_struct(extra)
             )
-            response: GetDigitalInterruptValueResponse = await client.GetDigitalInterruptValue(request)
+            response: GetDigitalInterruptValueResponse = await client.GetDigitalInterruptValue(request, timeout=18.2)
             assert response.value == 0
 
             interrupt = cast(MockDigitalInterrupt, board.digital_interrupts["interrupt1"])
             assert interrupt.extra == extra
+            assert interrupt.timeout == approx(18.2)
 
     @pytest.mark.asyncio
     async def test_set_gpio(self, board: MockBoard, service: BoardService):
@@ -157,11 +164,12 @@ class TestService:
 
             extra = {"foo": "bar", "baz": [1, 2, 3]}
             request = SetGPIORequest(name=board.name, pin="pin1", high=True, extra=dict_to_struct(extra))
-            await client.SetGPIO(request)
+            await client.SetGPIO(request, timeout=4.1)
 
             pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert pin.high is True
             assert pin.extra == extra
+            assert pin.timeout == approx(4.1)
 
     @pytest.mark.asyncio
     async def test_get_gpio(self, board: MockBoard, service: BoardService):
@@ -174,11 +182,12 @@ class TestService:
 
             extra = {"foo": "bar", "baz": [1, 2, 3]}
             request = GetGPIORequest(name=board.name, pin="pin1", extra=dict_to_struct(extra))
-            response: GetGPIOResponse = await client.GetGPIO(request)
+            response: GetGPIOResponse = await client.GetGPIO(request, timeout=1.82)
             assert response.high is False
 
             pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert pin.extra == extra
+            assert pin.timeout == approx(1.82)
 
     @pytest.mark.asyncio
     async def test_pwm(self, board: MockBoard, service: BoardService):
@@ -187,11 +196,12 @@ class TestService:
 
             extra = {"foo": "bar", "baz": [1, 2, 3]}
             request = PWMRequest(name=board.name, pin="pin1", extra=dict_to_struct(extra))
-            response: PWMResponse = await client.PWM(request)
+            response: PWMResponse = await client.PWM(request, timeout=7.86)
             assert response.duty_cycle_pct == 0.0
 
             pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert pin.extra == extra
+            assert pin.timeout == approx(7.86)
 
     @pytest.mark.asyncio
     async def test_set_pwm(self, board: MockBoard, service: BoardService):
@@ -200,11 +210,12 @@ class TestService:
 
             extra = {"foo": "bar", "baz": [1, 2, 3]}
             request = SetPWMRequest(name=board.name, pin="pin1", duty_cycle_pct=12.3, extra=dict_to_struct(extra))
-            await client.SetPWM(request)
+            await client.SetPWM(request, timeout=1.213)
 
             pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert pin.pwm == 12.3
             assert pin.extra == extra
+            assert pin.timeout == approx(1.213)
 
     @pytest.mark.asyncio
     async def test_pwm_frequency(self, board: MockBoard, service: BoardService):
@@ -213,11 +224,12 @@ class TestService:
 
             extra = {"foo": "bar", "baz": [1, 2, 3]}
             request = PWMFrequencyRequest(name=board.name, pin="pin1", extra=dict_to_struct(extra))
-            response: PWMFrequencyResponse = await client.PWMFrequency(request)
+            response: PWMFrequencyResponse = await client.PWMFrequency(request, timeout=182)
             assert response.frequency_hz == 0
 
             pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert pin.extra == extra
+            assert pin.timeout == approx(182)
 
     @pytest.mark.asyncio
     async def test_set_pwm_freq(self, board: MockBoard, service: BoardService):
@@ -231,6 +243,7 @@ class TestService:
             pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert pin.pwm_freq == 123
             assert pin.extra == extra
+            assert pin.timeout is None
 
     @pytest.mark.asyncio
     async def test_status(self, board: MockBoard, service: BoardService):
@@ -239,13 +252,14 @@ class TestService:
 
             extra = {"foo": "bar", "baz": [1, 2, 3]}
             request = StatusRequest(name=board.name, extra=dict_to_struct(extra))
-            response: StatusResponse = await client.Status(request)
+            response: StatusResponse = await client.Status(request, timeout=5.55)
 
             assert response.status == BoardStatus(
                 analogs={"reader1": AnalogStatus(value=3)},
                 digital_interrupts={"interrupt1": DigitalInterruptStatus(value=0)},
             )
             assert board.extra == extra
+            assert board.timeout == approx(5.55)
 
 
 class TestClient:
@@ -310,12 +324,13 @@ class TestClient:
             client = BoardClient(name=board.name, channel=channel)
 
             extra = {"foo": "bar", "baz": [1, 2, 3]}
-            status = await client.status(extra)
+            status = await client.status(extra, timeout=1.1)
             assert status == BoardStatus(
                 analogs={"reader1": AnalogStatus(value=3)},
                 digital_interrupts={"interrupt1": DigitalInterruptStatus(value=0)},
             )
             assert board.extra == extra
+            assert board.timeout == approx(1.1)
 
     @pytest.mark.asyncio
     async def test_model_attributes(self, board: MockBoard, service: BoardService):
@@ -333,11 +348,12 @@ class TestGPIOPinClient:
             client = BoardClient(name=board.name, channel=channel)
             pin = await client.gpio_pin_by_name("pin1")
             extra = {"foo": "bar", "baz": [1, 2, 3]}
-            await pin.set(True, extra)
+            await pin.set(True, extra, timeout=1.82)
 
             mock_pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert mock_pin.high is True
             assert mock_pin.extra == extra
+            assert mock_pin.timeout == approx(1.82)
 
     @pytest.mark.asyncio
     async def test_get(self, board: MockBoard, service: BoardService):
@@ -349,6 +365,7 @@ class TestGPIOPinClient:
             assert high is False
             mock_pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert mock_pin.extra == extra
+            assert mock_pin.timeout is None
 
     @pytest.mark.asyncio
     async def test_set_pwm(self, board: MockBoard, service: BoardService):
@@ -356,10 +373,11 @@ class TestGPIOPinClient:
             client = BoardClient(name=board.name, channel=channel)
             pin = await client.gpio_pin_by_name("pin1")
             extra = {"foo": "bar", "baz": [1, 2, 3]}
-            await pin.set_pwm(12.3, extra)
+            await pin.set_pwm(12.3, extra, timeout=3.23)
             mock_pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert mock_pin.pwm == 12.3
             assert mock_pin.extra == extra
+            assert mock_pin.timeout == approx(3.23)
 
     @pytest.mark.asyncio
     async def test_get_pwm(self, board: MockBoard, service: BoardService):
@@ -367,10 +385,11 @@ class TestGPIOPinClient:
             client = BoardClient(name=board.name, channel=channel)
             pin = await client.gpio_pin_by_name("pin1")
             extra = {"foo": "bar", "baz": [1, 2, 3]}
-            pwm = await pin.get_pwm(extra)
+            pwm = await pin.get_pwm(extra, timeout=1.2345)
             assert pwm == 0.0
             mock_pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert mock_pin.extra == extra
+            assert mock_pin.timeout == approx(1.2345)
 
     @pytest.mark.asyncio
     async def test_set_pwm_frequency(self, board: MockBoard, service: BoardService):
@@ -378,10 +397,11 @@ class TestGPIOPinClient:
             client = BoardClient(name=board.name, channel=channel)
             pin = await client.gpio_pin_by_name("pin1")
             extra = {"foo": "bar", "baz": [1, 2, 3]}
-            await pin.set_pwm_frequency(123, extra)
+            await pin.set_pwm_frequency(123, extra, timeout=4.341)
             mock_pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert mock_pin.pwm_freq == 123
             assert mock_pin.extra == extra
+            assert mock_pin.timeout == approx(4.341)
 
     @pytest.mark.asyncio
     async def test_get_pwm_freq(self, board: MockBoard, service: BoardService):
@@ -393,6 +413,7 @@ class TestGPIOPinClient:
             assert freq == 0
             mock_pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert mock_pin.extra == extra
+            assert mock_pin.timeout is None
 
     @pytest.mark.asyncio
     async def test_do(self, board: MockBoard, service: BoardService, generic_service: GenericService):

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -30,16 +30,13 @@ from viam.proto.component.board import (
 )
 from viam.utils import dict_to_struct
 
+from . import loose_approx
 from .mocks.components import (
     MockAnalogReader,
     MockBoard,
     MockDigitalInterrupt,
     MockGPIOPin,
 )
-
-
-def approx(val: float):
-    return pytest.approx(val, rel=val * 1e-3)
 
 
 @pytest.fixture(scope="function")
@@ -112,7 +109,7 @@ class TestBoard:
             digital_interrupts={"interrupt1": DigitalInterruptStatus(value=0)},
         )
         assert board.extra == extra
-        assert board.timeout == approx(1.82)
+        assert board.timeout == loose_approx(1.82)
 
     @pytest.mark.asyncio
     async def test_model_attributes(self, board: MockBoard):
@@ -142,7 +139,7 @@ class TestService:
 
             reader = cast(MockAnalogReader, board.analog_readers["reader1"])
             assert reader.extra == extra
-            assert reader.timeout == approx(4.4)
+            assert reader.timeout == loose_approx(4.4)
 
     @pytest.mark.asyncio
     async def test_get_digital_interrupt_value(self, board: MockBoard, service: BoardService):
@@ -162,7 +159,7 @@ class TestService:
 
             interrupt = cast(MockDigitalInterrupt, board.digital_interrupts["interrupt1"])
             assert interrupt.extra == extra
-            assert interrupt.timeout == approx(18.2)
+            assert interrupt.timeout == loose_approx(18.2)
 
     @pytest.mark.asyncio
     async def test_set_gpio(self, board: MockBoard, service: BoardService):
@@ -176,7 +173,7 @@ class TestService:
             pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert pin.high is True
             assert pin.extra == extra
-            assert pin.timeout == approx(4.1)
+            assert pin.timeout == loose_approx(4.1)
 
     @pytest.mark.asyncio
     async def test_get_gpio(self, board: MockBoard, service: BoardService):
@@ -194,7 +191,7 @@ class TestService:
 
             pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert pin.extra == extra
-            assert pin.timeout == approx(1.82)
+            assert pin.timeout == loose_approx(1.82)
 
     @pytest.mark.asyncio
     async def test_pwm(self, board: MockBoard, service: BoardService):
@@ -208,7 +205,7 @@ class TestService:
 
             pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert pin.extra == extra
-            assert pin.timeout == approx(7.86)
+            assert pin.timeout == loose_approx(7.86)
 
     @pytest.mark.asyncio
     async def test_set_pwm(self, board: MockBoard, service: BoardService):
@@ -222,7 +219,7 @@ class TestService:
             pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert pin.pwm == 12.3
             assert pin.extra == extra
-            assert pin.timeout == approx(1.213)
+            assert pin.timeout == loose_approx(1.213)
 
     @pytest.mark.asyncio
     async def test_pwm_frequency(self, board: MockBoard, service: BoardService):
@@ -236,7 +233,7 @@ class TestService:
 
             pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert pin.extra == extra
-            assert pin.timeout == approx(182)
+            assert pin.timeout == loose_approx(182)
 
     @pytest.mark.asyncio
     async def test_set_pwm_freq(self, board: MockBoard, service: BoardService):
@@ -266,7 +263,7 @@ class TestService:
                 digital_interrupts={"interrupt1": DigitalInterruptStatus(value=0)},
             )
             assert board.extra == extra
-            assert board.timeout == approx(5.55)
+            assert board.timeout == loose_approx(5.55)
 
 
 class TestClient:
@@ -337,7 +334,7 @@ class TestClient:
                 digital_interrupts={"interrupt1": DigitalInterruptStatus(value=0)},
             )
             assert board.extra == extra
-            assert board.timeout == approx(1.1)
+            assert board.timeout == loose_approx(1.1)
 
     @pytest.mark.asyncio
     async def test_model_attributes(self, board: MockBoard, service: BoardService):
@@ -360,7 +357,7 @@ class TestGPIOPinClient:
             mock_pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert mock_pin.high is True
             assert mock_pin.extra == extra
-            assert mock_pin.timeout == approx(1.82)
+            assert mock_pin.timeout == loose_approx(1.82)
 
     @pytest.mark.asyncio
     async def test_get(self, board: MockBoard, service: BoardService):
@@ -384,7 +381,7 @@ class TestGPIOPinClient:
             mock_pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert mock_pin.pwm == 12.3
             assert mock_pin.extra == extra
-            assert mock_pin.timeout == approx(3.23)
+            assert mock_pin.timeout == loose_approx(3.23)
 
     @pytest.mark.asyncio
     async def test_get_pwm(self, board: MockBoard, service: BoardService):
@@ -396,7 +393,7 @@ class TestGPIOPinClient:
             assert pwm == 0.0
             mock_pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert mock_pin.extra == extra
-            assert mock_pin.timeout == approx(1.2345)
+            assert mock_pin.timeout == loose_approx(1.2345)
 
     @pytest.mark.asyncio
     async def test_set_pwm_frequency(self, board: MockBoard, service: BoardService):
@@ -408,7 +405,7 @@ class TestGPIOPinClient:
             mock_pin = cast(MockGPIOPin, board.gpios["pin1"])
             assert mock_pin.pwm_freq == 123
             assert mock_pin.extra == extra
-            assert mock_pin.timeout == approx(4.341)
+            assert mock_pin.timeout == loose_approx(4.341)
 
     @pytest.mark.asyncio
     async def test_get_pwm_freq(self, board: MockBoard, service: BoardService):

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -23,12 +23,8 @@ from viam.proto.component.camera import (
     RenderFrameRequest,
 )
 
+from . import loose_approx
 from .mocks.components import MockCamera
-
-
-def approx(val: float):
-    return pytest.approx(val, rel=val * 1e-3)
-
 
 # ################################ NB ################################# #
 #   These test values have to be fixtures and must match the values in  #
@@ -102,13 +98,13 @@ class TestCamera:
         assert camera.timeout is None
 
         await camera.get_image(timeout=1.82)
-        assert camera.timeout == approx(1.82)
+        assert camera.timeout == loose_approx(1.82)
 
         await camera.get_point_cloud(timeout=4.4)
-        assert camera.timeout == approx(4.4)
+        assert camera.timeout == loose_approx(4.4)
 
         await camera.get_properties(timeout=7.86)
-        assert camera.timeout == approx(7.86)
+        assert camera.timeout == loose_approx(7.86)
 
 
 class TestService:
@@ -123,7 +119,7 @@ class TestService:
             response: GetImageResponse = await client.GetImage(request, timeout=18.2)
             img = Image.open(BytesIO(response.image), formats=["PNG"])
             assert img.tobytes() == image.tobytes()
-            assert camera.timeout == approx(18.2)
+            assert camera.timeout == loose_approx(18.2)
 
             # Test raw mime type
             request = GetImageRequest(name="camera", mime_type=CameraMimeType.RAW)
@@ -150,7 +146,7 @@ class TestService:
             buf = BytesIO(response.data)
             img = Image.open(buf, formats=["JPEG", "PNG"])
             assert img.tobytes() == image.tobytes()
-            assert camera.timeout == approx(4.4)
+            assert camera.timeout == loose_approx(4.4)
 
     @pytest.mark.asyncio
     async def test_get_point_cloud(self, camera: MockCamera, service: CameraService, point_cloud: bytes):
@@ -160,7 +156,7 @@ class TestService:
             request = GetPointCloudRequest(name="camera", mime_type=CameraMimeType.PCD)
             response: GetPointCloudResponse = await client.GetPointCloud(request, timeout=7.86)
             assert response.point_cloud == point_cloud
-            assert camera.timeout == approx(7.86)
+            assert camera.timeout == loose_approx(7.86)
 
     @pytest.mark.asyncio
     async def test_get_properties(self, camera: MockCamera, service: CameraService, properties: Camera.Properties):
@@ -171,7 +167,7 @@ class TestService:
             response: GetPropertiesResponse = await client.GetProperties(request, timeout=5.43)
             assert response.supports_pcd == properties.supports_pcd
             assert response.intrinsic_parameters == properties.intrinsic_parameters
-            assert camera.timeout == approx(5.43)
+            assert camera.timeout == loose_approx(5.43)
 
 
 class TestClient:
@@ -186,7 +182,7 @@ class TestClient:
             assert isinstance(img, Image.Image)
             assert img.convert("RGBA") == image.convert("RGBA")
             assert img.tobytes() == image.tobytes()
-            assert camera.timeout == approx(1.82)
+            assert camera.timeout == loose_approx(1.82)
 
             # Test raw mime type
             img = await client.get_image(CameraMimeType.RAW)
@@ -211,7 +207,7 @@ class TestClient:
             client = CameraClient("camera", channel)
             pc, _ = await client.get_point_cloud(timeout=4.4)
             assert pc == point_cloud
-            assert camera.timeout == approx(4.4)
+            assert camera.timeout == loose_approx(4.4)
 
     @pytest.mark.asyncio
     async def test_get_properties(self, camera: MockCamera, service: CameraService, properties: Camera.Properties):
@@ -220,7 +216,7 @@ class TestClient:
             client = CameraClient("camera", channel)
             props = await client.get_properties(timeout=7.86)
             assert props == properties
-            assert camera.timeout == approx(7.86)
+            assert camera.timeout == loose_approx(7.86)
 
     @pytest.mark.asyncio
     async def test_do(self, service: CameraService, generic_service: GenericService):

--- a/tests/test_gantry.py
+++ b/tests/test_gantry.py
@@ -1,5 +1,6 @@
 import pytest
 from grpclib.testing import ChannelFor
+
 from viam.components.gantry import GantryClient, GantryStatus, create_status
 from viam.components.gantry.service import GantryService
 from viam.components.generic.service import GenericService
@@ -16,11 +17,8 @@ from viam.proto.component.gantry import (
 )
 from viam.utils import dict_to_struct, message_to_struct
 
+from . import loose_approx
 from .mocks.components import MockGantry
-
-
-def approx(val: float):
-    return pytest.approx(val, rel=val * 1e-3)
 
 
 class TestGantry:
@@ -79,16 +77,16 @@ class TestGantry:
         assert self.gantry.timeout is None
 
         await self.gantry.get_position(timeout=5.5)
-        assert self.gantry.timeout == approx(5.5)
+        assert self.gantry.timeout == loose_approx(5.5)
 
         await self.gantry.move_to_position([1, 2, 3], timeout=1.82)
-        assert self.gantry.timeout == approx(1.82)
+        assert self.gantry.timeout == loose_approx(1.82)
 
         await self.gantry.get_lengths(timeout=7.86)
-        assert self.gantry.timeout == approx(7.86)
+        assert self.gantry.timeout == loose_approx(7.86)
 
         await self.gantry.stop(timeout=4.4)
-        assert self.gantry.timeout == approx(4.4)
+        assert self.gantry.timeout == loose_approx(4.4)
 
 
 class TestService:
@@ -104,7 +102,7 @@ class TestService:
             request = GetPositionRequest(name=self.gantry.name)
             response: GetPositionResponse = await client.GetPosition(request, timeout=9.87)
             assert list(response.positions_mm) == [1, 2, 3]
-            assert self.gantry.timeout == approx(9.87)
+            assert self.gantry.timeout == loose_approx(9.87)
 
     @pytest.mark.asyncio
     async def test_move_to_position(self):
@@ -113,7 +111,7 @@ class TestService:
             request = MoveToPositionRequest(name=self.gantry.name, positions_mm=[1, 8, 2])
             await client.MoveToPosition(request, timeout=18.2)
             assert self.gantry.position == [1, 8, 2]
-            assert self.gantry.timeout == approx(18.2)
+            assert self.gantry.timeout == loose_approx(18.2)
 
     @pytest.mark.asyncio
     async def test_get_lengths(self):
@@ -122,7 +120,7 @@ class TestService:
             request = GetLengthsRequest(name=self.gantry.name)
             response: GetLengthsResponse = await client.GetLengths(request, timeout=3.3)
             assert list(response.lengths_mm) == [4, 5, 6]
-            assert self.gantry.timeout == approx(3.3)
+            assert self.gantry.timeout == loose_approx(3.3)
 
     @pytest.mark.asyncio
     async def test_stop(self):
@@ -132,7 +130,7 @@ class TestService:
             request = StopRequest(name=self.gantry.name)
             await client.Stop(request, timeout=1.1)
             assert self.gantry.is_stopped is True
-            assert self.gantry.timeout == approx(1.1)
+            assert self.gantry.timeout == loose_approx(1.1)
 
     @pytest.mark.asyncio
     async def test_extra(self):
@@ -157,7 +155,7 @@ class TestClient:
             client = GantryClient(self.gantry.name, channel)
             pos = await client.get_position(timeout=1.82)
             assert pos == [1, 2, 3]
-            assert self.gantry.timeout == approx(1.82)
+            assert self.gantry.timeout == loose_approx(1.82)
 
     @pytest.mark.asyncio
     async def test_move_to_position(self):
@@ -165,7 +163,7 @@ class TestClient:
             client = GantryClient(self.gantry.name, channel)
             await client.move_to_position([1, 8, 2], timeout=4.4)
             assert self.gantry.position == [1, 8, 2]
-            assert self.gantry.timeout == approx(4.4)
+            assert self.gantry.timeout == loose_approx(4.4)
 
     @pytest.mark.asyncio
     async def test_get_lengths(self):
@@ -173,7 +171,7 @@ class TestClient:
             client = GantryClient(self.gantry.name, channel)
             lengths = await client.get_lengths(timeout=5.5)
             assert lengths == [4, 5, 6]
-            assert self.gantry.timeout == approx(5.5)
+            assert self.gantry.timeout == loose_approx(5.5)
 
     @pytest.mark.asyncio
     async def test_do(self):

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -10,11 +10,8 @@ from viam.proto.component.generic import (
 )
 from viam.utils import dict_to_struct, struct_to_dict
 
+from . import loose_approx
 from .mocks.components import MockGeneric
-
-
-def approx(val: float):
-    return pytest.approx(val, rel=val * 1e-3)
 
 
 class TestGeneric:
@@ -25,7 +22,7 @@ class TestGeneric:
     async def test_do(self):
         result = await self.generic.do_command({"command": "args"}, timeout=1.82)
         assert result == {"command": True}
-        assert self.generic.timeout == approx(1.82)
+        assert self.generic.timeout == loose_approx(1.82)
 
 
 class TestService:
@@ -43,7 +40,7 @@ class TestService:
             response: DoCommandResponse = await client.DoCommand(request, timeout=4.4)
             result = struct_to_dict(response.result)
             assert result == {"command": True}
-            assert self.generic.timeout == approx(4.4)
+            assert self.generic.timeout == loose_approx(4.4)
 
 
 class TestClient:
@@ -59,4 +56,4 @@ class TestClient:
             client = GenericClient(self.name, channel)
             result = await client.do_command({"command": "args"}, timeout=7.86)
             assert result == {"command": True}
-            assert self.generic.timeout == approx(7.86)
+            assert self.generic.timeout == loose_approx(7.86)

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -13,14 +13,19 @@ from viam.utils import dict_to_struct, struct_to_dict
 from .mocks.components import MockGeneric
 
 
-class TestSensor:
+def approx(val: float):
+    return pytest.approx(val, rel=val * 1e-3)
+
+
+class TestGeneric:
 
     generic = MockGeneric(name="generic")
 
     @pytest.mark.asyncio
     async def test_do(self):
-        result = await self.generic.do_command({"command": "args"})
+        result = await self.generic.do_command({"command": "args"}, timeout=1.82)
         assert result == {"command": True}
+        assert self.generic.timeout == approx(1.82)
 
 
 class TestService:
@@ -35,9 +40,10 @@ class TestService:
         async with ChannelFor([self.service]) as channel:
             client = GenericServiceStub(channel)
             request = DoCommandRequest(name=self.name, command=dict_to_struct({"command": "args"}))
-            response: DoCommandResponse = await client.DoCommand(request)
+            response: DoCommandResponse = await client.DoCommand(request, timeout=4.4)
             result = struct_to_dict(response.result)
             assert result == {"command": True}
+            assert self.generic.timeout == approx(4.4)
 
 
 class TestClient:
@@ -51,5 +57,6 @@ class TestClient:
     async def test_do(self):
         async with ChannelFor([self.service]) as channel:
             client = GenericClient(self.name, channel)
-            result = await client.do_command({"command": "args"})
+            result = await client.do_command({"command": "args"}, timeout=7.86)
             assert result == {"command": True}
+            assert self.generic.timeout == approx(7.86)

--- a/tests/test_gripper.py
+++ b/tests/test_gripper.py
@@ -16,6 +16,7 @@ from viam.proto.component.gripper import (
 )
 from viam.utils import message_to_struct
 
+from . import loose_approx
 from .mocks.components import MockGripper
 
 
@@ -39,22 +40,25 @@ def generic_service(gripper: Gripper) -> GenericService:
 class TestGripper:
     @pytest.mark.asyncio
     async def test_open(self, gripper: MockGripper):
-        await gripper.open()
+        await gripper.open(timeout=1.82)
         assert gripper.opened is True
+        assert gripper.timeout == loose_approx(1.82)
 
     @pytest.mark.asyncio
     async def test_grab(self, gripper: MockGripper):
         grabbed = await gripper.grab()
         assert gripper.opened is False
         assert isinstance(grabbed, bool)
+        assert gripper.timeout is None
 
     @pytest.mark.asyncio
     async def test_stop(self, gripper: MockGripper):
         assert gripper.is_stopped is True
         await gripper.open()
         assert gripper.is_stopped is False
-        await gripper.stop()
+        await gripper.stop(timeout=7.86)
         assert gripper.is_stopped is True
+        assert gripper.timeout == loose_approx(7.86)
 
     @pytest.mark.asyncio
     async def test_is_moving(self, gripper: MockGripper):
@@ -82,17 +86,19 @@ class TestService:
         async with ChannelFor([service]) as channel:
             client = GripperServiceStub(channel)
             request = OpenRequest(name=gripper.name)
-            await client.Open(request)
+            await client.Open(request, timeout=1.23)
             assert gripper.opened is True
+            assert gripper.timeout == loose_approx(1.23)
 
     @pytest.mark.asyncio
     async def test_grab(self, gripper: MockGripper, service: GripperService):
         async with ChannelFor([service]) as channel:
             client = GripperServiceStub(channel)
             request = GrabRequest(name=gripper.name)
-            response: GrabResponse = await client.Grab(request)
+            response: GrabResponse = await client.Grab(request, timeout=4.56)
             assert gripper.opened is False
             assert isinstance(response.success, bool)
+            assert gripper.timeout == loose_approx(4.56)
 
     @pytest.mark.asyncio
     async def test_stop(self, gripper: MockGripper, service: GripperService):
@@ -105,8 +111,9 @@ class TestService:
             assert gripper.is_stopped is False
 
             request = StopRequest(name=gripper.name)
-            await client.Stop(request)
+            await client.Stop(request, timeout=7.89)
             assert gripper.is_stopped is True
+            assert gripper.timeout == loose_approx(7.89)
 
 
 class TestClient:
@@ -114,16 +121,18 @@ class TestClient:
     async def test_open(self, gripper: MockGripper, service: GripperService):
         async with ChannelFor([service]) as channel:
             client = GripperClient(gripper.name, channel)
-            await client.open()
+            await client.open(timeout=1.23)
             assert gripper.opened is True
+            assert gripper.timeout == loose_approx(1.23)
 
     @pytest.mark.asyncio
     async def test_grab(self, gripper: MockGripper, service: GripperService):
         async with ChannelFor([service]) as channel:
             client = GripperClient(gripper.name, channel)
-            grabbed = await client.grab()
+            grabbed = await client.grab(timeout=2.34)
             assert gripper.opened is False
             assert isinstance(grabbed, bool)
+            assert gripper.timeout == loose_approx(2.34)
 
     @pytest.mark.asyncio
     async def test_stop(self, gripper: MockGripper, service: GripperService):
@@ -133,8 +142,9 @@ class TestClient:
             assert gripper.is_stopped is True
             await client.open()
             assert gripper.is_stopped is False
-            await client.stop()
+            await client.stop(timeout=3.45)
             assert gripper.is_stopped is True
+            assert gripper.timeout == loose_approx(3.45)
 
     @pytest.mark.asyncio
     async def test_is_moving(self, gripper: MockGripper, service: GripperService):

--- a/tests/test_motor.py
+++ b/tests/test_motor.py
@@ -22,6 +22,7 @@ from viam.proto.component.motor import (
 )
 from viam.utils import dict_to_struct, message_to_struct
 
+from . import loose_approx
 from .mocks.components import MockMotor
 
 
@@ -46,17 +47,20 @@ class TestMotor:
     @pytest.mark.asyncio
     async def test_set_power(self, motor: MockMotor):
         power = 0.32
-        await motor.set_power(power)
+        await motor.set_power(power, timeout=1.23)
         assert motor.power == power
+        assert motor.timeout == loose_approx(1.23)
 
     @pytest.mark.asyncio
     async def test_get_position(self, motor: MockMotor):
-        pos = await motor.get_position()
+        pos = await motor.get_position(timeout=2.34)
         assert pos == 0
+        assert motor.timeout == loose_approx(2.34)
 
     @pytest.mark.asyncio
     async def test_go_for(self, motor: MockMotor):
-        await motor.go_for(30, 20)
+        await motor.go_for(30, 20, timeout=3.45)
+        assert motor.timeout == loose_approx(3.45)
         assert await motor.get_position() == 20
 
         await motor.go_for(-10, 10)
@@ -70,7 +74,8 @@ class TestMotor:
 
     @pytest.mark.asyncio
     async def test_go_to(self, motor: MockMotor):
-        await motor.go_to(30, 20)
+        await motor.go_to(30, 20, timeout=4.56)
+        assert motor.timeout == loose_approx(4.56)
         assert await motor.get_position() == 20
 
         await motor.go_to(-10, 50)
@@ -78,28 +83,32 @@ class TestMotor:
 
     @pytest.mark.asyncio
     async def test_reset_zero(self, motor: MockMotor):
-        await motor.reset_zero_position(20)
+        await motor.reset_zero_position(20, timeout=5.67)
         assert motor.offset == 20
+        assert motor.timeout == loose_approx(5.67)
 
     @pytest.mark.asyncio
     async def test_get_properties(self, motor: MockMotor):
-        properties = await motor.get_properties()
+        properties = await motor.get_properties(timeout=6.78)
         assert properties.position_reporting is True
+        assert motor.timeout == loose_approx(6.78)
 
     @pytest.mark.asyncio
     async def test_stop(self, motor: MockMotor):
         await motor.set_power(10)
         assert motor.powered is True
-        await motor.stop()
+        await motor.stop(timeout=7.89)
         assert motor.powered is False
         assert motor.power == 0
+        assert motor.timeout == loose_approx(7.89)
 
     @pytest.mark.asyncio
     async def test_is_powered(self, motor: MockMotor):
         await motor.set_power(10)
-        is_powered, power_pct = await motor.is_powered()
+        is_powered, power_pct = await motor.is_powered(timeout=8.90)
         assert is_powered is True
         assert power_pct == 10
+        assert motor.timeout == loose_approx(8.90)
 
         await motor.set_power(0)
         is_powered, power_pct = await motor.is_powered()
@@ -139,16 +148,18 @@ class TestService:
         async with ChannelFor([service]) as channel:
             client = MotorServiceStub(channel)
             request = SetPowerRequest(name=motor.name, power_pct=13)
-            await client.SetPower(request)
+            await client.SetPower(request, timeout=1.23)
             assert motor.power == 13
+            assert motor.timeout == loose_approx(1.23)
 
     @pytest.mark.asyncio
     async def test_get_position(self, motor: MockMotor, service: MotorService):
         async with ChannelFor([service]) as channel:
             client = MotorServiceStub(channel)
             request = GetPositionRequest(name=motor.name)
-            response: GetPositionResponse = await client.GetPosition(request)
+            response: GetPositionResponse = await client.GetPosition(request, timeout=2.34)
             assert response.position == 0
+            assert motor.timeout == loose_approx(2.34)
 
     @pytest.mark.asyncio
     async def test_go_for(self, motor: MockMotor, service: MotorService):
@@ -156,8 +167,9 @@ class TestService:
             client = MotorServiceStub(channel)
 
             request = GoForRequest(name=motor.name, rpm=30, revolutions=20)
-            await client.GoFor(request)
+            await client.GoFor(request, timeout=3.45)
             assert motor.position == 20
+            assert motor.timeout == loose_approx(3.45)
 
             request = GoForRequest(name=motor.name, rpm=-10, revolutions=10)
             await client.GoFor(request)
@@ -177,8 +189,9 @@ class TestService:
             client = MotorServiceStub(channel)
 
             request = GoToRequest(name=motor.name, rpm=30, position_revolutions=20)
-            await client.GoTo(request)
+            await client.GoTo(request, timeout=4.56)
             assert motor.position == 20
+            assert motor.timeout == loose_approx(4.56)
 
             request = GoToRequest(name=motor.name, rpm=-10, position_revolutions=50)
             await client.GoTo(request)
@@ -189,25 +202,28 @@ class TestService:
         async with ChannelFor([service]) as channel:
             client = MotorServiceStub(channel)
             request = ResetZeroPositionRequest(name=motor.name, offset=20)
-            await client.ResetZeroPosition(request)
+            await client.ResetZeroPosition(request, timeout=5.67)
             assert motor.offset == 20
+            assert motor.timeout == loose_approx(5.67)
 
     @pytest.mark.asyncio
     async def test_get_properties(self, motor: MockMotor, service: MotorService):
         async with ChannelFor([service]) as channel:
             client = MotorServiceStub(channel)
             request = GetPropertiesRequest(name=motor.name)
-            response: GetPropertiesResponse = await client.GetProperties(request)
+            response: GetPropertiesResponse = await client.GetProperties(request, timeout=6.78)
             assert response.position_reporting is True
+            assert motor.timeout == loose_approx(6.78)
 
     @pytest.mark.asyncio
     async def test_stop(self, motor: MockMotor, service: MotorService):
         async with ChannelFor([service]) as channel:
             client = MotorServiceStub(channel)
             request = StopRequest(name=motor.name)
-            await client.Stop(request)
+            await client.Stop(request, timeout=7.89)
             assert motor.powered is False
             assert motor.power == 0
+            assert motor.timeout == loose_approx(7.89)
 
     @pytest.mark.asyncio
     async def test_is_powered(self, motor: MockMotor, service: MotorService):
@@ -217,9 +233,10 @@ class TestService:
             sp_request = SetPowerRequest(name=motor.name, power_pct=13)
             await client.SetPower(sp_request)
             request = IsPoweredRequest(name=motor.name)
-            response: IsPoweredResponse = await client.IsPowered(request)
+            response: IsPoweredResponse = await client.IsPowered(request, timeout=8.90)
             assert response.is_on is True
             assert response.power_pct == 13
+            assert motor.timeout == loose_approx(8.90)
 
             sp_request = SetPowerRequest(name=motor.name, power_pct=0)
             await client.SetPower(sp_request)
@@ -245,23 +262,26 @@ class TestClient:
     async def test_set_power(self, motor: MockMotor, service: MotorService):
         async with ChannelFor([service]) as channel:
             client = MotorClient(motor.name, channel)
-            await client.set_power(13)
+            await client.set_power(13, timeout=1.23)
             assert motor.power == 13
+            assert motor.timeout == loose_approx(1.23)
 
     @pytest.mark.asyncio
     async def test_get_position(self, motor: MockMotor, service: MotorService):
         async with ChannelFor([service]) as channel:
             client = MotorClient(motor.name, channel)
-            position = await client.get_position()
+            position = await client.get_position(timeout=2.34)
             assert position == 0
+            assert motor.timeout == loose_approx(2.34)
 
     @pytest.mark.asyncio
     async def test_go_for(self, motor: MockMotor, service: MotorService):
         async with ChannelFor([service]) as channel:
             client = MotorClient(motor.name, channel)
 
-            await client.go_for(30, 20)
+            await client.go_for(30, 20, timeout=3.45)
             assert motor.position == 20
+            assert motor.timeout == loose_approx(3.45)
 
             await client.go_for(-10, 10)
             assert motor.position == 10
@@ -277,8 +297,9 @@ class TestClient:
         async with ChannelFor([service]) as channel:
             client = MotorClient(motor.name, channel)
 
-            await client.go_to(30, 20)
+            await client.go_to(30, 20, timeout=4.56)
             assert motor.position == 20
+            assert motor.timeout == loose_approx(4.56)
 
             await client.go_to(-10, 50)
             assert motor.position == 50
@@ -287,23 +308,26 @@ class TestClient:
     async def test_reset_zero(self, motor: MockMotor, service: MotorService):
         async with ChannelFor([service]) as channel:
             client = MotorClient(motor.name, channel)
-            await client.reset_zero_position(20)
+            await client.reset_zero_position(20, timeout=5.67)
+            assert motor.timeout == loose_approx(5.67)
             assert motor.offset == 20
 
     @pytest.mark.asyncio
     async def test_get_properties(self, motor: MockMotor, service: MotorService):
         async with ChannelFor([service]) as channel:
             client = MotorClient(motor.name, channel)
-            properties = await client.get_properties()
+            properties = await client.get_properties(timeout=6.78)
             assert properties.position_reporting is True
+            assert motor.timeout == loose_approx(6.78)
 
     @pytest.mark.asyncio
     async def test_stop(self, motor: MockMotor, service: MotorService):
         async with ChannelFor([service]) as channel:
             client = MotorClient(motor.name, channel)
-            await client.stop()
+            await client.stop(timeout=7.89)
             assert motor.powered is False
             assert motor.power == 0
+            assert motor.timeout == loose_approx(7.89)
 
     @pytest.mark.asyncio
     async def test_is_powered(self, motor: MockMotor, service: MotorService):
@@ -311,9 +335,10 @@ class TestClient:
             client = MotorClient(motor.name, channel)
 
             await client.set_power(13)
-            is_on, power_pct = await client.is_powered()
+            is_on, power_pct = await client.is_powered(timeout=8.90)
             assert is_on is True
             assert power_pct == 13
+            assert motor.timeout == loose_approx(8.90)
 
             await client.set_power(0)
             is_on, power_pct = await client.is_powered()

--- a/tests/test_movement_sensor.py
+++ b/tests/test_movement_sensor.py
@@ -27,6 +27,7 @@ from viam.proto.component.movementsensor import (
     MovementSensorServiceStub,
 )
 
+from . import loose_approx
 from .mocks.components import MockMovementSensor
 
 COORDINATE = GeoPoint(latitude=40.664679865782624, longitude=-73.97668056188789)
@@ -114,6 +115,34 @@ class TestMovementSensor:
         }
 
     @pytest.mark.asyncio
+    async def test_timeout(self, movement_sensor: MockMovementSensor):
+        assert movement_sensor.timeout is None
+
+        await movement_sensor.get_position(timeout=1.23)
+        assert movement_sensor.timeout == loose_approx(1.23)
+
+        await movement_sensor.get_linear_velocity(timeout=2.34)
+        assert movement_sensor.timeout == loose_approx(2.34)
+
+        await movement_sensor.get_angular_velocity(timeout=3.45)
+        assert movement_sensor.timeout == loose_approx(3.45)
+
+        await movement_sensor.get_compass_heading(timeout=4.56)
+        assert movement_sensor.timeout == loose_approx(4.56)
+
+        await movement_sensor.get_orientation(timeout=5.67)
+        assert movement_sensor.timeout == loose_approx(5.67)
+
+        await movement_sensor.get_properties(timeout=6.78)
+        assert movement_sensor.timeout == loose_approx(6.78)
+
+        await movement_sensor.get_accuracy(timeout=7.89)
+        assert movement_sensor.timeout == loose_approx(7.89)
+
+        await movement_sensor.get_readings(timeout=8.90)
+        assert movement_sensor.timeout == loose_approx(8.90)
+
+    @pytest.mark.asyncio
     async def test_do(self, movement_sensor: MovementSensor):
         with pytest.raises(NotImplementedError):
             await movement_sensor.do_command({"command": "args"})
@@ -121,119 +150,133 @@ class TestMovementSensor:
 
 class TestService:
     @pytest.mark.asyncio
-    async def test_get_position(self, movement_sensor: MovementSensor, service: MovementSensorService):
+    async def test_get_position(self, movement_sensor: MockMovementSensor, service: MovementSensorService):
         async with ChannelFor([service]) as channel:
             client = MovementSensorServiceStub(channel)
             request = GetPositionRequest(name=movement_sensor.name)
-            response: GetPositionResponse = await client.GetPosition(request)
+            response: GetPositionResponse = await client.GetPosition(request, timeout=1.23)
             assert response.coordinate == COORDINATE
             assert response.altitude_mm == ALTITUDE
+            assert movement_sensor.timeout == loose_approx(1.23)
 
     @pytest.mark.asyncio
-    async def test_get_linear_velocity(self, movement_sensor: MovementSensor, service: MovementSensorService):
+    async def test_get_linear_velocity(self, movement_sensor: MockMovementSensor, service: MovementSensorService):
         async with ChannelFor([service]) as channel:
             client = MovementSensorServiceStub(channel)
             request = GetLinearVelocityRequest(name=movement_sensor.name)
-            response: GetLinearVelocityResponse = await client.GetLinearVelocity(request)
+            response: GetLinearVelocityResponse = await client.GetLinearVelocity(request, timeout=2.34)
             assert response.linear_velocity == LINEAR_VELOCITY
+            assert movement_sensor.timeout == loose_approx(2.34)
 
     @pytest.mark.asyncio
-    async def test_get_angular_velocity(self, movement_sensor: MovementSensor, service: MovementSensorService):
+    async def test_get_angular_velocity(self, movement_sensor: MockMovementSensor, service: MovementSensorService):
         async with ChannelFor([service]) as channel:
             client = MovementSensorServiceStub(channel)
             request = GetAngularVelocityRequest(name=movement_sensor.name)
-            response: GetAngularVelocityResponse = await client.GetAngularVelocity(request)
+            response: GetAngularVelocityResponse = await client.GetAngularVelocity(request, timeout=3.45)
             assert response.angular_velocity == ANGULAR_VELOCITY
+            assert movement_sensor.timeout == loose_approx(3.45)
 
     @pytest.mark.asyncio
-    async def test_get_compass_heading(self, movement_sensor: MovementSensor, service: MovementSensorService):
+    async def test_get_compass_heading(self, movement_sensor: MockMovementSensor, service: MovementSensorService):
         async with ChannelFor([service]) as channel:
             client = MovementSensorServiceStub(channel)
             request = GetCompassHeadingRequest(name=movement_sensor.name)
-            response: GetCompassHeadingResponse = await client.GetCompassHeading(request)
+            response: GetCompassHeadingResponse = await client.GetCompassHeading(request, timeout=4.56)
             assert response.value == HEADING
+            assert movement_sensor.timeout == loose_approx(4.56)
 
     @pytest.mark.asyncio
-    async def test_get_orientation(self, movement_sensor: MovementSensor, service: MovementSensorService):
+    async def test_get_orientation(self, movement_sensor: MockMovementSensor, service: MovementSensorService):
         async with ChannelFor([service]) as channel:
             client = MovementSensorServiceStub(channel)
             request = GetOrientationRequest(name=movement_sensor.name)
-            response: GetOrientationResponse = await client.GetOrientation(request)
+            response: GetOrientationResponse = await client.GetOrientation(request, timeout=5.67)
             assert response.orientation == ORIENTATION
+            assert movement_sensor.timeout == loose_approx(5.67)
 
     @pytest.mark.asyncio
-    async def test_get_properties(self, movement_sensor: MovementSensor, service: MovementSensorService):
+    async def test_get_properties(self, movement_sensor: MockMovementSensor, service: MovementSensorService):
         async with ChannelFor([service]) as channel:
             client = MovementSensorServiceStub(channel)
             request = GetPropertiesRequest(name=movement_sensor.name)
-            response: GetPropertiesResponse = await client.GetProperties(request)
+            response: GetPropertiesResponse = await client.GetProperties(request, timeout=6.78)
             assert response == PROPERTIES
+            assert movement_sensor.timeout == loose_approx(6.78)
 
     @pytest.mark.asyncio
-    async def test_get_accuracy(self, movement_sensor: MovementSensor, service: MovementSensorService):
+    async def test_get_accuracy(self, movement_sensor: MockMovementSensor, service: MovementSensorService):
         async with ChannelFor([service]) as channel:
             client = MovementSensorServiceStub(channel)
             request = GetAccuracyRequest(name=movement_sensor.name)
-            response: GetAccuracyResponse = await client.GetAccuracy(request)
+            response: GetAccuracyResponse = await client.GetAccuracy(request, timeout=7.89)
             assert response.accuracy_mm == pytest.approx(ACCURACY)
+            assert movement_sensor.timeout == loose_approx(7.89)
 
 
 class TestClient:
     @pytest.mark.asyncio
-    async def test_get_position(self, movement_sensor: MovementSensor, service: MovementSensorService):
+    async def test_get_position(self, movement_sensor: MockMovementSensor, service: MovementSensorService):
         async with ChannelFor([service]) as channel:
             client = MovementSensorClient(movement_sensor.name, channel)
-            (coord, alt) = await client.get_position()
+            (coord, alt) = await client.get_position(timeout=1.23)
             assert coord == COORDINATE
             assert alt == ALTITUDE
+            assert movement_sensor.timeout == loose_approx(1.23)
 
     @pytest.mark.asyncio
-    async def test_get_linear_velocity(self, movement_sensor: MovementSensor, service: MovementSensorService):
+    async def test_get_linear_velocity(self, movement_sensor: MockMovementSensor, service: MovementSensorService):
         async with ChannelFor([service]) as channel:
             client = MovementSensorClient(movement_sensor.name, channel)
-            value = await client.get_linear_velocity()
+            value = await client.get_linear_velocity(timeout=2.34)
             assert value == LINEAR_VELOCITY
+            assert movement_sensor.timeout == loose_approx(2.34)
 
     @pytest.mark.asyncio
-    async def test_get_angular_velocity(self, movement_sensor: MovementSensor, service: MovementSensorService):
+    async def test_get_angular_velocity(self, movement_sensor: MockMovementSensor, service: MovementSensorService):
         async with ChannelFor([service]) as channel:
             client = MovementSensorClient(movement_sensor.name, channel)
-            value = await client.get_angular_velocity()
+            value = await client.get_angular_velocity(timeout=3.45)
             assert value == ANGULAR_VELOCITY
+            assert movement_sensor.timeout == loose_approx(3.45)
 
     @pytest.mark.asyncio
-    async def test_get_compass_heading(self, movement_sensor: MovementSensor, service: MovementSensorService):
+    async def test_get_compass_heading(self, movement_sensor: MockMovementSensor, service: MovementSensorService):
         async with ChannelFor([service]) as channel:
             client = MovementSensorClient(movement_sensor.name, channel)
-            value = await client.get_compass_heading()
+            value = await client.get_compass_heading(timeout=4.56)
             assert value == HEADING
+            assert movement_sensor.timeout == loose_approx(4.56)
 
     @pytest.mark.asyncio
-    async def test_get_orientation(self, movement_sensor: MovementSensor, service: MovementSensorService):
+    async def test_get_orientation(self, movement_sensor: MockMovementSensor, service: MovementSensorService):
         async with ChannelFor([service]) as channel:
             client = MovementSensorClient(movement_sensor.name, channel)
-            value = await client.get_orientation()
+            value = await client.get_orientation(timeout=5.67)
             assert value == ORIENTATION
+            assert movement_sensor.timeout == loose_approx(5.67)
 
     @pytest.mark.asyncio
-    async def test_get_properties(self, movement_sensor: MovementSensor, service: MovementSensorService):
+    async def test_get_properties(self, movement_sensor: MockMovementSensor, service: MovementSensorService):
         async with ChannelFor([service]) as channel:
             client = MovementSensorClient(movement_sensor.name, channel)
-            value = await client.get_properties()
+            value = await client.get_properties(timeout=6.78)
             assert value == PROPERTIES
+            assert movement_sensor.timeout == loose_approx(6.78)
 
     @pytest.mark.asyncio
-    async def test_get_accuracy(self, movement_sensor: MovementSensor, service: MovementSensorService):
+    async def test_get_accuracy(self, movement_sensor: MockMovementSensor, service: MovementSensorService):
         async with ChannelFor([service]) as channel:
             client = MovementSensorClient(movement_sensor.name, channel)
-            value = await client.get_accuracy()
+            value = await client.get_accuracy(timeout=7.89)
             assert value == pytest.approx(ACCURACY)
+            assert movement_sensor.timeout == loose_approx(7.89)
 
     @pytest.mark.asyncio
-    async def test_get_readings(self, movement_sensor: MovementSensor, service: MovementSensorService):
+    async def test_get_readings(self, movement_sensor: MockMovementSensor, service: MovementSensorService):
         async with ChannelFor([service]) as channel:
             client = MovementSensorClient(movement_sensor.name, channel)
-            value = await client.get_readings()
+            value = await client.get_readings(timeout=8.90)
             assert value == {
                 "position": COORDINATE,
                 "altitude": ALTITUDE,
@@ -242,6 +285,7 @@ class TestClient:
                 "compass": HEADING,
                 "orientation": ORIENTATION,
             }
+            assert movement_sensor.timeout == loose_approx(8.90)
 
     @pytest.mark.asyncio
     async def test_do(self, movement_sensor: MovementSensor, service: MovementSensorService, generic_service: GenericService):

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -52,3 +52,8 @@ async def test_wrapper():
         result = await task
 
     assert test_obj.long_running_task_cancelled is True
+
+    # Test timed out
+    test_obj.long_running_task_cancelled = False
+    assert test_obj.long_running_task_cancelled is False
+    assert await asyncio.create_task(test_obj.long_running(timeout=0.02)) is True

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -12,6 +12,7 @@ from viam.proto.component.sensor import (
 )
 from viam.utils import primitive_to_value
 
+from . import loose_approx
 from .mocks.components import MockSensor
 
 
@@ -21,8 +22,9 @@ class TestSensor:
 
     @pytest.mark.asyncio
     async def test_get_readings(self):
-        readings = await self.sensor.get_readings()
+        readings = await self.sensor.get_readings(timeout=1.23)
         assert readings == {"a": 1, "b": 2, "c": 3}
+        assert self.sensor.timeout == loose_approx(1.23)
 
     @pytest.mark.asyncio
     async def test_do(self):
@@ -43,8 +45,9 @@ class TestService:
         async with ChannelFor([self.service]) as channel:
             client = SensorServiceStub(channel)
             request = GetReadingsRequest(name=self.name)
-            result: GetReadingsResponse = await client.GetReadings(request)
+            result: GetReadingsResponse = await client.GetReadings(request, timeout=2.34)
             assert result.readings == {key: primitive_to_value(value) for (key, value) in self.readings.items()}
+            assert self.sensor.timeout == loose_approx(2.34)
 
 
 class TestClient:
@@ -59,8 +62,9 @@ class TestClient:
     async def test_get_readings(self):
         async with ChannelFor([self.service]) as channel:
             client = SensorClient(self.name, channel)
-            value_readings = await client.get_readings()
+            value_readings = await client.get_readings(timeout=3.45)
             assert self.readings == value_readings
+            assert self.sensor.timeout == loose_approx(3.45)
 
     @pytest.mark.asyncio
     async def test_do(self):

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -15,6 +15,7 @@ from viam.proto.component.servo import (
 )
 from viam.utils import message_to_struct
 
+from . import loose_approx
 from .mocks.components import MockServo
 
 
@@ -25,19 +26,22 @@ class TestServo:
 
     @pytest.mark.asyncio
     async def test_move(self):
-        await self.servo.move(self.pos)
+        await self.servo.move(self.pos, timeout=1.23)
         assert self.servo.angle == self.pos
+        assert self.servo.timeout == loose_approx(1.23)
 
     @pytest.mark.asyncio
     async def test_get_position(self):
-        new_pos = await self.servo.get_position()
+        new_pos = await self.servo.get_position(timeout=2.34)
         assert new_pos == self.pos
+        assert self.servo.timeout == loose_approx(2.34)
 
     @pytest.mark.asyncio
     async def test_stop(self):
         assert self.servo.is_stopped is False
-        await self.servo.stop()
+        await self.servo.stop(timeout=3.45)
         assert self.servo.is_stopped is True
+        assert self.servo.timeout == loose_approx(3.45)
 
     @pytest.mark.asyncio
     async def test_is_moving(self):
@@ -72,16 +76,18 @@ class TestService:
         async with ChannelFor([self.service]) as channel:
             client = ServoServiceStub(channel)
             request = MoveRequest(name=self.name, angle_deg=self.pos)
-            await client.Move(request)
+            await client.Move(request, timeout=1.23)
             assert self.servo.angle == self.pos
+            assert self.servo.timeout == loose_approx(1.23)
 
     @pytest.mark.asyncio
     async def test_get_position(self):
         async with ChannelFor([self.service]) as channel:
             client = ServoServiceStub(channel)
             request = GetPositionRequest(name=self.name)
-            response: GetPositionResponse = await client.GetPosition(request)
+            response: GetPositionResponse = await client.GetPosition(request, timeout=2.34)
             assert response.position_deg == self.pos
+            assert self.servo.timeout == loose_approx(2.34)
 
     @pytest.mark.asyncio
     async def test_stop(self):
@@ -89,8 +95,9 @@ class TestService:
             assert self.servo.is_stopped is False
             client = ServoServiceStub(channel)
             request = StopRequest(name=self.name)
-            await client.Stop(request)
+            await client.Stop(request, timeout=3.45)
             assert self.servo.is_stopped is True
+            assert self.servo.timeout == loose_approx(3.45)
 
 
 class TestClient:
@@ -105,23 +112,26 @@ class TestClient:
     async def test_move(self):
         async with ChannelFor([self.service]) as channel:
             client = ServoClient(self.servo.name, channel)
-            await client.move(self.pos)
+            await client.move(self.pos, timeout=1.23)
             assert self.servo.angle == self.pos
+            assert self.servo.timeout == loose_approx(1.23)
 
     @pytest.mark.asyncio
     async def test_get_position(self):
         async with ChannelFor([self.service]) as channel:
             client = ServoClient(self.servo.name, channel)
-            new_pos = await client.get_position()
+            new_pos = await client.get_position(timeout=2.34)
             assert new_pos == self.pos
+            assert self.servo.timeout == loose_approx(2.34)
 
     @pytest.mark.asyncio
     async def test_stop(self):
         async with ChannelFor([self.service]) as channel:
             assert self.servo.is_stopped is False
             client = ServoClient(self.name, channel)
-            await client.stop()
+            await client.stop(timeout=3.45)
             assert self.servo.is_stopped is True
+            assert self.servo.timeout == loose_approx(3.45)
 
     @pytest.mark.asyncio
     async def test_is_moving(self):


### PR DESCRIPTION
Add timeouts to components and their clients. The `timeout` parameter is one that always has to be named. 

Also changed in this PR is that any `extra` parameters are now also required to be explicitly named. 