### PR TITLE
Rsdk 2930 error when resource not registered

### DIFF
--- a/src/viam/resource/manager.py
+++ b/src/viam/resource/manager.py
@@ -3,8 +3,9 @@ from typing import Dict, List, Type, TypeVar
 
 from viam.proto.common import ResourceName
 from viam.resource.base import ResourceBase
-from viam.services.service_base import ServiceBase
+from viam.resource.registry import Registry
 
+from ..services.service_base import ServiceBase
 from ..components.component_base import ComponentBase
 from ..errors import DuplicateResourceError, ResourceNotFoundError
 
@@ -46,6 +47,7 @@ class ResourceManager:
             if subtype in _BaseClasses:
                 continue
             if hasattr(subtype, "get_resource_name"):
+                Registry.lookup_subtype(component.SUBTYPE)  # confirm the subtype is registered in Registry
                 rn = subtype.get_resource_name(component.name)  # type: ignore
                 rnames[rn] = component
         for rn in rnames:

--- a/src/viam/resource/manager.py
+++ b/src/viam/resource/manager.py
@@ -41,13 +41,14 @@ class ResourceManager:
         Args:
             component (ResourceBase): The component to register
         """
+        Registry.lookup_subtype(component.SUBTYPE)  # confirm the subtype is registered in Registry
+
         _BaseClasses = (ResourceBase, ComponentBase, ServiceBase)
         rnames: Dict[ResourceName, ResourceBase] = {}
         for subtype in component.__class__.mro():
             if subtype in _BaseClasses:
                 continue
             if hasattr(subtype, "get_resource_name"):
-                Registry.lookup_subtype(component.SUBTYPE)  # confirm the subtype is registered in Registry
                 rn = subtype.get_resource_name(component.name)  # type: ignore
                 rnames[rn] = component
         for rn in rnames:


### PR DESCRIPTION
[RSDK-2930](https://viam.atlassian.net/browse/RSDK-2930)

When a resource is not registered completely, the server should return an error when starting up. Now, `Registry` checks to see if the component's subtype is registered.

As these changes were introduced, `TestComponent` also needed to be registered in the registry. 

[RSDK-2930]: https://viam.atlassian.net/browse/RSDK-2930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ