### PR TITLE
RSDK-2837 - Add some inherited methods to docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@
 # -- Project information -----------------------------------------------------
 
 project = "Viam Python SDK"
-copyright = "2023, Viam Inc"
+copyright = "2022-2023, Viam Inc"
 author = "Viam Inc"
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,9 +6,9 @@
 
 # -- Project information -----------------------------------------------------
 
-project = u"Viam Python SDK"
-copyright = u"2022, Viam Inc"
-author = u"Viam Inc"
+project = "Viam Python SDK"
+copyright = "2023, Viam Inc"
+author = "Viam Inc"
 
 # -- General configuration ---------------------------------------------------
 
@@ -22,13 +22,14 @@ extensions = [
     "sphinx.ext.viewcode",
 ]
 autoapi_dirs = ["../src"]
-autoapi_file_patterns = ['*.pyi', '*.py']
+autoapi_file_patterns = ["*.pyi", "*.py"]
 autoapi_options = [
-    'undoc-members',
-    'show-inhertiance',
-    'show-module-summary',
-    'special-members',
-    'imported-members',
+    "undoc-members",
+    "show-inheritance",
+    "inherited-members",
+    "show-module-summary",
+    "special-members",
+    "imported-members",
 ]
 
 # List of patterns, relative to source directory, that match files and
@@ -38,24 +39,28 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 def skip_member(app, what, name, obj, skip, options) -> bool:
-    if 'gen.proto' in name:
+    if "gen.proto" in name:
         return True
-    if 'proto' in name:
-        if 'google' in name:
+    if "proto" in name:
+        if "google" in name:
             return True
-    if what == 'attribute':
-        if '_FIELD_NUMBER' in name:
+    should_keep = ["from_robot", "do_command", "get_resource_name", "get_operation"]
+    if obj.inherited and not any(method in name for method in should_keep):
+        return True
+    if what == "attribute":
+        if "_FIELD_NUMBER" in name:
             return True
-        if 'DESCRIPTOR' in name:
+        if "DESCRIPTOR" in name:
             return True
-    if what == 'method':
-        if 'ClearField' in name:
+    if what == "method":
+        if "ClearField" in name:
             return True
     return skip
 
 
 def setup(sphinx):
-    sphinx.connect('autoapi-skip-member', skip_member)
+    sphinx.connect("autoapi-skip-member", skip_member)
+
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -66,5 +71,5 @@ def setup(sphinx):
 html_theme = "sphinx_rtd_theme"
 
 html_theme_options = {
-    'navigation_depth': -1,
+    "navigation_depth": -1,
 }


### PR DESCRIPTION
a piece of feedback I got was that some of the inherited methods would be useful to see in the docs - however, doing it blindly will show documentation for far too much stuff, especially in the generated code

basically adds this section into every resource definition file
<img width="720" alt="Screen Shot 2023-04-24 at 13 39 56" src="https://user-images.githubusercontent.com/90270663/234074285-f9899611-e51b-4c6a-90f3-179d57255244.png">

also fixed a typo in `show-inheritance`