### PR TITLE
Select default mime type when empty

### DIFF
--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -353,7 +353,7 @@ class MockCamera(Camera):
         self.image = Image.new("RGBA", (100, 100), "#AABBCCDD")
         self.point_cloud = b"THIS IS A POINT CLOUD"
         self.props = Camera.Properties(
-            True,
+            False,
             IntrinsicParameters(width_px=1, height_px=2, focal_x_px=3, focal_y_px=4, center_x_px=5, center_y_px=6),
             DistortionParameters(model="no_distortion"),
         )
@@ -372,7 +372,7 @@ class MockCamera(Camera):
 
     async def get_point_cloud(self, *, timeout: Optional[float] = None, **kwargs) -> Tuple[bytes, str]:
         self.timeout = timeout
-        return self.point_cloud, CameraMimeType.PCD.value
+        return self.point_cloud, CameraMimeType.PCD
 
     async def get_properties(self, *, timeout: Optional[float] = None, **kwargs) -> Camera.Properties:
         self.timeout = timeout

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -49,7 +49,7 @@ def point_cloud() -> bytes:
 @pytest.fixture(scope="function")
 def properties() -> Camera.Properties:
     return Camera.Properties(
-        True,
+        False,
         IntrinsicParameters(width_px=1, height_px=2, focal_x_px=3, focal_y_px=4, center_x_px=5, center_y_px=6),
         DistortionParameters(model="no_distortion"),
     )
@@ -141,6 +141,11 @@ class TestService:
             img = Image.frombytes("RGBA", (100, 100), response.image, "raw")
             assert img == image
             assert response.mime_type == "unknown"
+
+            # Test empty mime type. Empty mime type should default to JPEG for non-depth cameras
+            request = GetImageRequest(name="camera")
+            response: GetImageResponse = await client.GetImage(request)
+            assert service._camera_mime_types["camera"] == CameraMimeType.JPEG
 
     @pytest.mark.asyncio
     async def test_render_frame(self, camera: MockCamera, service: CameraRPCService, image: Image.Image):


### PR DESCRIPTION
When the mime type is empty on a `camera.get_image` request, python was sending back an empty mime type instead of choosing a default mime type. 

I basically copied what's going on in RDK, which I saw @kharijarrett implemented, so tagging him as a reviewer.

Cc: @thegreatco this should help with oakd