### PR TITLE
RSDK-594 Pass metadata into all service methods

### DIFF
--- a/src/viam/components/audio_input/service.py
+++ b/src/viam/components/audio_input/service.py
@@ -37,7 +37,7 @@ class AudioInputService(AudioInputServiceBase, ComponentServiceBase[AudioInput])
             raise e.grpc_error
 
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        audio_stream = await audio_input.stream(timeout=timeout)
+        audio_stream = await audio_input.stream(timeout=timeout, metadata=stream.metadata)
         first_chunk = await audio_stream.__anext__()
         await stream.send_message(ChunksResponse(info=first_chunk.info))
         await stream.send_message(ChunksResponse(chunk=first_chunk.chunk))
@@ -53,7 +53,7 @@ class AudioInputService(AudioInputServiceBase, ComponentServiceBase[AudioInput])
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        response = (await audio_input.get_properties(timeout=timeout)).proto
+        response = (await audio_input.get_properties(timeout=timeout, metadata=stream.metadata)).proto
         await stream.send_message(response)
 
     async def Record(self, stream: Stream[RecordRequest, HttpBody]) -> None:

--- a/src/viam/components/base/service.py
+++ b/src/viam/components/base/service.py
@@ -40,6 +40,7 @@ class BaseService(BaseServiceBase, ComponentServiceBase[Base]):
             velocity=request.mm_per_sec,
             extra=struct_to_dict(request.extra),
             timeout=timeout,
+            metadata=stream.metadata,
         )
         response = MoveStraightResponse()
         await stream.send_message(response)
@@ -53,7 +54,13 @@ class BaseService(BaseServiceBase, ComponentServiceBase[Base]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await base.spin(angle=request.angle_deg, velocity=request.degs_per_sec, extra=struct_to_dict(request.extra), timeout=timeout)
+        await base.spin(
+            angle=request.angle_deg,
+            velocity=request.degs_per_sec,
+            extra=struct_to_dict(request.extra),
+            timeout=timeout,
+            metadata=stream.metadata,
+        )
         response = SpinResponse()
         await stream.send_message(response)
 
@@ -66,7 +73,9 @@ class BaseService(BaseServiceBase, ComponentServiceBase[Base]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await base.set_power(request.linear, request.angular, extra=struct_to_dict(request.extra), timeout=timeout)
+        await base.set_power(
+            request.linear, request.angular, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata
+        )
         response = SetPowerResponse()
         await stream.send_message(response)
 
@@ -79,7 +88,9 @@ class BaseService(BaseServiceBase, ComponentServiceBase[Base]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await base.set_velocity(request.linear, request.angular, extra=struct_to_dict(request.extra), timeout=timeout)
+        await base.set_velocity(
+            request.linear, request.angular, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata
+        )
         await stream.send_message(SetVelocityResponse())
 
     async def Stop(self, stream: Stream[StopRequest, StopResponse]) -> None:
@@ -91,6 +102,6 @@ class BaseService(BaseServiceBase, ComponentServiceBase[Base]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await base.stop(extra=struct_to_dict(request.extra), timeout=timeout)
+        await base.stop(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = StopResponse()
         await stream.send_message(response)

--- a/src/viam/components/board/service.py
+++ b/src/viam/components/board/service.py
@@ -43,7 +43,7 @@ class BoardService(BoardServiceBase, ComponentServiceBase[Board]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        status = await board.status(extra=struct_to_dict(request.extra), timeout=timeout)
+        status = await board.status(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = StatusResponse(status=status)
         await stream.send_message(response)
 
@@ -57,7 +57,7 @@ class BoardService(BoardServiceBase, ComponentServiceBase[Board]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await pin.set(request.high, extra=struct_to_dict(request.extra), timeout=timeout)
+        await pin.set(request.high, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = SetGPIOResponse()
         await stream.send_message(response)
 
@@ -71,7 +71,7 @@ class BoardService(BoardServiceBase, ComponentServiceBase[Board]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        high = await pin.get(extra=struct_to_dict(request.extra), timeout=timeout)
+        high = await pin.get(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetGPIOResponse(high=high)
         await stream.send_message(response)
 
@@ -85,7 +85,7 @@ class BoardService(BoardServiceBase, ComponentServiceBase[Board]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        pwm = await pin.get_pwm(extra=struct_to_dict(request.extra), timeout=timeout)
+        pwm = await pin.get_pwm(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = PWMResponse(duty_cycle_pct=pwm)
         await stream.send_message(response)
 
@@ -99,7 +99,7 @@ class BoardService(BoardServiceBase, ComponentServiceBase[Board]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await pin.set_pwm(request.duty_cycle_pct, extra=struct_to_dict(request.extra), timeout=timeout)
+        await pin.set_pwm(request.duty_cycle_pct, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = SetPWMResponse()
         await stream.send_message(response)
 
@@ -113,7 +113,7 @@ class BoardService(BoardServiceBase, ComponentServiceBase[Board]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        frequency = await pin.get_pwm_frequency(extra=struct_to_dict(request.extra), timeout=timeout)
+        frequency = await pin.get_pwm_frequency(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = PWMFrequencyResponse(frequency_hz=frequency)
         await stream.send_message(response)
 
@@ -127,7 +127,7 @@ class BoardService(BoardServiceBase, ComponentServiceBase[Board]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await pin.set_pwm_frequency(request.frequency_hz, extra=struct_to_dict(request.extra), timeout=timeout)
+        await pin.set_pwm_frequency(request.frequency_hz, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = SetPWMFrequencyResponse()
         await stream.send_message(response)
 
@@ -141,7 +141,7 @@ class BoardService(BoardServiceBase, ComponentServiceBase[Board]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        value = await analog_reader.read(extra=struct_to_dict(request.extra), timeout=timeout)
+        value = await analog_reader.read(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = ReadAnalogReaderResponse(value=value)
         await stream.send_message(response)
 
@@ -155,6 +155,6 @@ class BoardService(BoardServiceBase, ComponentServiceBase[Board]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        value = await interrupt.value(extra=struct_to_dict(request.extra), timeout=timeout)
+        value = await interrupt.value(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetDigitalInterruptValueResponse(value=value)
         await stream.send_message(response)

--- a/src/viam/components/camera/service.py
+++ b/src/viam/components/camera/service.py
@@ -35,7 +35,7 @@ class CameraService(CameraServiceBase, ComponentServiceBase[Camera]):
             raise e.grpc_error
 
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        image = await camera.get_image(request.mime_type, timeout=timeout)
+        image = await camera.get_image(request.mime_type, timeout=timeout, metadata=stream.metadata)
         try:
             mimetype, is_lazy = CameraMimeType.from_lazy(request.mime_type)
             if CameraMimeType.is_supported(mimetype):
@@ -62,7 +62,7 @@ class CameraService(CameraServiceBase, ComponentServiceBase[Camera]):
         except ValueError:
             mimetype = CameraMimeType.JPEG
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        image = await camera.get_image(mimetype, timeout=timeout)
+        image = await camera.get_image(mimetype, timeout=timeout, metadata=stream.metadata)
         try:
             img = mimetype.encode_image(image)
         finally:
@@ -79,7 +79,7 @@ class CameraService(CameraServiceBase, ComponentServiceBase[Camera]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        pc, mimetype = await camera.get_point_cloud(timeout=timeout)
+        pc, mimetype = await camera.get_point_cloud(timeout=timeout, metadata=stream.metadata)
         response = GetPointCloudResponse(mime_type=mimetype, point_cloud=pc)
         await stream.send_message(response)
 
@@ -92,7 +92,7 @@ class CameraService(CameraServiceBase, ComponentServiceBase[Camera]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        properties = await camera.get_properties(timeout=timeout)
+        properties = await camera.get_properties(timeout=timeout, metadata=stream.metadata)
         response = GetPropertiesResponse(
             supports_pcd=properties.supports_pcd,
             intrinsic_parameters=properties.intrinsic_parameters,

--- a/src/viam/components/gantry/service.py
+++ b/src/viam/components/gantry/service.py
@@ -34,7 +34,7 @@ class GantryService(GantryServiceBase, ComponentServiceBase[Gantry]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        position = await gantry.get_position(extra=struct_to_dict(request.extra), timeout=timeout)
+        position = await gantry.get_position(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetPositionResponse(positions_mm=position)
         await stream.send_message(response)
 
@@ -47,7 +47,9 @@ class GantryService(GantryServiceBase, ComponentServiceBase[Gantry]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await gantry.move_to_position(list(request.positions_mm), request.world_state, extra=struct_to_dict(request.extra), timeout=timeout)
+        await gantry.move_to_position(
+            list(request.positions_mm), request.world_state, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata
+        )
         response = MoveToPositionResponse()
         await stream.send_message(response)
 
@@ -60,7 +62,7 @@ class GantryService(GantryServiceBase, ComponentServiceBase[Gantry]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        lengths = await gantry.get_lengths(extra=struct_to_dict(request.extra), timeout=timeout)
+        lengths = await gantry.get_lengths(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetLengthsResponse(lengths_mm=lengths)
         await stream.send_message(response)
 
@@ -73,6 +75,6 @@ class GantryService(GantryServiceBase, ComponentServiceBase[Gantry]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await gantry.stop(extra=struct_to_dict(request.extra), timeout=timeout)
+        await gantry.stop(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = StopResponse()
         await stream.send_message(response)

--- a/src/viam/components/generic/service.py
+++ b/src/viam/components/generic/service.py
@@ -31,7 +31,7 @@ class GenericService(GenericServiceBase, ComponentServiceBase[ComponentBase]):
             raise e.grpc_error
         try:
             timeout = stream.deadline.time_remaining() if stream.deadline else None
-            result = await component.do_command(struct_to_dict(request.command), timeout=timeout)
+            result = await component.do_command(struct_to_dict(request.command), timeout=timeout, metadata=stream.metadata)
         except NotImplementedError:
             raise GRPCError(Status.UNIMPLEMENTED, f"``DO`` command is unimplemented for component named: {name}")
         response = DoCommandResponse(result=dict_to_struct(result))

--- a/src/viam/components/gripper/service.py
+++ b/src/viam/components/gripper/service.py
@@ -32,7 +32,7 @@ class GripperService(GripperServiceBase, ComponentServiceBase[Gripper]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await gripper.open(extra=struct_to_dict(request.extra), timeout=timeout)
+        await gripper.open(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = OpenResponse()
         await stream.send_message(response)
 
@@ -45,7 +45,7 @@ class GripperService(GripperServiceBase, ComponentServiceBase[Gripper]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        grabbed = await gripper.grab(extra=struct_to_dict(request.extra), timeout=timeout)
+        grabbed = await gripper.grab(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GrabResponse(success=grabbed)
         await stream.send_message(response)
 
@@ -57,5 +57,5 @@ class GripperService(GripperServiceBase, ComponentServiceBase[Gripper]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await gripper.stop(extra=struct_to_dict(request.extra), timeout=timeout)
+        await gripper.stop(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         await stream.send_message(StopResponse())

--- a/src/viam/components/input/service.py
+++ b/src/viam/components/input/service.py
@@ -42,7 +42,7 @@ class InputControllerService(InputControllerServiceBase, ComponentServiceBase[Co
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        controls = await controller.get_controls(extra=struct_to_dict(request.extra), timeout=timeout)
+        controls = await controller.get_controls(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetControlsResponse(controls=[c.value for c in controls])
         await stream.send_message(response)
 
@@ -55,7 +55,7 @@ class InputControllerService(InputControllerServiceBase, ComponentServiceBase[Co
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        events = await controller.get_events(extra=struct_to_dict(request.extra), timeout=timeout)
+        events = await controller.get_events(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         pb_events = [e.proto for e in events.values()]
         response = GetEventsResponse(events=pb_events)
         await stream.send_message(response)
@@ -157,7 +157,7 @@ class InputControllerService(InputControllerServiceBase, ComponentServiceBase[Co
             controller = self.get_component(name)
             pb_event = request.event
             event = Event.from_proto(pb_event)
-            await controller.trigger_event(event, extra=struct_to_dict(request.extra), timeout=timeout)
+            await controller.trigger_event(event, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         except ComponentNotFoundError as e:
             raise e.grpc_error
         except NotSupportedError as e:

--- a/src/viam/components/motor/service.py
+++ b/src/viam/components/motor/service.py
@@ -41,7 +41,7 @@ class MotorService(MotorServiceBase, ComponentServiceBase[Motor]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await motor.set_power(request.power_pct, extra=struct_to_dict(request.extra), timeout=timeout)
+        await motor.set_power(request.power_pct, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         await stream.send_message(SetPowerResponse())
 
     async def GoFor(self, stream: Stream[GoForRequest, GoForResponse]) -> None:
@@ -53,7 +53,7 @@ class MotorService(MotorServiceBase, ComponentServiceBase[Motor]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await motor.go_for(request.rpm, request.revolutions, extra=struct_to_dict(request.extra), timeout=timeout)
+        await motor.go_for(request.rpm, request.revolutions, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         await stream.send_message(GoForResponse())
 
     async def GoTo(self, stream: Stream[GoToRequest, GoToResponse]) -> None:
@@ -65,7 +65,9 @@ class MotorService(MotorServiceBase, ComponentServiceBase[Motor]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await motor.go_to(request.rpm, request.position_revolutions, extra=struct_to_dict(request.extra), timeout=timeout)
+        await motor.go_to(
+            request.rpm, request.position_revolutions, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata
+        )
         await stream.send_message(GoToResponse())
 
     async def ResetZeroPosition(self, stream: Stream[ResetZeroPositionRequest, ResetZeroPositionResponse]) -> None:
@@ -77,7 +79,7 @@ class MotorService(MotorServiceBase, ComponentServiceBase[Motor]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await motor.reset_zero_position(request.offset, extra=struct_to_dict(request.extra), timeout=timeout)
+        await motor.reset_zero_position(request.offset, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         await stream.send_message(ResetZeroPositionResponse())
 
     async def GetPosition(self, stream: Stream[GetPositionRequest, GetPositionResponse]) -> None:
@@ -89,7 +91,7 @@ class MotorService(MotorServiceBase, ComponentServiceBase[Motor]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        position = await motor.get_position(extra=struct_to_dict(request.extra), timeout=timeout)
+        position = await motor.get_position(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         await stream.send_message(GetPositionResponse(position=position))
 
     async def GetProperties(self, stream: Stream[GetPropertiesRequest, GetPropertiesResponse]) -> None:
@@ -101,7 +103,7 @@ class MotorService(MotorServiceBase, ComponentServiceBase[Motor]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        properties = await motor.get_properties(extra=struct_to_dict(request.extra), timeout=timeout)
+        properties = await motor.get_properties(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetPropertiesResponse(**properties.__dict__)
         await stream.send_message(response)
 
@@ -114,7 +116,7 @@ class MotorService(MotorServiceBase, ComponentServiceBase[Motor]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await motor.stop(extra=struct_to_dict(request.extra), timeout=timeout)
+        await motor.stop(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = StopResponse()
         await stream.send_message(response)
 
@@ -127,5 +129,5 @@ class MotorService(MotorServiceBase, ComponentServiceBase[Motor]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        is_powered, power_pct = await motor.is_powered(extra=struct_to_dict(request.extra), timeout=timeout)
+        is_powered, power_pct = await motor.is_powered(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         await stream.send_message(IsPoweredResponse(is_on=is_powered, power_pct=power_pct))

--- a/src/viam/components/movement_sensor/service.py
+++ b/src/viam/components/movement_sensor/service.py
@@ -39,7 +39,7 @@ class MovementSensorService(MovementSensorServiceBase, ComponentServiceBase[Move
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        velocity = await sensor.get_linear_velocity(extra=struct_to_dict(request.extra), timeout=timeout)
+        velocity = await sensor.get_linear_velocity(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetLinearVelocityResponse(linear_velocity=velocity)
         await stream.send_message(response)
 
@@ -52,7 +52,7 @@ class MovementSensorService(MovementSensorServiceBase, ComponentServiceBase[Move
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        velocity = await sensor.get_angular_velocity(extra=struct_to_dict(request.extra), timeout=timeout)
+        velocity = await sensor.get_angular_velocity(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetAngularVelocityResponse(angular_velocity=velocity)
         await stream.send_message(response)
 
@@ -65,7 +65,7 @@ class MovementSensorService(MovementSensorServiceBase, ComponentServiceBase[Move
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        heading = await sensor.get_compass_heading(extra=struct_to_dict(request.extra), timeout=timeout)
+        heading = await sensor.get_compass_heading(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetCompassHeadingResponse(value=heading)
         await stream.send_message(response)
 
@@ -78,7 +78,7 @@ class MovementSensorService(MovementSensorServiceBase, ComponentServiceBase[Move
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        orientation = await sensor.get_orientation(extra=struct_to_dict(request.extra), timeout=timeout)
+        orientation = await sensor.get_orientation(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetOrientationResponse(orientation=orientation)
         await stream.send_message(response)
 
@@ -91,7 +91,7 @@ class MovementSensorService(MovementSensorServiceBase, ComponentServiceBase[Move
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        point, alt = await sensor.get_position(extra=struct_to_dict(request.extra), timeout=timeout)
+        point, alt = await sensor.get_position(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetPositionResponse(coordinate=point, altitude_mm=alt)
         await stream.send_message(response)
 
@@ -104,7 +104,7 @@ class MovementSensorService(MovementSensorServiceBase, ComponentServiceBase[Move
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        response = await sensor.get_properties(extra=struct_to_dict(request.extra), timeout=timeout)
+        response = await sensor.get_properties(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         await stream.send_message(response)
 
     async def GetAccuracy(self, stream: Stream[GetAccuracyRequest, GetAccuracyResponse]) -> None:
@@ -116,6 +116,6 @@ class MovementSensorService(MovementSensorServiceBase, ComponentServiceBase[Move
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        accuracy = await sensor.get_accuracy(extra=struct_to_dict(request.extra), timeout=timeout)
+        accuracy = await sensor.get_accuracy(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetAccuracyResponse(accuracy_mm=accuracy)
         await stream.send_message(response)

--- a/src/viam/components/pose_tracker/service.py
+++ b/src/viam/components/pose_tracker/service.py
@@ -28,5 +28,7 @@ class PoseTrackerService(PoseTrackerServiceBase, ComponentServiceBase[PoseTracke
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        poses = await pose_tracker.get_poses(list(request.body_names), extra=struct_to_dict(request.extra), timeout=timeout)
+        poses = await pose_tracker.get_poses(
+            list(request.body_names), extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata
+        )
         await stream.send_message(GetPosesResponse(body_poses=poses))

--- a/src/viam/components/sensor/service.py
+++ b/src/viam/components/sensor/service.py
@@ -28,6 +28,6 @@ class SensorService(SensorServiceBase, ComponentServiceBase[Sensor]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        readings = await sensor.get_readings(extra=struct_to_dict(request.extra), timeout=timeout)
+        readings = await sensor.get_readings(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetReadingsResponse(readings=sensor_readings_native_to_value(readings))
         await stream.send_message(response)

--- a/src/viam/components/servo/service.py
+++ b/src/viam/components/servo/service.py
@@ -32,7 +32,7 @@ class ServoService(ServoServiceBase, ComponentServiceBase[Servo]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await servo.move(request.angle_deg, extra=struct_to_dict(request.extra), timeout=timeout)
+        await servo.move(request.angle_deg, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         await stream.send_message(MoveResponse())
 
     async def GetPosition(self, stream: Stream[GetPositionRequest, GetPositionResponse]) -> None:
@@ -44,7 +44,7 @@ class ServoService(ServoServiceBase, ComponentServiceBase[Servo]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        position = await servo.get_position(extra=struct_to_dict(request.extra), timeout=timeout)
+        position = await servo.get_position(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         resp = GetPositionResponse(position_deg=position)
         await stream.send_message(resp)
 
@@ -57,5 +57,5 @@ class ServoService(ServoServiceBase, ComponentServiceBase[Servo]):
         except ComponentNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await servo.stop(extra=struct_to_dict(request.extra), timeout=timeout)
+        await servo.stop(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         await stream.send_message(StopResponse())

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -126,7 +126,7 @@ class MockAudioInput(AudioInput):
         self.timeout = timeout
         return MediaStreamWithIterator(read())
 
-    async def get_properties(self, *, timeout: Optional[float] = None) -> AudioInput.Properties:
+    async def get_properties(self, *, timeout: Optional[float] = None, **kwargs) -> AudioInput.Properties:
         self.timeout = timeout
         return self.properties
 
@@ -365,9 +365,7 @@ class MockCamera(Camera):
         self.timeout: Optional[float] = None
         super().__init__(name)
 
-    async def get_image(
-        self, mime_type: str = "", timeout: Optional[float] = None, **kwargs
-    ) -> Union[Image.Image, RawImage]:
+    async def get_image(self, mime_type: str = "", timeout: Optional[float] = None, **kwargs) -> Union[Image.Image, RawImage]:
         self.timeout = timeout
         mime_type, is_lazy = CameraMimeType.from_lazy(mime_type)
         if is_lazy or (not CameraMimeType.is_supported(mime_type)):


### PR DESCRIPTION
JIRA: https://viam.atlassian.net/browse/RSDK-594

Follow-up to: https://github.com/viamrobotics/viam-python-sdk/pull/188 - there we started passing metadata to the arm service methods to synchronize operation ids. This PR does that for all other component service methods.