### PR TITLE
Rsdk 2071 support modular validation and implicit dependencies

### DIFF
--- a/examples/module/README.md
+++ b/examples/module/README.md
@@ -13,7 +13,7 @@ The definition of the new resources are in the `src` directory. Within this dire
 
 The `proto` directory contains the `gizmo.proto` and `summation.proto` definitions of all the message types and calls that can be made to the Gizmo component and Summation service. It also has the compiled python output of the protobuf definition.
 
-The `gizmo` directory contains all the necessary definitions for creating a custom `Gizmo` component type. The `api.py` file defines what a `Gizmo` can do (mirroring the `proto` definition), implements the gRPC `GizmoService` for receiving calls, and the gRPC `GizmoClient` for making calls. See the [API docs](https://docs.viam.com/program/extend/modular-resources/#apis) for more info. The `my_gizmo.py` file in contains the unique implementation of a `Gizmo`. This is defined as a specific `Model`. See the [Model docs](https://docs.viam.com/program/extend/modular-resources/#models) for more info.
+The `gizmo` directory contains all the necessary definitions for creating a custom `Gizmo` component type. The `api.py` file defines what a `Gizmo` can do (mirroring the `proto` definition), implements the gRPC `GizmoService` for receiving calls, and the gRPC `GizmoClient` for making calls. See the [API docs](https://docs.viam.com/program/extend/modular-resources/#apis) for more info. The `my_gizmo.py` file in contains the unique implementation of a `Gizmo`. This is defined as a specific `Model`. See the [Model docs](https://docs.viam.com/program/extend/modular-resources/#models) for more info. This implementation uses the `validate_config` function to specify an implicit dependency on a `motor` by default and throw an error if there is an `invalid` attribute.
 
 Similarly, the `summation` directory contains the analogous definitions for the `Summation` service type. The files in this directory mirror the files in the `gizmo` directory.
 
@@ -38,7 +38,8 @@ An example configuration for a Gizmo component and a Summation service could loo
       "namespace": "acme",
       "model": "acme:demo:mygizmo",
       "attributes": {
-        "arg1": "arg1"
+        "arg1": "arg1",
+        "motor": "motor1"
       },
       "depends_on": []
     }

--- a/examples/module/src/gizmo/__init__.py
+++ b/examples/module/src/gizmo/__init__.py
@@ -10,5 +10,4 @@ from .my_gizmo import MyGizmo
 
 Registry.register_subtype(ResourceRegistration(Gizmo, GizmoService, lambda name, channel: GizmoClient(name, channel)))
 
-Registry.register_resource_creator(Gizmo.SUBTYPE, MyGizmo.MODEL, MyGizmo.new)
-Registry.register_resource_validator(Gizmo.SUBTYPE, MyGizmo.MODEL, MyGizmo.validate_config)
+Registry.register_resource_creator(Gizmo.SUBTYPE, MyGizmo.MODEL, MyGizmo.new, MyGizmo.validate_config)

--- a/examples/module/src/gizmo/__init__.py
+++ b/examples/module/src/gizmo/__init__.py
@@ -10,3 +10,4 @@ from .my_gizmo import MyGizmo
 Registry.register_subtype(ResourceRegistration(Gizmo, GizmoService, lambda name, channel: GizmoClient(name, channel)))
 
 Registry.register_resource_creator(Gizmo.SUBTYPE, MyGizmo.MODEL, MyGizmo.new)
+Registry.register_resource_validator(Gizmo.SUBTYPE, MyGizmo.MODEL, MyGizmo.validate_config)

--- a/examples/module/src/gizmo/__init__.py
+++ b/examples/module/src/gizmo/__init__.py
@@ -2,7 +2,7 @@
 This file registers the Gizmo subtype with the Viam Registry, as well as the specific MyGizmo model.
 """
 
-from viam.components.motor import *  # Need to import motor to so the component registers itself
+from viam.components.motor import *  # noqa: F403 Need to import motor to so the component registers itself
 from viam.resource.registry import ResourceRegistration, Registry
 
 from .api import Gizmo, GizmoClient, GizmoService

--- a/examples/module/src/gizmo/__init__.py
+++ b/examples/module/src/gizmo/__init__.py
@@ -2,7 +2,7 @@
 This file registers the Gizmo subtype with the Viam Registry, as well as the specific MyGizmo model.
 """
 
-from viam.components.motor import *  # noqa: F403 Need to import motor to so the component registers itself
+from viam.components.motor import *  # noqa: F403 Need to import motor so the component registers itself
 from viam.resource.registry import ResourceRegistration, Registry
 
 from .api import Gizmo, GizmoClient, GizmoService

--- a/examples/module/src/gizmo/__init__.py
+++ b/examples/module/src/gizmo/__init__.py
@@ -3,11 +3,11 @@ This file registers the Gizmo subtype with the Viam Registry, as well as the spe
 """
 
 from viam.components.motor import *  # noqa: F403 Need to import motor so the component registers itself
-from viam.resource.registry import ResourceRegistration, Registry
+from viam.resource.registry import Registry, ResourceCreatorRegistration, ResourceRegistration
 
 from .api import Gizmo, GizmoClient, GizmoService
 from .my_gizmo import MyGizmo
 
 Registry.register_subtype(ResourceRegistration(Gizmo, GizmoService, lambda name, channel: GizmoClient(name, channel)))
 
-Registry.register_resource_creator(Gizmo.SUBTYPE, MyGizmo.MODEL, MyGizmo.new, MyGizmo.validate_config)
+Registry.register_resource_creator(Gizmo.SUBTYPE, MyGizmo.MODEL, ResourceCreatorRegistration(MyGizmo.new, MyGizmo.validate_config))

--- a/examples/module/src/gizmo/__init__.py
+++ b/examples/module/src/gizmo/__init__.py
@@ -2,6 +2,7 @@
 This file registers the Gizmo subtype with the Viam Registry, as well as the specific MyGizmo model.
 """
 
+from viam.components.motor import *
 from viam.resource.registry import ResourceRegistration, Registry
 
 from .api import Gizmo, GizmoClient, GizmoService

--- a/examples/module/src/gizmo/__init__.py
+++ b/examples/module/src/gizmo/__init__.py
@@ -2,7 +2,7 @@
 This file registers the Gizmo subtype with the Viam Registry, as well as the specific MyGizmo model.
 """
 
-from viam.components.motor import *
+from viam.components.motor import *  # Need to import motor to so the component registers itself
 from viam.resource.registry import ResourceRegistration, Registry
 
 from .api import Gizmo, GizmoClient, GizmoService

--- a/examples/module/src/gizmo/my_gizmo.py
+++ b/examples/module/src/gizmo/my_gizmo.py
@@ -29,15 +29,15 @@ class MyGizmo(Gizmo, Reconfigurable):
         return gizmo
 
     @classmethod
-    def validate_config(cls, config: ComponentConfig) -> List[str]:
+    def validate_config(cls, config: ComponentConfig) -> Sequence[str]:
         # Custom validation can be done by specifiying a validate function like this one. Validate functions
-        # can throw `throw` errors that will be returned to the parent through gRPC. Validate functions can
-        # also return a vector of strings representing the implicit dependencies of the resource.
+        # can raise errors that will be returned to the parent through gRPC. Validate functions can
+        # also return a sequence of strings representing the implicit dependencies of the resource.
         if "invalid" in config.attributes.fields:
             raise Exception(f"'invalid' attribute not allowed for model {cls.SUBTYPE}:{cls.MODEL}")
         motor = [config.attributes.fields["motor"].string_value]
         if motor == []:
-            raise Exception("A motor is required for Gizmo module.")
+            raise Exception("A motor is required for Gizmo component.")
         return motor
 
     async def do_one(self, arg1: str, **kwargs) -> bool:

--- a/examples/module/src/gizmo/my_gizmo.py
+++ b/examples/module/src/gizmo/my_gizmo.py
@@ -36,10 +36,10 @@ class MyGizmo(Gizmo, Reconfigurable):
         if "invalid" in config.attributes.fields:
             raise Exception(f"'invalid' attribute not allowed for model {cls.SUBTYPE}:{cls.MODEL}")
         arg1 = config.attributes.fields["arg1"].string_value
-        if arg1 is None:
-            raise Exception("arg1 attribute is required for Gizmo component.")
+        if arg1 == "":
+            raise Exception("A arg1 attribute is required for Gizmo component.")
         motor = [config.attributes.fields["motor"].string_value]
-        if motor == []:
+        if motor == [""]:
             raise Exception("A motor is required for Gizmo component.")
         return motor
 

--- a/examples/module/src/gizmo/my_gizmo.py
+++ b/examples/module/src/gizmo/my_gizmo.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Mapping, Sequence
+from typing import ClassVar, List, Mapping, Sequence
 
 from typing_extensions import Self
 
@@ -27,6 +27,10 @@ class MyGizmo(Gizmo, Reconfigurable):
         gizmo = cls(config.name)
         gizmo.my_arg = config.attributes.fields["arg1"].string_value
         return gizmo
+
+    @classmethod
+    def validate_config(cls, config: ComponentConfig) -> List[str]:
+        return [config.attributes.fields["arg1"].string_value]
 
     async def do_one(self, arg1: str, **kwargs) -> bool:
         return arg1 == self.my_arg

--- a/examples/module/src/gizmo/my_gizmo.py
+++ b/examples/module/src/gizmo/my_gizmo.py
@@ -30,7 +30,9 @@ class MyGizmo(Gizmo, Reconfigurable):
 
     @classmethod
     def validate_config(cls, config: ComponentConfig) -> List[str]:
-        return [config.attributes.fields["arg1"].string_value]
+        if "invalid" in config.attributes.fields:
+            raise Exception(f"'invalid' attribute not allowed for model {cls.SUBTYPE}:{cls.MODEL}")
+        return [config.attributes.fields["motor"].string_value]
 
     async def do_one(self, arg1: str, **kwargs) -> bool:
         return arg1 == self.my_arg

--- a/examples/module/src/gizmo/my_gizmo.py
+++ b/examples/module/src/gizmo/my_gizmo.py
@@ -30,6 +30,9 @@ class MyGizmo(Gizmo, Reconfigurable):
 
     @classmethod
     def validate_config(cls, config: ComponentConfig) -> List[str]:
+        # Custom validation can be done by specifiying a validate function like this one. Validate functions
+        # can throw `throw` errors that will be returned to the parent through gRPC. Validate functions can
+        # also return a vector of strings representing the implicit dependencies of the resource.
         if "invalid" in config.attributes.fields:
             raise Exception(f"'invalid' attribute not allowed for model {cls.SUBTYPE}:{cls.MODEL}")
         motor = [config.attributes.fields["motor"].string_value]

--- a/examples/module/src/gizmo/my_gizmo.py
+++ b/examples/module/src/gizmo/my_gizmo.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, List, Mapping, Sequence
+from typing import ClassVar, Mapping, Sequence
 
 from typing_extensions import Self
 
@@ -35,6 +35,9 @@ class MyGizmo(Gizmo, Reconfigurable):
         # also return a sequence of strings representing the implicit dependencies of the resource.
         if "invalid" in config.attributes.fields:
             raise Exception(f"'invalid' attribute not allowed for model {cls.SUBTYPE}:{cls.MODEL}")
+        arg1 = config.attributes.fields["arg1"].string_value
+        if arg1 is None:
+            raise Exception("arg1 attribute is required for Gizmo component.")
         motor = [config.attributes.fields["motor"].string_value]
         if motor == []:
             raise Exception("A motor is required for Gizmo component.")

--- a/examples/module/src/gizmo/my_gizmo.py
+++ b/examples/module/src/gizmo/my_gizmo.py
@@ -32,7 +32,10 @@ class MyGizmo(Gizmo, Reconfigurable):
     def validate_config(cls, config: ComponentConfig) -> List[str]:
         if "invalid" in config.attributes.fields:
             raise Exception(f"'invalid' attribute not allowed for model {cls.SUBTYPE}:{cls.MODEL}")
-        return [config.attributes.fields["motor"].string_value]
+        motor = [config.attributes.fields["motor"].string_value]
+        if motor == []:
+            raise Exception("A motor is required for Gizmo module.")
+        return motor
 
     async def do_one(self, arg1: str, **kwargs) -> bool:
         return arg1 == self.my_arg

--- a/examples/module/src/summation/__init__.py
+++ b/examples/module/src/summation/__init__.py
@@ -2,11 +2,11 @@
 This file registers the Summation subtype with the Viam Registry, as well as the specific MySummation model.
 """
 
-from viam.resource.registry import Registry, ResourceRegistration
+from viam.resource.registry import Registry, ResourceCreatorRegistration, ResourceRegistration
 
 from .api import SummationClient, SummationRPCService, SummationService
 from .my_summation import MySummationService
 
 Registry.register_subtype(ResourceRegistration(SummationService, SummationRPCService, lambda name, channel: SummationClient(name, channel)))
 
-Registry.register_resource_creator(SummationService.SUBTYPE, MySummationService.MODEL, MySummationService.new)
+Registry.register_resource_creator(SummationService.SUBTYPE, MySummationService.MODEL, ResourceCreatorRegistration(MySummationService.new))

--- a/src/viam/errors.py
+++ b/src/viam/errors.py
@@ -83,3 +83,13 @@ class NotSupportedError(ViamGRPCError):
     def __init__(self, message: str):
         self.message = message
         self.grpc_code = Status.UNIMPLEMENTED
+
+
+class ValidationError(ViamGRPCError):
+    """
+    Exception raised when there is an error during module validation
+    """
+
+    def __init__(self, message: str):
+        self.message = message
+        self.grpc_code = Status.FAILED_PRECONDITION

--- a/src/viam/errors.py
+++ b/src/viam/errors.py
@@ -92,4 +92,4 @@ class ValidationError(ViamGRPCError):
 
     def __init__(self, message: str):
         self.message = message
-        self.grpc_code = Status.FAILED_PRECONDITION
+        self.grpc_code = Status.INVALID_ARGUMENT

--- a/src/viam/module/module.py
+++ b/src/viam/module/module.py
@@ -16,6 +16,8 @@ from viam.proto.module import (
     ReadyResponse,
     ReconfigureResourceRequest,
     RemoveResourceRequest,
+    ValidateConfigRequest,
+    ValidateConfigResponse,
 )
 from viam.proto.robot import ResourceRPCSubtype
 from viam.resource.base import ResourceBase
@@ -176,3 +178,14 @@ class Module:
             Registry.lookup_resource_creator(subtype, model)
         except ResourceNotFoundError:
             raise ValueError(f"Cannot add model because it has not been registered. Subtype: {subtype}. Model: {model}")
+
+    async def validate_config(self, request: ValidateConfigRequest) -> ValidateConfigResponse:
+        config: ComponentConfig = request.config
+        subtype = Subtype.from_string(config.api)
+        model = Model.from_string(config.api)
+        validator = Registry.lookup_validator(subtype, model)
+        if validator is not None:
+            dependencies = validator(config)
+            return ValidateConfigResponse(dependencies=dependencies)
+
+        return ValidateConfigResponse()

--- a/src/viam/module/module.py
+++ b/src/viam/module/module.py
@@ -184,10 +184,8 @@ class Module:
         subtype = Subtype.from_string(config.api)
         model = Model.from_string(config.model)
         validator = Registry.lookup_validator(subtype, model)
-        if validator is not None:
-            try:
-                dependencies = validator(config)
-                return ValidateConfigResponse(dependencies=dependencies)
-            except Exception as e:
-                raise ValidationError(f"{type(Exception)}: {e}").grpc_error
-        return ValidateConfigResponse()
+        try:
+            dependencies = validator(config)
+            return ValidateConfigResponse(dependencies=dependencies)
+        except Exception as e:
+            raise ValidationError(f"{type(Exception)}: {e}")

--- a/src/viam/module/module.py
+++ b/src/viam/module/module.py
@@ -182,7 +182,7 @@ class Module:
     async def validate_config(self, request: ValidateConfigRequest) -> ValidateConfigResponse:
         config: ComponentConfig = request.config
         subtype = Subtype.from_string(config.api)
-        model = Model.from_string(config.api)
+        model = Model.from_string(config.model)
         validator = Registry.lookup_validator(subtype, model)
         if validator is not None:
             dependencies = validator(config)

--- a/src/viam/module/module.py
+++ b/src/viam/module/module.py
@@ -6,7 +6,7 @@ from grpclib.utils import _service_name
 
 from viam import logging
 from viam.components.component_base import ComponentBase
-from viam.errors import ResourceNotFoundError
+from viam.errors import ResourceNotFoundError, ValidationError
 from viam.proto.app.robot import ComponentConfig
 from viam.proto.module import (
     AddResourceRequest,
@@ -185,7 +185,9 @@ class Module:
         model = Model.from_string(config.model)
         validator = Registry.lookup_validator(subtype, model)
         if validator is not None:
-            dependencies = validator(config)
-            return ValidateConfigResponse(dependencies=dependencies)
-
+            try:
+                dependencies = validator(config)
+                return ValidateConfigResponse(dependencies=dependencies)
+            except Exception as e:
+                raise ValidationError(f"{type(Exception)}: {e}")
         return ValidateConfigResponse()

--- a/src/viam/module/module.py
+++ b/src/viam/module/module.py
@@ -189,5 +189,5 @@ class Module:
                 dependencies = validator(config)
                 return ValidateConfigResponse(dependencies=dependencies)
             except Exception as e:
-                raise ValidationError(f"{type(Exception)}: {e}")
+                raise ValidationError(f"{type(Exception)}: {e}").grpc_error
         return ValidateConfigResponse()

--- a/src/viam/module/module.py
+++ b/src/viam/module/module.py
@@ -188,4 +188,4 @@ class Module:
             dependencies = validator(config)
             return ValidateConfigResponse(dependencies=dependencies)
         except Exception as e:
-            raise ValidationError(f"{type(Exception)}: {e}")
+            raise ValidationError(f"{type(Exception)}: {e}").grpc_error

--- a/src/viam/module/service.py
+++ b/src/viam/module/service.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING
 
 from grpclib.server import Stream
 
-from viam.errors import MethodNotImplementedError
 from viam.proto.module import (
     AddResourceRequest,
     AddResourceResponse,
@@ -52,4 +51,8 @@ class ModuleService(ModuleServiceBase):
         await stream.send_message(response)
 
     async def ValidateConfig(self, stream: Stream[ValidateConfigRequest, ValidateConfigResponse]) -> None:
-        raise MethodNotImplementedError("ValidateConfig").grpc_error
+        request = await stream.recv_message()
+        assert request is not None
+        response = await self._module.validate_config(request)
+        if response is not None:
+            await stream.send_message(response)

--- a/src/viam/resource/registry.py
+++ b/src/viam/resource/registry.py
@@ -119,10 +119,7 @@ class Registry:
         Args:
             subtype (Subtype): The Subtype of the resource
             model (Model): The Model of the resource
-            creator (ResourceCreator): A function that can create a resource given a mapping of dependencies (``ResourceName`` to
-                                       ``ResourceBase``).
-            validator (Validator): A function that can validate a resource and return implicit dependencies. If called without a
-                                    validator function, default to a function returning an empty Sequence
+            registration (ResourceCreatorRegistration): The registration functions of the model
 
         Raises:
             DuplicateResourceError: Raised if the Subtype and Model pairing is already registered

--- a/src/viam/resource/registry.py
+++ b/src/viam/resource/registry.py
@@ -11,7 +11,6 @@ from typing import (
     Mapping,
     Type,
     TypeVar,
-    Union,
 )
 
 from google.protobuf.struct_pb2 import Struct
@@ -172,16 +171,14 @@ class Registry:
                 raise ResourceNotFoundError(subtype.resource_type, subtype.resource_subtype)
 
     @classmethod
-    def lookup_validator(cls, subtype: "Subtype", model: "Model") -> Union["Validator", None]:
+    def lookup_validator(cls, subtype: "Subtype", model: "Model") -> "Validator":
         """Lookup and retrieve a registered validator function by its subtype and model. If there is none, return None
 
         Args:
             subtype (Subtype): The Subtype of the resource
             model (Model): The Model of the resource
         """
-        with cls._lock:
-            if f"{subtype}/{model}" in cls._VALIDATORS.keys():
-                return cls._VALIDATORS[f"{subtype}/{model}"]
+        return cls._VALIDATORS.get(f"{subtype}/{model}", lambda x: [])
 
     @classmethod
     def REGISTERED_SUBTYPES(cls) -> Mapping["Subtype", ResourceRegistration]:

--- a/src/viam/resource/registry.py
+++ b/src/viam/resource/registry.py
@@ -41,7 +41,14 @@ class ResourceCreatorRegistration:
     """
 
     creator: "ResourceCreator"
+    """A function that can create a resource given a mapping of dependencies (``ResourceName`` to ``ResourceBase``
+    """
+
     validator: "Validator" = lambda x: []
+    """A function that can validate a resource and return implicit dependencies.
+
+    If called without a validator function, default to a function returning an empty Sequence
+    """
 
 
 @dataclass

--- a/src/viam/resource/registry.py
+++ b/src/viam/resource/registry.py
@@ -121,14 +121,10 @@ class Registry:
         Args:
             subtype (Subtype): The Subtype of the resource
             model (Model): The Model of the resource
-            creator (ResourceCreator): A function that can validate a resource and return implicit dependencies
+            validator (Validator): A function that can validate a resource and return implicit dependencies
 
         Raises:
-            ResourceNotFoundError: _description_
-            ResourceNotFoundError: _description_
-
-        Returns:
-            _type_: _description_
+            DuplicateResourceError: Raised if the Subtype and Model pairing already has a registered validator
         """
         key = f"{subtype}/{model}"
         with cls._lock:

--- a/src/viam/resource/types.py
+++ b/src/viam/resource/types.py
@@ -196,4 +196,5 @@ def resource_name_from_string(string: str) -> ResourceName:
     return ResourceName(namespace=parts[0], type=parts[1], subtype=parts[2], name=name)
 
 
+Validator: TypeAlias = Callable
 ResourceCreator: TypeAlias = Callable[[ComponentConfig, Mapping[ResourceName, "ResourceBase"]], "ResourceBase"]

--- a/src/viam/resource/types.py
+++ b/src/viam/resource/types.py
@@ -1,6 +1,6 @@
 import re
 import sys
-from typing import TYPE_CHECKING, Callable, ClassVar, Mapping
+from typing import TYPE_CHECKING, Callable, ClassVar, Mapping, Sequence
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
@@ -196,5 +196,5 @@ def resource_name_from_string(string: str) -> ResourceName:
     return ResourceName(namespace=parts[0], type=parts[1], subtype=parts[2], name=name)
 
 
-Validator: TypeAlias = Callable
 ResourceCreator: TypeAlias = Callable[[ComponentConfig, Mapping[ResourceName, "ResourceBase"]], "ResourceBase"]
+Validator: TypeAlias = Callable[[ComponentConfig], Sequence[str]]

--- a/tests/mocks/module/gizmo/__init__.py
+++ b/tests/mocks/module/gizmo/__init__.py
@@ -1,3 +1,4 @@
+from viam.components.motor import *
 from viam.resource.registry import Registry, ResourceRegistration
 
 from .api import Gizmo, GizmoClient, GizmoService

--- a/tests/mocks/module/gizmo/__init__.py
+++ b/tests/mocks/module/gizmo/__init__.py
@@ -1,4 +1,4 @@
-from viam.components.motor import *  # noqa: F403 Need to import motor to so the component registers itself
+from viam.components.motor import *  # noqa: F403 Need to import motor so the component registers itself
 from viam.resource.registry import Registry, ResourceRegistration
 
 from .api import Gizmo, GizmoClient, GizmoService

--- a/tests/mocks/module/gizmo/__init__.py
+++ b/tests/mocks/module/gizmo/__init__.py
@@ -6,3 +6,4 @@ from .my_gizmo import MyGizmo
 Registry.register_subtype(ResourceRegistration(Gizmo, GizmoService, lambda name, channel: GizmoClient(name, channel)))
 
 Registry.register_resource_creator(Gizmo.SUBTYPE, MyGizmo.MODEL, MyGizmo.new)
+Registry.register_resource_validator(Gizmo.SUBTYPE, MyGizmo.MODEL, MyGizmo.validate_config)

--- a/tests/mocks/module/gizmo/__init__.py
+++ b/tests/mocks/module/gizmo/__init__.py
@@ -1,9 +1,9 @@
 from viam.components.motor import *  # noqa: F403 Need to import motor so the component registers itself
-from viam.resource.registry import Registry, ResourceRegistration
+from viam.resource.registry import Registry, ResourceRegistration, ResourceCreatorRegistration
 
 from .api import Gizmo, GizmoClient, GizmoService
 from .my_gizmo import MyGizmo
 
 Registry.register_subtype(ResourceRegistration(Gizmo, GizmoService, lambda name, channel: GizmoClient(name, channel)))
 
-Registry.register_resource_creator(Gizmo.SUBTYPE, MyGizmo.MODEL, MyGizmo.new, MyGizmo.validate_config)
+Registry.register_resource_creator(Gizmo.SUBTYPE, MyGizmo.MODEL, ResourceCreatorRegistration(MyGizmo.new, MyGizmo.validate_config))

--- a/tests/mocks/module/gizmo/__init__.py
+++ b/tests/mocks/module/gizmo/__init__.py
@@ -1,4 +1,4 @@
-from viam.components.motor import *
+from viam.components.motor import *  # Need to import motor to so the component registers itself
 from viam.resource.registry import Registry, ResourceRegistration
 
 from .api import Gizmo, GizmoClient, GizmoService

--- a/tests/mocks/module/gizmo/__init__.py
+++ b/tests/mocks/module/gizmo/__init__.py
@@ -6,5 +6,4 @@ from .my_gizmo import MyGizmo
 
 Registry.register_subtype(ResourceRegistration(Gizmo, GizmoService, lambda name, channel: GizmoClient(name, channel)))
 
-Registry.register_resource_creator(Gizmo.SUBTYPE, MyGizmo.MODEL, MyGizmo.new)
-Registry.register_resource_validator(Gizmo.SUBTYPE, MyGizmo.MODEL, MyGizmo.validate_config)
+Registry.register_resource_creator(Gizmo.SUBTYPE, MyGizmo.MODEL, MyGizmo.new, MyGizmo.validate_config)

--- a/tests/mocks/module/gizmo/__init__.py
+++ b/tests/mocks/module/gizmo/__init__.py
@@ -1,4 +1,4 @@
-from viam.components.motor import *  # Need to import motor to so the component registers itself
+from viam.components.motor import *  # noqa: F403 Need to import motor to so the component registers itself
 from viam.resource.registry import Registry, ResourceRegistration
 
 from .api import Gizmo, GizmoClient, GizmoService

--- a/tests/mocks/module/gizmo/my_gizmo.py
+++ b/tests/mocks/module/gizmo/my_gizmo.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Mapping, Sequence
+from typing import ClassVar, List, Mapping, Sequence
 
 from typing_extensions import Self
 
@@ -21,6 +21,10 @@ class MyGizmo(Gizmo, Reconfigurable):
         gizmo = cls(config.name)
         gizmo.my_arg = config.attributes.fields["arg1"].string_value
         return gizmo
+
+    @classmethod
+    def validate_config(cls, config: ComponentConfig) -> List[str]:
+        return [config.attributes.fields["arg1"].string_value]
 
     async def do_one(self, arg1: str, **kwargs) -> bool:
         return arg1 == self.my_arg

--- a/tests/mocks/module/gizmo/my_gizmo.py
+++ b/tests/mocks/module/gizmo/my_gizmo.py
@@ -26,7 +26,7 @@ class MyGizmo(Gizmo, Reconfigurable):
     def validate_config(cls, config: ComponentConfig) -> List[str]:
         if "invalid" in config.attributes.fields:
             raise Exception(f"'invalid' attribute not allowed for model {cls.SUBTYPE}:{cls.MODEL}")
-        return [config.attributes.fields["arg1"].string_value]
+        return [config.attributes.fields["motor"].string_value]
 
     async def do_one(self, arg1: str, **kwargs) -> bool:
         return arg1 == self.my_arg

--- a/tests/mocks/module/gizmo/my_gizmo.py
+++ b/tests/mocks/module/gizmo/my_gizmo.py
@@ -28,9 +28,9 @@ class MyGizmo(Gizmo, Reconfigurable):
             raise Exception(f"'invalid' attribute not allowed for model {cls.SUBTYPE}:{cls.MODEL}")
         arg1 = config.attributes.fields["arg1"].string_value
         if arg1 is None:
-            raise Exception("arg1 attribute is required for Gizmo component.")
+            raise Exception("A arg1 attribute is required for Gizmo component.")
         motor = [config.attributes.fields["motor"].string_value]
-        if motor == []:
+        if motor == [""]:
             raise Exception("A motor is required for Gizmo component.")
         return motor
 

--- a/tests/mocks/module/gizmo/my_gizmo.py
+++ b/tests/mocks/module/gizmo/my_gizmo.py
@@ -27,7 +27,7 @@ class MyGizmo(Gizmo, Reconfigurable):
         if "invalid" in config.attributes.fields:
             raise Exception(f"'invalid' attribute not allowed for model {cls.SUBTYPE}:{cls.MODEL}")
         arg1 = config.attributes.fields["arg1"].string_value
-        if arg1 is None:
+        if arg1 == "":
             raise Exception("A arg1 attribute is required for Gizmo component.")
         motor = [config.attributes.fields["motor"].string_value]
         if motor == [""]:

--- a/tests/mocks/module/gizmo/my_gizmo.py
+++ b/tests/mocks/module/gizmo/my_gizmo.py
@@ -26,9 +26,12 @@ class MyGizmo(Gizmo, Reconfigurable):
     def validate_config(cls, config: ComponentConfig) -> List[str]:
         if "invalid" in config.attributes.fields:
             raise Exception(f"'invalid' attribute not allowed for model {cls.SUBTYPE}:{cls.MODEL}")
+        arg1 = config.attributes.fields["arg1"].string_value
+        if arg1 is None:
+            raise Exception("arg1 attribute is required for Gizmo component.")
         motor = [config.attributes.fields["motor"].string_value]
-        if motor == [""]:
-            raise Exception("A motor is required for Gizmo module.")
+        if motor == []:
+            raise Exception("A motor is required for Gizmo component.")
         return motor
 
     async def do_one(self, arg1: str, **kwargs) -> bool:

--- a/tests/mocks/module/gizmo/my_gizmo.py
+++ b/tests/mocks/module/gizmo/my_gizmo.py
@@ -24,6 +24,9 @@ class MyGizmo(Gizmo, Reconfigurable):
 
     @classmethod
     def validate_config(cls, config: ComponentConfig) -> List[str]:
+        # Custom validation can be done by specifiying a validate function like this one. Validate functions
+        # can throw `throw` errors that will be returned to the parent through gRPC. Validate functions can
+        # also return a vector of strings representing the implicit dependencies of the resource.
         if "invalid" in config.attributes.fields:
             raise Exception(f"'invalid' attribute not allowed for model {cls.SUBTYPE}:{cls.MODEL}")
         motor = [config.attributes.fields["motor"].string_value]

--- a/tests/mocks/module/gizmo/my_gizmo.py
+++ b/tests/mocks/module/gizmo/my_gizmo.py
@@ -26,7 +26,10 @@ class MyGizmo(Gizmo, Reconfigurable):
     def validate_config(cls, config: ComponentConfig) -> List[str]:
         if "invalid" in config.attributes.fields:
             raise Exception(f"'invalid' attribute not allowed for model {cls.SUBTYPE}:{cls.MODEL}")
-        return [config.attributes.fields["motor"].string_value]
+        motor = [config.attributes.fields["motor"].string_value]
+        if motor == [""]:
+            raise Exception("A motor is required for Gizmo module.")
+        return motor
 
     async def do_one(self, arg1: str, **kwargs) -> bool:
         return arg1 == self.my_arg

--- a/tests/mocks/module/gizmo/my_gizmo.py
+++ b/tests/mocks/module/gizmo/my_gizmo.py
@@ -24,9 +24,6 @@ class MyGizmo(Gizmo, Reconfigurable):
 
     @classmethod
     def validate_config(cls, config: ComponentConfig) -> List[str]:
-        # Custom validation can be done by specifiying a validate function like this one. Validate functions
-        # can throw `throw` errors that will be returned to the parent through gRPC. Validate functions can
-        # also return a vector of strings representing the implicit dependencies of the resource.
         if "invalid" in config.attributes.fields:
             raise Exception(f"'invalid' attribute not allowed for model {cls.SUBTYPE}:{cls.MODEL}")
         motor = [config.attributes.fields["motor"].string_value]

--- a/tests/mocks/module/gizmo/my_gizmo.py
+++ b/tests/mocks/module/gizmo/my_gizmo.py
@@ -24,6 +24,8 @@ class MyGizmo(Gizmo, Reconfigurable):
 
     @classmethod
     def validate_config(cls, config: ComponentConfig) -> List[str]:
+        if "invalid" in config.attributes.fields:
+            raise Exception(f"'invalid' attribute not allowed for model {cls.SUBTYPE}:{cls.MODEL}")
         return [config.attributes.fields["arg1"].string_value]
 
     async def do_one(self, arg1: str, **kwargs) -> bool:

--- a/tests/mocks/module/summation/__init__.py
+++ b/tests/mocks/module/summation/__init__.py
@@ -1,8 +1,8 @@
-from viam.resource.registry import Registry, ResourceRegistration
+from viam.resource.registry import Registry, ResourceCreatorRegistration, ResourceRegistration
 
 from .api import SummationClient, SummationRPCService, SummationService
 from .my_summation import MySummationService
 
 Registry.register_subtype(ResourceRegistration(SummationService, SummationRPCService, lambda name, channel: SummationClient(name, channel)))
 
-Registry.register_resource_creator(SummationService.SUBTYPE, MySummationService.MODEL, MySummationService.new)
+Registry.register_resource_creator(SummationService.SUBTYPE, MySummationService.MODEL, ResourceCreatorRegistration(MySummationService.new))

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -218,6 +218,22 @@ class TestModule:
         assert await g1.do_one("arg2") is False
         assert await g2.do_one("arg2") is True
 
+    async def test_validate_config(self):
+        req = ValidateConfigRequest(
+            config=(
+                ComponentConfig(
+                    name="gizmo1",
+                    namespace="acme",
+                    type="gizmo",
+                    model="acme:demo:mygizmo",
+                    attributes=dict_to_struct({"arg1": "arg2"}),
+                    api="acme:component:gizmo",
+                )
+            )
+        )
+        response = await self.module.validate_config(req)
+        assert response.dependencies == ["arg2"]
+
 
 class TestService:
     @pytest.mark.asyncio

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -5,6 +5,7 @@ import pytest
 import pytest_asyncio
 from grpclib.testing import ChannelFor
 
+from viam.errors import ValidationError
 from viam.module import Module
 from viam.module.service import ModuleService
 from viam.proto.app.robot import ComponentConfig
@@ -233,6 +234,21 @@ class TestModule:
         )
         response = await self.module.validate_config(req)
         assert response.dependencies == ["arg2"]
+
+        req = ValidateConfigRequest(
+            config=(
+                ComponentConfig(
+                    name="gizmo2",
+                    namespace="acme",
+                    type="gizmo",
+                    model="acme:demo:mygizmo",
+                    attributes=dict_to_struct({"arg1": "arg2", "invalid": "attribute"}),
+                    api="acme:component:gizmo",
+                )
+            )
+        )
+        with pytest.raises(ValidationError):
+            response = await self.module.validate_config(req)
 
 
 class TestService:

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -5,7 +5,7 @@ import pytest
 import pytest_asyncio
 from grpclib.testing import ChannelFor
 
-from viam.errors import ValidationError
+from viam.errors import GRPCError
 from viam.module import Module
 from viam.module.service import ModuleService
 from viam.proto.app.robot import ComponentConfig
@@ -247,7 +247,7 @@ class TestModule:
                 )
             )
         )
-        with pytest.raises(ValidationError):
+        with pytest.raises(GRPCError, match=r".*Status.INVALID_ARGUMENT.*"):
             response = await self.module.validate_config(req)
 
         req = ValidateConfigRequest(
@@ -262,7 +262,22 @@ class TestModule:
                 )
             )
         )
-        with pytest.raises(ValidationError):
+        with pytest.raises(GRPCError, match=r".*Status.INVALID_ARGUMENT.*"):
+            response = await self.module.validate_config(req)
+
+        req = ValidateConfigRequest(
+            config=(
+                ComponentConfig(
+                    name="gizmo3",
+                    namespace="acme",
+                    type="gizmo",
+                    model="acme:demo:mygizmo",
+                    attributes=dict_to_struct({"motor": "motor1"}),
+                    api="acme:component:gizmo",
+                )
+            )
+        )
+        with pytest.raises(GRPCError, match=r".*Status.INVALID_ARGUMENT.*"):
             response = await self.module.validate_config(req)
 
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -67,7 +67,7 @@ class TestModule:
                 namespace="acme",
                 type="gizmo",
                 model="acme:demo:mygizmo",
-                attributes=dict_to_struct({"arg1": "arg1"}),
+                attributes=dict_to_struct({"arg1": "arg1", "motor": "motor1"}),
                 api="acme:component:gizmo",
             )
         )
@@ -99,7 +99,7 @@ class TestModule:
                 namespace="acme",
                 type="gizmo",
                 model="acme:demo:mygizmo",
-                attributes=dict_to_struct({"arg1": "arg2"}),
+                attributes=dict_to_struct({"arg1": "arg2", "motor": "motor1"}),
                 api="acme:component:gizmo",
             )
         )
@@ -132,7 +132,7 @@ class TestModule:
                     namespace="acme",
                     type="gizmo",
                     model="acme:demo:mygizmo",
-                    attributes=dict_to_struct({"arg1": "arg2"}),
+                    attributes=dict_to_struct({"arg1": "arg2", "motor": "motor1"}),
                     api="acme:component:gizmo",
                 ),
                 dependencies=["rdk:component:arm/arm1"],
@@ -194,7 +194,7 @@ class TestModule:
                 namespace="acme",
                 type="gizmo",
                 model="acme:demo:mygizmo",
-                attributes=dict_to_struct({"arg1": "arg1"}),
+                attributes=dict_to_struct({"arg1": "arg1", "motor": "motor1"}),
                 api="acme:component:gizmo",
             )
         )
@@ -205,7 +205,7 @@ class TestModule:
                 namespace="acme",
                 type="gizmo",
                 model="acme:demo:mygizmo",
-                attributes=dict_to_struct({"arg1": "arg2"}),
+                attributes=dict_to_struct({"arg1": "arg2", "motor": "motor1"}),
                 api="acme:component:gizmo",
             )
         )
@@ -227,13 +227,13 @@ class TestModule:
                     namespace="acme",
                     type="gizmo",
                     model="acme:demo:mygizmo",
-                    attributes=dict_to_struct({"arg1": "arg2"}),
+                    attributes=dict_to_struct({"arg1": "arg2", "motor": "motor1"}),
                     api="acme:component:gizmo",
                 )
             )
         )
         response = await self.module.validate_config(req)
-        assert response.dependencies == ["arg2"]
+        assert response.dependencies == ["motor1"]
 
         req = ValidateConfigRequest(
             config=(
@@ -242,7 +242,7 @@ class TestModule:
                     namespace="acme",
                     type="gizmo",
                     model="acme:demo:mygizmo",
-                    attributes=dict_to_struct({"arg1": "arg2", "invalid": "attribute"}),
+                    attributes=dict_to_struct({"arg1": "arg2", "invalid": "attribute", "motor": "motor1"}),
                     api="acme:component:gizmo",
                 )
             )

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -250,6 +250,21 @@ class TestModule:
         with pytest.raises(ValidationError):
             response = await self.module.validate_config(req)
 
+        req = ValidateConfigRequest(
+            config=(
+                ComponentConfig(
+                    name="gizmo3",
+                    namespace="acme",
+                    type="gizmo",
+                    model="acme:demo:mygizmo",
+                    attributes=dict_to_struct({"arg1": "arg2"}),
+                    api="acme:component:gizmo",
+                )
+            )
+        )
+        with pytest.raises(ValidationError):
+            response = await self.module.validate_config(req)
+
 
 class TestService:
     @pytest.mark.asyncio

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -4,7 +4,6 @@ from unittest import mock
 import pytest
 import pytest_asyncio
 from grpclib.testing import ChannelFor
-from grpclib.exceptions import GRPCError
 
 from viam.module import Module
 from viam.module.service import ModuleService
@@ -16,7 +15,8 @@ from viam.proto.module import (
     ReadyResponse,
     ReconfigureResourceRequest,
     RemoveResourceRequest,
-    ValidateConfigRequest
+    ValidateConfigRequest,
+    ValidateConfigResponse,
 )
 from viam.proto.robot import ResourceRPCSubtype
 from viam.resource.types import Model, Subtype
@@ -256,6 +256,6 @@ class TestService:
     async def test_validate_config(self, service: ModuleService):
         async with ChannelFor([service]) as channel:
             client = ModuleServiceStub(channel)
-            request = ValidateConfigRequest()
-            with pytest.raises(GRPCError, match=r".*Status.UNIMPLEMENTED.*"):
-                await client.ValidateConfig(request)
+            with mock.patch("viam.module.module.Module.validate_config", return_value=ValidateConfigResponse()) as mocked:
+                await client.ValidateConfig(ValidateConfigRequest())
+                mocked.assert_called_once()

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -280,6 +280,19 @@ class TestModule:
         with pytest.raises(GRPCError, match=r".*Status.INVALID_ARGUMENT.*"):
             response = await self.module.validate_config(req)
 
+        req = ValidateConfigRequest(
+            config=ComponentConfig(
+                name="mysum1",
+                namespace="acme",
+                type="summation",
+                model="acme:demo:mysum",
+                attributes=dict_to_struct({"subtract": False}),
+                api="acme:service:summation",
+            )
+        )
+        response = await self.module.validate_config(req)
+        assert response.dependencies == []
+
 
 class TestService:
     @pytest.mark.asyncio


### PR DESCRIPTION
[RSDK-2071](https://viam.atlassian.net/browse/RSDK-2071)

Changes in this PR:
- Adds a new resource validator type with `lookup` and `register` functions to work with and store resource validators.
- Adds `validate_config` function that allows a module to look up and run (if any) a stored resource validator.
- Implements `ValidateConfig` to call `validate_config`.
- Adds a new gRPC error called ValidationError that will be raised when any Exception is thrown during `validate_config`.
- Test `validate_config` with example `Gizmo` module that stores a validator during init.
- Adds a validator function section to `README.md`

cc @benjirewis 

[RSDK-2071]: https://viam.atlassian.net/browse/RSDK-2071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ