### PR TITLE
Hoist error throwing to superclass

### DIFF
--- a/examples/module/src/gizmo/api.py
+++ b/examples/module/src/gizmo/api.py
@@ -27,7 +27,6 @@ from grpclib.server import Stream
 
 from viam.components.component_base import ComponentBase
 from viam.components.generic.client import do_command
-from viam.errors import ResourceNotFoundError
 from viam.resource.rpc_service_base import ResourceRPCServiceBase
 from viam.resource.types import RESOURCE_TYPE_COMPONENT, Subtype
 from viam.utils import ValueTypes
@@ -82,10 +81,7 @@ class GizmoService(GizmoServiceBase, ResourceRPCServiceBase[Gizmo]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            gizmo = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gizmo = self.get_resource(name)
         resp = await gizmo.do_one(request.arg1)
         response = DoOneResponse(ret1=resp)
         await stream.send_message(response)
@@ -97,10 +93,7 @@ class GizmoService(GizmoServiceBase, ResourceRPCServiceBase[Gizmo]):
         if len(set(names)) != 1:
             raise Exception("Unexpectedly received requests for multiple Gizmos")
         name = names[0]
-        try:
-            gizmo = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gizmo = self.get_resource(name)
         resp = await gizmo.do_one_client_stream(args)
         response = DoOneClientStreamResponse(ret1=resp)
         await stream.send_message(response)
@@ -109,10 +102,7 @@ class GizmoService(GizmoServiceBase, ResourceRPCServiceBase[Gizmo]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            gizmo = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gizmo = self.get_resource(name)
         resps = await gizmo.do_one_server_stream(request.arg1)
         for resp in resps:
             await stream.send_message(DoOneServerStreamResponse(ret1=resp))
@@ -127,10 +117,7 @@ class GizmoService(GizmoServiceBase, ResourceRPCServiceBase[Gizmo]):
                 continue
             if name != request.name:
                 raise Exception("Unexpectedly received requests for multiple Gizmos")
-        try:
-            gizmo = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gizmo = self.get_resource(name)
 
         resps = await gizmo.do_one_bidi_stream(args)
         for resp in resps:
@@ -140,10 +127,7 @@ class GizmoService(GizmoServiceBase, ResourceRPCServiceBase[Gizmo]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            gizmo = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gizmo = self.get_resource(name)
         resp = await gizmo.do_two(request.arg1)
         response = DoTwoResponse(ret1=resp)
         await stream.send_message(response)

--- a/examples/module/src/summation/api.py
+++ b/examples/module/src/summation/api.py
@@ -26,7 +26,6 @@ from typing import Final, Sequence
 from grpclib.client import Channel
 from grpclib.server import Stream
 
-from viam.errors import ResourceNotFoundError
 from viam.resource.rpc_service_base import ResourceRPCServiceBase
 from viam.resource.types import RESOURCE_TYPE_SERVICE, Subtype
 from viam.services.service_base import ServiceBase
@@ -54,10 +53,7 @@ class SummationRPCService(SummationServiceBase, ResourceRPCServiceBase[Summation
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            service = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        service = self.get_resource(name)
         resp = await service.sum(request.numbers)
         await stream.send_message(SumResponse(sum=resp))
 

--- a/src/viam/components/arm/service.py
+++ b/src/viam/components/arm/service.py
@@ -1,6 +1,5 @@
 from grpclib.server import Stream
 
-from viam.errors import ResourceNotFoundError
 from viam.proto.common import DoCommandRequest, DoCommandResponse
 from viam.proto.component.arm import (
     ArmServiceBase,
@@ -34,10 +33,7 @@ class ArmRPCService(ArmServiceBase, ResourceRPCServiceBase[Arm]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            arm = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        arm = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         position = await arm.get_end_position(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetEndPositionResponse(pose=position)
@@ -47,10 +43,7 @@ class ArmRPCService(ArmServiceBase, ResourceRPCServiceBase[Arm]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            arm = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        arm = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await arm.move_to_position(request.to, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = MoveToPositionResponse()
@@ -60,10 +53,7 @@ class ArmRPCService(ArmServiceBase, ResourceRPCServiceBase[Arm]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            arm = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        arm = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         positions = await arm.get_joint_positions(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetJointPositionsResponse(positions=positions)
@@ -73,10 +63,7 @@ class ArmRPCService(ArmServiceBase, ResourceRPCServiceBase[Arm]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            arm = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        arm = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await arm.move_to_joint_positions(request.positions, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = MoveToJointPositionsResponse()
@@ -86,10 +73,7 @@ class ArmRPCService(ArmServiceBase, ResourceRPCServiceBase[Arm]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            arm = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        arm = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await arm.stop(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = StopResponse()
@@ -99,10 +83,7 @@ class ArmRPCService(ArmServiceBase, ResourceRPCServiceBase[Arm]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            arm = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        arm = self.get_resource(name)
         is_moving = await arm.is_moving()
         response = IsMovingResponse(is_moving=is_moving)
         await stream.send_message(response)
@@ -110,10 +91,7 @@ class ArmRPCService(ArmServiceBase, ResourceRPCServiceBase[Arm]):
     async def DoCommand(self, stream: Stream[DoCommandRequest, DoCommandResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        try:
-            arm = self.get_resource(request.name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        arm = self.get_resource(request.name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         result = await arm.do_command(command=struct_to_dict(request.command), timeout=timeout, metadata=stream.metadata)
         response = DoCommandResponse(result=dict_to_struct(result))

--- a/src/viam/components/base/service.py
+++ b/src/viam/components/base/service.py
@@ -1,6 +1,5 @@
 from grpclib.server import Stream
 
-from viam.errors import ResourceNotFoundError
 from viam.proto.common import DoCommandRequest, DoCommandResponse
 from viam.proto.component.base import (
     BaseServiceBase,
@@ -34,10 +33,7 @@ class BaseRPCService(BaseServiceBase, ResourceRPCServiceBase[Base]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            base = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        base = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await base.move_straight(
             distance=request.distance_mm,
@@ -53,10 +49,7 @@ class BaseRPCService(BaseServiceBase, ResourceRPCServiceBase[Base]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            base = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        base = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await base.spin(
             angle=request.angle_deg,
@@ -72,10 +65,7 @@ class BaseRPCService(BaseServiceBase, ResourceRPCServiceBase[Base]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            base = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        base = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await base.set_power(
             request.linear, request.angular, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata
@@ -87,10 +77,7 @@ class BaseRPCService(BaseServiceBase, ResourceRPCServiceBase[Base]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            base = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        base = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await base.set_velocity(
             request.linear, request.angular, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata
@@ -101,10 +88,7 @@ class BaseRPCService(BaseServiceBase, ResourceRPCServiceBase[Base]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            base = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        base = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await base.stop(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = StopResponse()
@@ -114,10 +98,7 @@ class BaseRPCService(BaseServiceBase, ResourceRPCServiceBase[Base]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            base = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        base = self.get_resource(name)
         is_moving = await base.is_moving()
         response = IsMovingResponse(is_moving=is_moving)
         await stream.send_message(response)
@@ -125,10 +106,7 @@ class BaseRPCService(BaseServiceBase, ResourceRPCServiceBase[Base]):
     async def DoCommand(self, stream: Stream[DoCommandRequest, DoCommandResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        try:
-            base = self.get_resource(request.name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        base = self.get_resource(request.name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         result = await base.do_command(command=struct_to_dict(request.command), timeout=timeout, metadata=stream.metadata)
         response = DoCommandResponse(result=dict_to_struct(result))

--- a/src/viam/components/board/service.py
+++ b/src/viam/components/board/service.py
@@ -42,10 +42,7 @@ class BoardRPCService(BoardServiceBase, ResourceRPCServiceBase[Board]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            board = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        board = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         status = await board.status(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = StatusResponse(status=status)
@@ -55,8 +52,8 @@ class BoardRPCService(BoardServiceBase, ResourceRPCServiceBase[Board]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
+        board = self.get_resource(name)
         try:
-            board = self.get_resource(name)
             pin = await board.gpio_pin_by_name(request.pin)
         except ResourceNotFoundError as e:
             raise e.grpc_error
@@ -69,8 +66,8 @@ class BoardRPCService(BoardServiceBase, ResourceRPCServiceBase[Board]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
+        board = self.get_resource(name)
         try:
-            board = self.get_resource(name)
             pin = await board.gpio_pin_by_name(request.pin)
         except ResourceNotFoundError as e:
             raise e.grpc_error
@@ -83,8 +80,8 @@ class BoardRPCService(BoardServiceBase, ResourceRPCServiceBase[Board]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
+        board = self.get_resource(name)
         try:
-            board = self.get_resource(name)
             pin = await board.gpio_pin_by_name(request.pin)
         except ResourceNotFoundError as e:
             raise e.grpc_error
@@ -97,8 +94,8 @@ class BoardRPCService(BoardServiceBase, ResourceRPCServiceBase[Board]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
+        board = self.get_resource(name)
         try:
-            board = self.get_resource(name)
             pin = await board.gpio_pin_by_name(request.pin)
         except ResourceNotFoundError as e:
             raise e.grpc_error
@@ -111,8 +108,8 @@ class BoardRPCService(BoardServiceBase, ResourceRPCServiceBase[Board]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
+        board = self.get_resource(name)
         try:
-            board = self.get_resource(name)
             pin = await board.gpio_pin_by_name(request.pin)
         except ResourceNotFoundError as e:
             raise e.grpc_error
@@ -125,8 +122,8 @@ class BoardRPCService(BoardServiceBase, ResourceRPCServiceBase[Board]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
+        board = self.get_resource(name)
         try:
-            board = self.get_resource(name)
             pin = await board.gpio_pin_by_name(request.pin)
         except ResourceNotFoundError as e:
             raise e.grpc_error
@@ -139,8 +136,8 @@ class BoardRPCService(BoardServiceBase, ResourceRPCServiceBase[Board]):
         request = await stream.recv_message()
         assert request is not None
         name = request.board_name
+        board = self.get_resource(name)
         try:
-            board = self.get_resource(name)
             analog_reader = await board.analog_reader_by_name(request.analog_reader_name)
         except ResourceNotFoundError as e:
             raise e.grpc_error
@@ -153,8 +150,8 @@ class BoardRPCService(BoardServiceBase, ResourceRPCServiceBase[Board]):
         request = await stream.recv_message()
         assert request is not None
         name = request.board_name
+        board = self.get_resource(name)
         try:
-            board = self.get_resource(name)
             interrupt = await board.digital_interrupt_by_name(request.digital_interrupt_name)
         except ResourceNotFoundError as e:
             raise e.grpc_error
@@ -167,10 +164,7 @@ class BoardRPCService(BoardServiceBase, ResourceRPCServiceBase[Board]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            board = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        board = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await board.set_power_mode(
             mode=request.power_mode,
@@ -184,10 +178,7 @@ class BoardRPCService(BoardServiceBase, ResourceRPCServiceBase[Board]):
     async def DoCommand(self, stream: Stream[DoCommandRequest, DoCommandResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        try:
-            board = self.get_resource(request.name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        board = self.get_resource(request.name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         result = await board.do_command(command=struct_to_dict(request.command), timeout=timeout, metadata=stream.metadata)
         response = DoCommandResponse(result=dict_to_struct(result))

--- a/src/viam/components/camera/service.py
+++ b/src/viam/components/camera/service.py
@@ -1,7 +1,6 @@
 from google.api.httpbody_pb2 import HttpBody
 from grpclib.server import Stream
 
-from viam.errors import ResourceNotFoundError
 from viam.media.video import CameraMimeType
 from viam.proto.common import DoCommandRequest, DoCommandResponse
 from viam.proto.component.camera import (
@@ -31,10 +30,7 @@ class CameraRPCService(CameraServiceBase, ResourceRPCServiceBase[Camera]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            camera = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        camera = self.get_resource(name)
 
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         image = await camera.get_image(request.mime_type, timeout=timeout, metadata=stream.metadata)
@@ -55,10 +51,7 @@ class CameraRPCService(CameraServiceBase, ResourceRPCServiceBase[Camera]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            camera = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        camera = self.get_resource(name)
         try:
             mimetype = CameraMimeType(request.mime_type)
         except ValueError:
@@ -76,10 +69,7 @@ class CameraRPCService(CameraServiceBase, ResourceRPCServiceBase[Camera]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            camera = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        camera = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         pc, mimetype = await camera.get_point_cloud(timeout=timeout, metadata=stream.metadata)
         response = GetPointCloudResponse(mime_type=mimetype, point_cloud=pc)
@@ -89,10 +79,7 @@ class CameraRPCService(CameraServiceBase, ResourceRPCServiceBase[Camera]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            camera = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        camera = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         properties = await camera.get_properties(timeout=timeout, metadata=stream.metadata)
         response = GetPropertiesResponse(
@@ -105,10 +92,7 @@ class CameraRPCService(CameraServiceBase, ResourceRPCServiceBase[Camera]):
     async def DoCommand(self, stream: Stream[DoCommandRequest, DoCommandResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        try:
-            camera = self.get_resource(request.name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        camera = self.get_resource(request.name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         result = await camera.do_command(command=struct_to_dict(request.command), timeout=timeout, metadata=stream.metadata)
         response = DoCommandResponse(result=dict_to_struct(result))

--- a/src/viam/components/encoder/service.py
+++ b/src/viam/components/encoder/service.py
@@ -1,6 +1,5 @@
 from grpclib.server import Stream
 
-from viam.errors import ResourceNotFoundError
 from viam.proto.common import DoCommandRequest, DoCommandResponse
 from viam.proto.component.encoder import (
     EncoderServiceBase,
@@ -28,10 +27,7 @@ class EncoderRPCService(EncoderServiceBase, ResourceRPCServiceBase[Encoder]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            encoder = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        encoder = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await encoder.reset_position(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         await stream.send_message(ResetPositionResponse())
@@ -40,10 +36,7 @@ class EncoderRPCService(EncoderServiceBase, ResourceRPCServiceBase[Encoder]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            encoder = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        encoder = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         position, pos_type = await encoder.get_position(
             position_type=request.position_type, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata
@@ -54,10 +47,7 @@ class EncoderRPCService(EncoderServiceBase, ResourceRPCServiceBase[Encoder]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            encoder = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        encoder = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         properties = await encoder.get_properties(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetPropertiesResponse(**properties.__dict__)
@@ -66,10 +56,7 @@ class EncoderRPCService(EncoderServiceBase, ResourceRPCServiceBase[Encoder]):
     async def DoCommand(self, stream: Stream[DoCommandRequest, DoCommandResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        try:
-            encoder = self.get_resource(request.name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        encoder = self.get_resource(request.name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         result = await encoder.do_command(command=struct_to_dict(request.command), timeout=timeout, metadata=stream.metadata)
         response = DoCommandResponse(result=dict_to_struct(result))

--- a/src/viam/components/gantry/service.py
+++ b/src/viam/components/gantry/service.py
@@ -1,6 +1,5 @@
 from grpclib.server import Stream
 
-from viam.errors import ResourceNotFoundError
 from viam.proto.common import DoCommandRequest, DoCommandResponse
 from viam.proto.component.gantry import (
     GantryServiceBase,
@@ -32,10 +31,7 @@ class GantryRPCService(GantryServiceBase, ResourceRPCServiceBase[Gantry]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            gantry = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gantry = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         position = await gantry.get_position(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetPositionResponse(positions_mm=position)
@@ -45,10 +41,7 @@ class GantryRPCService(GantryServiceBase, ResourceRPCServiceBase[Gantry]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            gantry = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gantry = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await gantry.move_to_position(
             list(request.positions_mm), extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata
@@ -60,10 +53,7 @@ class GantryRPCService(GantryServiceBase, ResourceRPCServiceBase[Gantry]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            gantry = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gantry = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         lengths = await gantry.get_lengths(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetLengthsResponse(lengths_mm=lengths)
@@ -73,10 +63,7 @@ class GantryRPCService(GantryServiceBase, ResourceRPCServiceBase[Gantry]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            gantry = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gantry = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await gantry.stop(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = StopResponse()
@@ -86,10 +73,7 @@ class GantryRPCService(GantryServiceBase, ResourceRPCServiceBase[Gantry]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            gantry = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gantry = self.get_resource(name)
         is_moving = await gantry.is_moving()
         response = IsMovingResponse(is_moving=is_moving)
         await stream.send_message(response)
@@ -97,10 +81,7 @@ class GantryRPCService(GantryServiceBase, ResourceRPCServiceBase[Gantry]):
     async def DoCommand(self, stream: Stream[DoCommandRequest, DoCommandResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        try:
-            gantry = self.get_resource(request.name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gantry = self.get_resource(request.name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         result = await gantry.do_command(command=struct_to_dict(request.command), timeout=timeout, metadata=stream.metadata)
         response = DoCommandResponse(result=dict_to_struct(result))

--- a/src/viam/components/generic/service.py
+++ b/src/viam/components/generic/service.py
@@ -2,7 +2,6 @@ from grpclib import GRPCError, Status
 from grpclib.server import Stream
 
 from viam.components.component_base import ComponentBase
-from viam.errors import ResourceNotFoundError
 from viam.proto.common import DoCommandRequest, DoCommandResponse
 from viam.proto.component.generic import GenericServiceBase
 from viam.resource.rpc_service_base import ResourceRPCServiceBase
@@ -22,10 +21,7 @@ class GenericRPCService(GenericServiceBase, ResourceRPCServiceBase[ComponentBase
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            component = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        component = self.get_resource(name)
         try:
             timeout = stream.deadline.time_remaining() if stream.deadline else None
             result = await component.do_command(struct_to_dict(request.command), timeout=timeout, metadata=stream.metadata)

--- a/src/viam/components/gripper/service.py
+++ b/src/viam/components/gripper/service.py
@@ -1,6 +1,5 @@
 from grpclib.server import Stream
 
-from viam.errors import ResourceNotFoundError
 from viam.proto.common import DoCommandRequest, DoCommandResponse
 from viam.proto.component.gripper import (
     GrabRequest,
@@ -30,10 +29,7 @@ class GripperRPCService(GripperServiceBase, ResourceRPCServiceBase[Gripper]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            gripper = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gripper = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await gripper.open(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = OpenResponse()
@@ -43,10 +39,7 @@ class GripperRPCService(GripperServiceBase, ResourceRPCServiceBase[Gripper]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            gripper = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gripper = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         grabbed = await gripper.grab(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GrabResponse(success=grabbed)
@@ -55,10 +48,7 @@ class GripperRPCService(GripperServiceBase, ResourceRPCServiceBase[Gripper]):
     async def Stop(self, stream: Stream[StopRequest, StopResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        try:
-            gripper = self.get_resource(request.name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gripper = self.get_resource(request.name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await gripper.stop(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         await stream.send_message(StopResponse())
@@ -67,10 +57,7 @@ class GripperRPCService(GripperServiceBase, ResourceRPCServiceBase[Gripper]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            gripper = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gripper = self.get_resource(name)
         is_moving = await gripper.is_moving()
         response = IsMovingResponse(is_moving=is_moving)
         await stream.send_message(response)
@@ -78,10 +65,7 @@ class GripperRPCService(GripperServiceBase, ResourceRPCServiceBase[Gripper]):
     async def DoCommand(self, stream: Stream[DoCommandRequest, DoCommandResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        try:
-            gripper = self.get_resource(request.name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gripper = self.get_resource(request.name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         result = await gripper.do_command(command=struct_to_dict(request.command), timeout=timeout, metadata=stream.metadata)
         response = DoCommandResponse(result=dict_to_struct(result))

--- a/src/viam/components/motor/service.py
+++ b/src/viam/components/motor/service.py
@@ -1,6 +1,5 @@
 from grpclib.server import Stream
 
-from viam.errors import ResourceNotFoundError
 from viam.proto.common import DoCommandRequest, DoCommandResponse
 from viam.proto.component.motor import (
     GetPositionRequest,
@@ -40,10 +39,7 @@ class MotorRPCService(MotorServiceBase, ResourceRPCServiceBase[Motor]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            motor = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        motor = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await motor.set_power(request.power_pct, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         await stream.send_message(SetPowerResponse())
@@ -52,10 +48,7 @@ class MotorRPCService(MotorServiceBase, ResourceRPCServiceBase[Motor]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            motor = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        motor = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await motor.go_for(request.rpm, request.revolutions, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         await stream.send_message(GoForResponse())
@@ -64,10 +57,7 @@ class MotorRPCService(MotorServiceBase, ResourceRPCServiceBase[Motor]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            motor = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        motor = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await motor.go_to(
             request.rpm, request.position_revolutions, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata
@@ -78,10 +68,7 @@ class MotorRPCService(MotorServiceBase, ResourceRPCServiceBase[Motor]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            motor = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        motor = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await motor.reset_zero_position(request.offset, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         await stream.send_message(ResetZeroPositionResponse())
@@ -90,10 +77,7 @@ class MotorRPCService(MotorServiceBase, ResourceRPCServiceBase[Motor]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            motor = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        motor = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         position = await motor.get_position(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         await stream.send_message(GetPositionResponse(position=position))
@@ -102,10 +86,7 @@ class MotorRPCService(MotorServiceBase, ResourceRPCServiceBase[Motor]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            motor = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        motor = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         properties = await motor.get_properties(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetPropertiesResponse(**properties.__dict__)
@@ -115,10 +96,7 @@ class MotorRPCService(MotorServiceBase, ResourceRPCServiceBase[Motor]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            motor = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        motor = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await motor.stop(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = StopResponse()
@@ -128,10 +106,7 @@ class MotorRPCService(MotorServiceBase, ResourceRPCServiceBase[Motor]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            motor = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        motor = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         is_powered, power_pct = await motor.is_powered(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         await stream.send_message(IsPoweredResponse(is_on=is_powered, power_pct=power_pct))
@@ -140,10 +115,7 @@ class MotorRPCService(MotorServiceBase, ResourceRPCServiceBase[Motor]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            motor = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        motor = self.get_resource(name)
         is_moving = await motor.is_moving()
         response = IsMovingResponse(is_moving=is_moving)
         await stream.send_message(response)
@@ -151,10 +123,7 @@ class MotorRPCService(MotorServiceBase, ResourceRPCServiceBase[Motor]):
     async def DoCommand(self, stream: Stream[DoCommandRequest, DoCommandResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        try:
-            motor = self.get_resource(request.name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        motor = self.get_resource(request.name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         result = await motor.do_command(command=struct_to_dict(request.command), timeout=timeout, metadata=stream.metadata)
         response = DoCommandResponse(result=dict_to_struct(result))

--- a/src/viam/components/movement_sensor/service.py
+++ b/src/viam/components/movement_sensor/service.py
@@ -1,7 +1,6 @@
 from grpclib.server import Stream
 
 from viam.components.movement_sensor.movement_sensor import MovementSensor
-from viam.errors import ResourceNotFoundError
 from viam.proto.common import DoCommandRequest, DoCommandResponse
 from viam.proto.component.movementsensor import (
     GetAccuracyRequest,
@@ -37,10 +36,7 @@ class MovementSensorRPCService(MovementSensorServiceBase, ResourceRPCServiceBase
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            sensor = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        sensor = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         velocity = await sensor.get_linear_velocity(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetLinearVelocityResponse(linear_velocity=velocity)
@@ -50,10 +46,7 @@ class MovementSensorRPCService(MovementSensorServiceBase, ResourceRPCServiceBase
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            sensor = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        sensor = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         velocity = await sensor.get_angular_velocity(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetAngularVelocityResponse(angular_velocity=velocity)
@@ -63,10 +56,7 @@ class MovementSensorRPCService(MovementSensorServiceBase, ResourceRPCServiceBase
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            sensor = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        sensor = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         acceleration = await sensor.get_linear_acceleration(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetLinearAccelerationResponse(linear_acceleration=acceleration)
@@ -76,10 +66,7 @@ class MovementSensorRPCService(MovementSensorServiceBase, ResourceRPCServiceBase
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            sensor = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        sensor = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         heading = await sensor.get_compass_heading(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetCompassHeadingResponse(value=heading)
@@ -89,10 +76,7 @@ class MovementSensorRPCService(MovementSensorServiceBase, ResourceRPCServiceBase
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            sensor = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        sensor = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         orientation = await sensor.get_orientation(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetOrientationResponse(orientation=orientation)
@@ -102,10 +86,7 @@ class MovementSensorRPCService(MovementSensorServiceBase, ResourceRPCServiceBase
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            sensor = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        sensor = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         point, alt = await sensor.get_position(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetPositionResponse(coordinate=point, altitude_m=alt)
@@ -115,10 +96,7 @@ class MovementSensorRPCService(MovementSensorServiceBase, ResourceRPCServiceBase
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            sensor = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        sensor = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         response = await sensor.get_properties(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         await stream.send_message(response.proto)
@@ -127,10 +105,7 @@ class MovementSensorRPCService(MovementSensorServiceBase, ResourceRPCServiceBase
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            sensor = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        sensor = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         accuracy = await sensor.get_accuracy(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         response = GetAccuracyResponse(accuracy=accuracy)
@@ -139,10 +114,7 @@ class MovementSensorRPCService(MovementSensorServiceBase, ResourceRPCServiceBase
     async def DoCommand(self, stream: Stream[DoCommandRequest, DoCommandResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        try:
-            sensor = self.get_resource(request.name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        sensor = self.get_resource(request.name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         result = await sensor.do_command(command=struct_to_dict(request.command), timeout=timeout, metadata=stream.metadata)
         response = DoCommandResponse(result=dict_to_struct(result))

--- a/src/viam/components/servo/service.py
+++ b/src/viam/components/servo/service.py
@@ -1,6 +1,5 @@
 from grpclib.server import Stream
 
-from viam.errors import ResourceNotFoundError
 from viam.proto.common import DoCommandRequest, DoCommandResponse
 from viam.proto.component.servo import (
     GetPositionRequest,
@@ -30,10 +29,7 @@ class ServoRPCService(ServoServiceBase, ResourceRPCServiceBase[Servo]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            servo = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        servo = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await servo.move(request.angle_deg, extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         await stream.send_message(MoveResponse())
@@ -42,10 +38,7 @@ class ServoRPCService(ServoServiceBase, ResourceRPCServiceBase[Servo]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            servo = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        servo = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         position = await servo.get_position(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         resp = GetPositionResponse(position_deg=position)
@@ -55,10 +48,7 @@ class ServoRPCService(ServoServiceBase, ResourceRPCServiceBase[Servo]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            servo = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        servo = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         await servo.stop(extra=struct_to_dict(request.extra), timeout=timeout, metadata=stream.metadata)
         await stream.send_message(StopResponse())
@@ -67,20 +57,14 @@ class ServoRPCService(ServoServiceBase, ResourceRPCServiceBase[Servo]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            servo = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        servo = self.get_resource(name)
         is_moving = await servo.is_moving()
         await stream.send_message(IsMovingResponse(is_moving=is_moving))
 
     async def DoCommand(self, stream: Stream[DoCommandRequest, DoCommandResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        try:
-            servo = self.get_resource(request.name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        servo = self.get_resource(request.name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         result = await servo.do_command(command=struct_to_dict(request.command), timeout=timeout, metadata=stream.metadata)
         response = DoCommandResponse(result=dict_to_struct(result))

--- a/src/viam/resource/rpc_service_base.py
+++ b/src/viam/resource/rpc_service_base.py
@@ -2,6 +2,7 @@ import abc
 from typing import Generic, Type
 
 from viam.components.component_base import ComponentBase
+from viam.errors import ResourceNotFoundError
 from viam.resource.manager import ResourceManager, ResourceType
 from viam.rpc.types import RPCServiceBase
 from viam.services.service_base import ServiceBase
@@ -31,11 +32,14 @@ class ResourceRPCServiceBase(abc.ABC, RPCServiceBase, Generic[ResourceType]):
             name (str): Name of the resource
 
         Raises:
-            ResourceNotFoundError
+            GRPCError with the status code Status.NOT_FOUND
 
         Returns:
             ResourceType: The resource
         """
-        if self.RESOURCE_TYPE == ComponentBase or self.RESOURCE_TYPE == ResourceBase or self.RESOURCE_TYPE == ServiceBase:
-            return self.manager._resource_by_name_only(name)  # type: ignore
-        return self.manager.get_resource(self.RESOURCE_TYPE, self.RESOURCE_TYPE.get_resource_name(name))  # type: ignore
+        try:
+            if self.RESOURCE_TYPE == ComponentBase or self.RESOURCE_TYPE == ResourceBase or self.RESOURCE_TYPE == ServiceBase:
+                return self.manager._resource_by_name_only(name)  # type: ignore
+            return self.manager.get_resource(self.RESOURCE_TYPE, self.RESOURCE_TYPE.get_resource_name(name))  # type: ignore
+        except ResourceNotFoundError as e:
+            raise e.grpc_error

--- a/src/viam/services/mlmodel/service.py
+++ b/src/viam/services/mlmodel/service.py
@@ -1,6 +1,5 @@
 from grpclib.server import Stream
 
-from viam.errors import ResourceNotFoundError
 from viam.proto.service.mlmodel import InferRequest, InferResponse, MetadataRequest, MetadataResponse, MLModelServiceBase
 from viam.resource.rpc_service_base import ResourceRPCServiceBase
 from viam.utils import dict_to_struct
@@ -19,10 +18,7 @@ class MLModelRPCService(MLModelServiceBase, ResourceRPCServiceBase):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            mlmodel = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        mlmodel = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         output_data = await mlmodel.infer(input_data=request.input_data, timeout=timeout)
         response = InferResponse(output_data=dict_to_struct(output_data))
@@ -32,10 +28,7 @@ class MLModelRPCService(MLModelServiceBase, ResourceRPCServiceBase):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            mlmodel = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        mlmodel = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         metadata = await mlmodel.metadata(timeout=timeout)
         response = MetadataResponse(metadata=metadata)

--- a/src/viam/services/slam/service.py
+++ b/src/viam/services/slam/service.py
@@ -1,6 +1,5 @@
 from grpclib.server import Stream
 
-from viam.errors import ResourceNotFoundError
 from viam.proto.common import DoCommandRequest, DoCommandResponse
 from viam.proto.service.slam import (
     GetInternalStateRequest,
@@ -28,10 +27,7 @@ class SLAMRPCService(SLAMServiceBase, ResourceRPCServiceBase[SLAM]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            slam = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        slam = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         chunks = await slam.get_internal_state(timeout=timeout)
         for chunk in chunks:
@@ -42,10 +38,7 @@ class SLAMRPCService(SLAMServiceBase, ResourceRPCServiceBase[SLAM]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            slam = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        slam = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         chunks = await slam.get_point_cloud_map(timeout=timeout)
         for chunk in chunks:
@@ -56,10 +49,7 @@ class SLAMRPCService(SLAMServiceBase, ResourceRPCServiceBase[SLAM]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            slam = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        slam = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         position = await slam.get_position(timeout=timeout)
         response = GetPositionResponse(pose=position)
@@ -68,10 +58,7 @@ class SLAMRPCService(SLAMServiceBase, ResourceRPCServiceBase[SLAM]):
     async def DoCommand(self, stream: Stream[DoCommandRequest, DoCommandResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        try:
-            slam = self.get_resource(request.name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        slam = self.get_resource(request.name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         result = await slam.do_command(command=struct_to_dict(request.command), timeout=timeout, metadata=stream.metadata)
         response = DoCommandResponse(result=dict_to_struct(result))

--- a/tests/mocks/module/gizmo/api.py
+++ b/tests/mocks/module/gizmo/api.py
@@ -6,7 +6,6 @@ from grpclib.server import Stream
 
 from viam.components.component_base import ComponentBase
 from viam.components.generic.client import do_command
-from viam.errors import ResourceNotFoundError
 from viam.resource.rpc_service_base import ResourceRPCServiceBase
 from viam.resource.types import RESOURCE_TYPE_COMPONENT, Subtype
 from viam.utils import ValueTypes
@@ -61,10 +60,7 @@ class GizmoService(GizmoServiceBase, ResourceRPCServiceBase[Gizmo]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            gizmo = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gizmo = self.get_resource(name)
         resp = await gizmo.do_one(request.arg1)
         response = DoOneResponse(ret1=resp)
         await stream.send_message(response)
@@ -76,10 +72,7 @@ class GizmoService(GizmoServiceBase, ResourceRPCServiceBase[Gizmo]):
         if len(set(names)) != 1:
             raise Exception("Unexpectedly received requests for multiple Gizmos")
         name = names[0]
-        try:
-            gizmo = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gizmo = self.get_resource(name)
         resp = await gizmo.do_one_client_stream(args)
         response = DoOneClientStreamResponse(ret1=resp)
         await stream.send_message(response)
@@ -88,10 +81,7 @@ class GizmoService(GizmoServiceBase, ResourceRPCServiceBase[Gizmo]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            gizmo = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gizmo = self.get_resource(name)
         resps = await gizmo.do_one_server_stream(request.arg1)
         for resp in resps:
             await stream.send_message(DoOneServerStreamResponse(ret1=resp))
@@ -106,10 +96,7 @@ class GizmoService(GizmoServiceBase, ResourceRPCServiceBase[Gizmo]):
                 continue
             if name != request.name:
                 raise Exception("Unexpectedly received requests for multiple Gizmos")
-        try:
-            gizmo = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gizmo = self.get_resource(name)
 
         resps = await gizmo.do_one_bidi_stream(args)
         for resp in resps:
@@ -119,10 +106,7 @@ class GizmoService(GizmoServiceBase, ResourceRPCServiceBase[Gizmo]):
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            gizmo = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        gizmo = self.get_resource(name)
         resp = await gizmo.do_two(request.arg1)
         response = DoTwoResponse(ret1=resp)
         await stream.send_message(response)

--- a/tests/mocks/module/summation/api.py
+++ b/tests/mocks/module/summation/api.py
@@ -4,7 +4,6 @@ from typing import Final, Sequence
 from grpclib.client import Channel
 from grpclib.server import Stream
 
-from viam.errors import ResourceNotFoundError
 from viam.resource.rpc_service_base import ResourceRPCServiceBase
 from viam.resource.types import RESOURCE_TYPE_SERVICE, Subtype
 from viam.services.service_base import ServiceBase
@@ -32,10 +31,7 @@ class SummationRPCService(SummationServiceBase, ResourceRPCServiceBase[Summation
         request = await stream.recv_message()
         assert request is not None
         name = request.name
-        try:
-            service = self.get_resource(name)
-        except ResourceNotFoundError as e:
-            raise e.grpc_error
+        service = self.get_resource(name)
         resp = await service.sum(request.numbers)
         await stream.send_message(SumResponse(sum=resp))
 


### PR DESCRIPTION
Moved throwing of the `ResourceNotFoundError.grpc_error` to the superclass of all `<Resource>RPCService`s. This reduces a ton of boilerplate, especially around creating new services/module services