### PR TITLE
New release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ on:
 
 jobs:
   prepare:
-    if: github.repository_owner == 'viamrobotics' && github.ref == 'refs/heads/main'
-    runs-on: [self-hosted, x64]
+    # if: github.repository_owner == 'viamrobotics' && github.ref == 'refs/heads/main'
+    # runs-on: [self-hosted, x64]
+    runs-on: [ubuntu-latest]
     container:
       image: ghcr.io/viamrobotics/canon:amd64
     outputs:
-      sha: ${{ steps.commit.outputs.commit_long_sha }}
       version: ${{ steps.bump_version.outputs.version }}
     steps:
       - name: Check if organization member
@@ -36,20 +36,18 @@ jobs:
           username: ${{ github.actor }}
           token:  ${{ secrets.GITHUB_TOKEN }}
 
-      - name: cancelling
+      - name: Cancelling - user not part of organization
         uses: andymckay/cancel-action@0.2
         if: |
           steps.is_organization_member.outputs.result == 'false'
 
       - name: Checkout Code
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.REPO_READ_TOKEN }}
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
 
-      - name: Install package
+      - name: Install Package
         run: poetry install
 
       - name: Clean Format Test
@@ -60,19 +58,42 @@ jobs:
         run: |
           poetry version ${{ inputs.version }}
           echo "SDK_VERSION=$(poetry version -s)" >> $GITHUB_ENV
-          echo "::set-output name=version::$(poetry version -s)"
+          echo "version=$(poetry version -s)" >> $GITHUB_OUTPUT
 
-      - name: Commit + Push
-        id: commit
-        uses: EndBug/add-and-commit@v9.0.0
+      - name: Check if release exists
+        uses: cardinalby/git-get-release-action@1.2.4
+        id: release_exists
         with:
-          default_author: github_actions
-          message: Bumping version to v${{ env.SDK_VERSION }} [skip ci]
+          name: v${{ env.version }}
+          doNotFailIfNotFound: 'true'
+
+      - name: Cancelling - release already exists
+        uses: andymckay/cancel-action@0.2
+        if: |
+          steps.release_exists.outputs.id != ''
+
+      - name: Add + Commit + Open PR
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: Bump version to ${{ env.SDK_VERSION }}
+          branch: rc-${{ env.SDK_VERSION }}
+          delete-branch: true
+          base: main
+          body: This is an auto-generated PR to merge the rc branch back into main upon successful release.
+
+      # - name: Commit + Push
+      #   id: commit
+      #   uses: EndBug/add-and-commit@v9.1.3
+      #   with:
+      #     new_branch: rc-${{ env.SDK_VERSION }}
+      #     default_author: github_actions
+      #     message: Bumping version to v${{ env.SDK_VERSION }} [skip ci]
 
   build:
     needs: prepare
-    if: github.repository_owner == 'viamrobotics' && github.ref == 'refs/heads/main'
-    runs-on: [self-hosted, x64]
+    # if: github.repository_owner == 'viamrobotics' && github.ref == 'refs/heads/main'
+    # runs-on: [self-hosted, x64]
+    runs-on: [ubuntu-latest]
     container:
       image: ghcr.io/viamrobotics/canon:amd64
     strategy:
@@ -97,7 +118,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
-          ref: ${{ needs.prepare.outputs.sha }}
+          ref: rc-${{ needs.prepare.outputs.version }}
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
@@ -122,8 +143,9 @@ jobs:
 
   release:
     needs: [prepare, build]
-    if: github.repository_owner == 'viamrobotics' && github.ref == 'refs/heads/main'
-    runs-on: [self-hosted, x64]
+    # if: github.repository_owner == 'viamrobotics' && github.ref == 'refs/heads/main'
+    # runs-on: [self-hosted, x64]
+    runs-on: [ubuntu-latest]
     container:
       image: ghcr.io/viamrobotics/canon:amd64
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,8 @@ on:
 
 jobs:
   prepare:
-    # if: github.repository_owner == 'viamrobotics' && github.ref == 'refs/heads/main'
-    # runs-on: [self-hosted, x64]
-    runs-on: [ubuntu-latest]
+    if: github.repository_owner == 'viamrobotics' && github.ref == 'refs/heads/main'
+    runs-on: [self-hosted, x64]
     container:
       image: ghcr.io/viamrobotics/canon:amd64
     outputs:
@@ -86,9 +85,8 @@ jobs:
 
   build:
     needs: prepare
-    # if: github.repository_owner == 'viamrobotics' && github.ref == 'refs/heads/main'
-    # runs-on: [self-hosted, x64]
-    runs-on: [ubuntu-latest]
+    if: github.repository_owner == 'viamrobotics' && github.ref == 'refs/heads/main'
+    runs-on: [self-hosted, x64]
     container:
       image: ghcr.io/viamrobotics/canon:amd64
     strategy:
@@ -138,9 +136,8 @@ jobs:
 
   release:
     needs: [prepare, build]
-    # if: github.repository_owner == 'viamrobotics' && github.ref == 'refs/heads/main'
-    # runs-on: [self-hosted, x64]
-    runs-on: [ubuntu-latest]
+    if: github.repository_owner == 'viamrobotics' && github.ref == 'refs/heads/main'
+    runs-on: [self-hosted, x64]
     container:
       image: ghcr.io/viamrobotics/canon:amd64
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: v${{ env.version }}
+          releaseName: v${{ env.version }}
           doNotFailIfNotFound: 'true'
 
       - name: Cancelling - release already exists
@@ -81,15 +81,8 @@ jobs:
           branch: rc-${{ env.SDK_VERSION }}
           delete-branch: true
           base: main
+          title: rc-${{ env.SDK_VERSION }}
           body: This is an auto-generated PR to merge the rc branch back into main upon successful release.
-
-      # - name: Commit + Push
-      #   id: commit
-      #   uses: EndBug/add-and-commit@v9.1.3
-      #   with:
-      #     new_branch: rc-${{ env.SDK_VERSION }}
-      #     default_author: github_actions
-      #     message: Bumping version to v${{ env.SDK_VERSION }} [skip ci]
 
   build:
     needs: prepare

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
       - name: Check if release exists
         uses: cardinalby/git-get-release-action@1.2.4
         id: release_exists
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           name: v${{ env.version }}
           doNotFailIfNotFound: 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          releaseName: v${{ env.version }}
+          releaseName: v${{ env.SDK_VERSION }}
           doNotFailIfNotFound: 'true'
 
       - name: Cancelling - release already exists

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -39,7 +39,7 @@ jobs:
         run: make format
 
       - name: Add + Commit + Open PR
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v5
         with:
           commit-message: '[WORKFLOW] Updating protos from ${{ github.event.client_payload.repo_name }}, commit: ${{ github.event.client_payload.sha }}'
           branch: 'workflow/update-protos'

--- a/src/viam/resource/manager.py
+++ b/src/viam/resource/manager.py
@@ -5,9 +5,9 @@ from viam.proto.common import ResourceName
 from viam.resource.base import ResourceBase
 from viam.resource.registry import Registry
 
-from ..services.service_base import ServiceBase
 from ..components.component_base import ComponentBase
 from ..errors import DuplicateResourceError, ResourceNotFoundError
+from ..services.service_base import ServiceBase
 
 ResourceType = TypeVar("ResourceType", bound=ResourceBase)
 

--- a/src/viam/services/mlmodel/client.py
+++ b/src/viam/services/mlmodel/client.py
@@ -1,4 +1,5 @@
 from typing import Dict, Mapping, Optional
+
 from grpclib.client import Channel
 
 from viam.proto.common import DoCommandRequest, DoCommandResponse

--- a/src/viam/services/mlmodel/mlmodel.py
+++ b/src/viam/services/mlmodel/mlmodel.py
@@ -1,6 +1,6 @@
 import abc
-
 from typing import Dict, Final, Optional
+
 from viam.proto.service.mlmodel import Metadata
 from viam.resource.types import RESOURCE_NAMESPACE_RDK, RESOURCE_TYPE_SERVICE, Subtype
 from viam.utils import ValueTypes


### PR DESCRIPTION
This reworked workflow has the following changes:

* When updating the version number, it will now commit and push that to a new branch: `rc-{VERSION}`, rather than committing and pushing it directly to `main`
* It will then open a PR from the `rc` branch to `main`
* The new release will be made from the `rc` branch, not `main`