### PR TITLE
Ignore Event Loop is closed error on close

### DIFF
--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -160,6 +160,12 @@ class ViamChannel:
         if not self._closed:
             try:
                 self.channel.close()
+            except RuntimeError as e:
+                # ignore event loop is closed errors - robot is getting shutdown
+                if len(e.args) > 0 and e.args[0] == "Event loop is closed":
+                    LOGGER.debug("ViamChannel might not have shut down cleanly - Event loop was closed")
+                    return
+                raise
             finally:
                 self.release()
                 self._closed = True


### PR DESCRIPTION
want to ignore this since this is unavoidable in some cases (with keyboard interrupts, for example) and should be generally safe

alternatively we can just not call close if event loop is already closed (which also requires catching a RuntimeError)