### PR TITLE
Fix ResourceName delimiters

### DIFF
--- a/src/viam/__init__.py
+++ b/src/viam/__init__.py
@@ -41,4 +41,4 @@ sys.excepthook = _log_exceptions
 ##################
 # MONKEY PATCHES #
 ##################
-_ResourceName.__hash__ = lambda self: hash(f"{self.namespace}/{self.type}/{self.subtype}/{self.name}")
+_ResourceName.__hash__ = lambda self: hash(f"{self.namespace}:{self.type}:{self.subtype}/{self.name}")

--- a/src/viam/module/module.py
+++ b/src/viam/module/module.py
@@ -134,7 +134,7 @@ class Module:
             await self.add_resource(add_request)
 
     async def remove_resource(self, request: RemoveResourceRequest):
-        rn = resource_name_from_string(request.name.replace("/", ":"))
+        rn = resource_name_from_string(request.name)
         resource = self.server.get_component(ComponentBase, rn)
         if isinstance(resource, Stoppable):
             if iscoroutinefunction(resource.stop):

--- a/src/viam/resource/types.py
+++ b/src/viam/resource/types.py
@@ -174,7 +174,7 @@ class Model:
 
 
 def resource_name_from_string(string: str) -> ResourceName:
-    """Create a ResourceName from its string representation (namespace:resource_type:resource_subtype:name)
+    """Create a ResourceName from its string representation (namespace:resource_type:resource_subtype/<optional_remote:>name)
 
     Args:
         string (str): The ResourceName as a string
@@ -185,10 +185,18 @@ def resource_name_from_string(string: str) -> ResourceName:
     Returns:
         ResourceName: The new ResourceName
     """
-    parts = string.split(":")
-    if len(parts) < 4:
+    regex = re.compile(r"^([\w-]+:[\w-]+:(?:[\w-]+))\/?([\w-]+:(?:[\w-]+:)*)?(.+)?$")
+    match = regex.match(string)
+    if not match:
         raise ValueError(f"{string} is not a valid ResourceName")
-    return ResourceName(namespace=parts[0], type=parts[1], subtype=parts[2], name=":".join(parts[3:]))
+    parts = match[1].split(":")
+    if len(parts) != 3:
+        raise ValueError(f"{string} is not a valid ResourceName")
+    if match[2]:
+        name = f"{match[2]}{match[3]}"
+    else:
+        name = match[3]
+    return ResourceName(namespace=parts[0], type=parts[1], subtype=parts[2], name=name)
 
 
 class ResourceBase(Protocol):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -125,14 +125,14 @@ def test_model():
 
 def test_resource_name_from_string():
     # normal
-    rn = resource_name_from_string("namespace:type:subtype:name")
+    rn = resource_name_from_string("namespace:type:subtype/name")
     assert rn.namespace == "namespace"
     assert rn.type == "type"
     assert rn.subtype == "subtype"
     assert rn.name == "name"
 
     # remote
-    rn = resource_name_from_string("ns:tp:st:remote:nm")
+    rn = resource_name_from_string("ns:tp:st/remote:nm")
     assert rn.namespace == "ns"
     assert rn.type == "tp"
     assert rn.subtype == "st"


### PR DESCRIPTION
Incorrectly had `ResourceName` being `namespace:type:subtype:name` rather than `namespace:type:subtype/name`. Whoops.