### PR TITLE
RSDK 2128 allow partial movement sensor readings dictionary

### DIFF
--- a/src/viam/components/movement_sensor/movement_sensor.py
+++ b/src/viam/components/movement_sensor/movement_sensor.py
@@ -100,7 +100,7 @@ class MovementSensor(Sensor):
 
     async def get_readings(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> Mapping[str, Any]:
         """Obtain the measurements/data specific to this sensor.
-        If a sensor is not configured to have a measurement or piece of data, it will be missing from the return dictionary.
+        If a sensor is not configured to have a measurement or fails to read a piece of data, it will be missing from the return dictionary.
         An ERROR log will still appear stating that the measurement/data was Unimplemented.
 
         Returns:

--- a/src/viam/components/movement_sensor/movement_sensor.py
+++ b/src/viam/components/movement_sensor/movement_sensor.py
@@ -3,6 +3,7 @@ import asyncio
 from typing import Any, Dict, Final, List, Mapping, Optional, Tuple
 from grpclib import GRPCError
 
+from viam.errors import MethodNotImplementedError, NotSupportedError
 from viam.proto.common import GeoPoint, Orientation, Vector3
 from viam.proto.component.movementsensor import GetPropertiesResponse
 from viam.resource.types import RESOURCE_NAMESPACE_RDK, RESOURCE_TYPE_COMPONENT, Subtype
@@ -129,6 +130,7 @@ class MovementSensor(Sensor):
 
         # Add returned value to the readings dictionary if value is of expected type; omit if unimplemented.
         def add_reading(name: str, reading, returntype: List) -> None:
+            possible_error_types = (NotImplementedError, MethodNotImplementedError, NotSupportedError)
             if type(reading) in returntype:
                 if name == "position":
                     readings["position"] = reading[0]
@@ -136,7 +138,7 @@ class MovementSensor(Sensor):
                 else:
                     readings[name] = reading
                 return
-            elif isinstance(reading, GRPCError) and "Unimplemented" in str(reading.message):
+            elif isinstance(reading, possible_error_types) or (isinstance(reading, GRPCError) and "Unimplemented" in str(reading.message)):
                 return
             raise reading
 

--- a/src/viam/components/movement_sensor/movement_sensor.py
+++ b/src/viam/components/movement_sensor/movement_sensor.py
@@ -100,6 +100,8 @@ class MovementSensor(Sensor):
 
     async def get_readings(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> Mapping[str, Any]:
         """Obtain the measurements/data specific to this sensor.
+        If a sensor is not configured to have a measurement or piece of data, it will be missing from the return dictionary.
+        An ERROR log will still appear stating that the measurement/data was Unimplemented.
 
         Returns:
             Mapping[str, Any]: The readings for the MovementSensor:
@@ -108,6 +110,7 @@ class MovementSensor(Sensor):
                 altitude: float,
                 linear_velocity: Vector3,
                 angular_velocity: Vector3,
+                linear_acceleration: Vector3
                 compass: float,
                 orientation: Orientation
             }

--- a/tests/test_movement_sensor.py
+++ b/tests/test_movement_sensor.py
@@ -171,10 +171,6 @@ class TestMovementSensor:
         assert value == {
             "position": COORDINATE,
             "altitude": ALTITUDE,
-            "linear_velocity": Vector3(),
-            "angular_velocity": Vector3(),
-            "linear_acceleration": Vector3(),
-            "compass": 0,
             "orientation": ORIENTATION,
         }
 

--- a/tests/test_movement_sensor.py
+++ b/tests/test_movement_sensor.py
@@ -1,6 +1,7 @@
 import pytest
 from grpclib.testing import ChannelFor
 from grpclib import GRPCError, Status
+
 from typing import Any, Dict, Optional
 
 from viam.components.generic.service import GenericService
@@ -154,12 +155,12 @@ class TestMovementSensor:
         }
         assert movement_sensor.extra == EXTRA_PARAMS
 
-        # A mock method to replace some get functions just for testing
+        # A mock method to replace some get functions just for testing that should result in omitted entries in the dictionary
         async def get_reading(*, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> Vector3:
-            raise GRPCError(Status(2))
+            raise GRPCError(Status(2), "Unimplemented")
 
         async def get_compass_heading(*, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> float:
-            raise GRPCError(Status(2))
+            raise GRPCError(Status(2), "Unimplemented")
 
         movement_sensor.get_linear_velocity = get_reading
         movement_sensor.get_linear_acceleration = get_reading
@@ -172,6 +173,15 @@ class TestMovementSensor:
             "altitude": ALTITUDE,
             "orientation": ORIENTATION,
         }
+
+        # A mock method to replace some get functions just for testing that should result in a raised error
+        async def get_orientation(*, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> Orientation:
+            raise GRPCError(Status(2), "not implemented")
+
+        movement_sensor.get_orientation = get_orientation
+
+        with pytest.raises(GRPCError):
+            await movement_sensor.get_readings(extra=EXTRA_PARAMS)
 
     @pytest.mark.asyncio
     async def test_timeout(self, movement_sensor: MockMovementSensor):

--- a/tests/test_movement_sensor.py
+++ b/tests/test_movement_sensor.py
@@ -1,7 +1,6 @@
 import pytest
 from grpclib.testing import ChannelFor
-from grpclib import GRPCError
-from grpclib import Status
+from grpclib import GRPCError, Status
 from typing import Any, Dict, Optional
 
 from viam.components.generic.service import GenericService

--- a/tests/test_movement_sensor.py
+++ b/tests/test_movement_sensor.py
@@ -157,10 +157,10 @@ class TestMovementSensor:
 
         # A mock method to replace some get functions just for testing
         async def get_reading(*, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> Vector3:
-            raise GRPCError(Status(12))
+            raise GRPCError(Status(2))
 
         async def get_compass_heading(*, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> float:
-            raise GRPCError(Status(12))
+            raise GRPCError(Status(2))
 
         movement_sensor.get_linear_velocity = get_reading
         movement_sensor.get_linear_acceleration = get_reading


### PR DESCRIPTION
[RSDK-2128](https://viam.atlassian.net/browse/RSDK-2128)

Currently, when a movement sensor does not have keys for all the possible readings, it returns an error. For example, the accelerometer on the Viam Rovers by default only have a linear acceleration reading set up. When a user calls `get_reading()` on the rover's accelerometer, an `GRPCError` is raised, failing out of the function altogether without any return.

The goal of this ticket is to be able to call `get_readings()` and return a dictionary that has default values for whatever reading is not supported on the sensor.

Calling `get_readings()` still returns an ERROR logs, but is able to return an incomplete library of `readings`.
```
2023-03-03 18:04:31,722         INFO    viam.rpc.dial (dial.py:212)     Connecting to socket: /tmp/proxy-WokwCPR4.sock
2023-03-03T23:04:31.854702Z ERROR viam_rust_utils::rpc::client_stream: Error processing trailers: Code=2 message=Position Unimplemented    
2023-03-03T23:04:31.854729Z ERROR viam_rust_utils::rpc::client_channel: error deserializing message: Code=2 message=Position Unimplemented    
(<Status.UNKNOWN: 2>, 'Code=2 message=Position Unimplemented', None)
2023-03-03T23:04:31.882735Z ERROR viam_rust_utils::rpc::client_stream: Error processing trailers: Code=2 message=LinearVelocity Unimplemented    
2023-03-03T23:04:31.882754Z ERROR viam_rust_utils::rpc::client_channel: error deserializing message: Code=2 message=LinearVelocity Unimplemented    
(<Status.UNKNOWN: 2>, 'Code=2 message=LinearVelocity Unimplemented', None)
2023-03-03T23:04:31.906334Z ERROR viam_rust_utils::rpc::client_stream: Error processing trailers: Code=2 message=AngularVelocity Unimplemented    
2023-03-03T23:04:31.906350Z ERROR viam_rust_utils::rpc::client_channel: error deserializing message: Code=2 message=AngularVelocity Unimplemented    
(<Status.UNKNOWN: 2>, 'Code=2 message=AngularVelocity Unimplemented', None)
2023-03-03T23:04:31.950363Z ERROR viam_rust_utils::rpc::client_stream: Error processing trailers: Code=2 message=CompassHeading Unimplemented    
2023-03-03T23:04:31.950380Z ERROR viam_rust_utils::rpc::client_channel: error deserializing message: Code=2 message=CompassHeading Unimplemented    
(<Status.UNKNOWN: 2>, 'Code=2 message=CompassHeading Unimplemented', None)
2023-03-03T23:04:31.971760Z ERROR viam_rust_utils::rpc::client_stream: Error processing trailers: Code=2 message=Orientation Unimplemented    
2023-03-03T23:04:31.971777Z ERROR viam_rust_utils::rpc::client_channel: error deserializing message: Code=2 message=Orientation Unimplemented    
(<Status.UNKNOWN: 2>, 'Code=2 message=Orientation Unimplemented', None)
{'linear_acceleration': y: 919.6875
z: 9580.078125
}
```

[RSDK-2128]: https://viam.atlassian.net/browse/RSDK-2128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ