### PR TITLE
Fix session client for Python versions <= 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "viam-sdk"
-version = "0.4.0rc1"
+version = "0.4.0"
 description = "Viam Robotics Python SDK"
 authors = [ "Naveed <naveed@viam.com>" ]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "viam-sdk"
-version = "0.3.1"
+version = "0.4.0rc1"
 description = "Viam Robotics Python SDK"
 authors = [ "Naveed <naveed@viam.com>" ]
 license = "Apache-2.0"

--- a/src/viam/components/arm/service.py
+++ b/src/viam/components/arm/service.py
@@ -1,6 +1,6 @@
 from grpclib.server import Stream
-from viam.errors import MethodNotImplementedError
 
+from viam.errors import MethodNotImplementedError
 from viam.proto.common import (
     DoCommandRequest,
     DoCommandResponse,

--- a/src/viam/resource/rpc_service_base.py
+++ b/src/viam/resource/rpc_service_base.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Type
 
 from viam.components.component_base import ComponentBase
 from viam.errors import ResourceNotFoundError

--- a/src/viam/robot/service.py
+++ b/src/viam/robot/service.py
@@ -4,6 +4,8 @@ from typing import Any, Dict, Iterable, List, Set
 from grpclib.server import Stream
 
 from viam import logging
+from viam.components.movement_sensor import MovementSensor
+from viam.components.sensor import Sensor
 from viam.errors import MethodNotImplementedError, ViamGRPCError
 from viam.proto.common import ResourceName
 from viam.proto.robot import (
@@ -43,8 +45,6 @@ from viam.proto.robot import (
 from viam.resource.registry import Registry
 from viam.resource.rpc_service_base import ResourceRPCServiceBase
 from viam.utils import resource_names_for_resource, struct_to_dict
-from viam.components.sensor import Sensor
-from viam.components.movement_sensor import MovementSensor
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/viam/sessions_client.py
+++ b/src/viam/sessions_client.py
@@ -31,7 +31,7 @@ EXEMPT_METADATA_METHODS = frozenset(
 
 
 def loop_kwargs():
-    if sys.version_info[:2] <= (3, 9):
+    if sys.version_info <= (3, 9):
         return {"loop": asyncio.get_running_loop()}
     return {}
 

--- a/src/viam/sessions_client.py
+++ b/src/viam/sessions_client.py
@@ -31,8 +31,9 @@ EXEMPT_METADATA_METHODS = frozenset(
 
 
 def loop_kwargs():
-    loop = asyncio.get_running_loop()
-    return {"loop": loop} if sys.version_info[:2] <= (3, 9) else {}
+    if sys.version_info[:2] <= (3, 9):
+        return {"loop": asyncio.get_running_loop()}
+    return {}
 
 
 async def delay(coro, seconds):

--- a/src/viam/sessions_client.py
+++ b/src/viam/sessions_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 from datetime import timedelta
 from typing import Optional
 
@@ -29,8 +30,13 @@ EXEMPT_METADATA_METHODS = frozenset(
 )
 
 
+def loop_kwargs():
+    loop = asyncio.get_running_loop()
+    return {"loop": loop} if sys.version_info[:2] <= (3, 9) else {}
+
+
 async def delay(coro, seconds):
-    await asyncio.sleep(seconds)
+    await asyncio.sleep(seconds, **loop_kwargs())
     await coro
 
 
@@ -42,7 +48,7 @@ class SessionsClient:
 
     _current_id: str = ""
     _disabled: bool = False
-    _lock = asyncio.Lock()
+    _lock = asyncio.Lock(**loop_kwargs())
     _supported: Optional[bool] = None
     _heartbeat_interval: Optional[timedelta] = None
 

--- a/src/viam/sessions_client.py
+++ b/src/viam/sessions_client.py
@@ -48,7 +48,6 @@ class SessionsClient:
 
     _current_id: str = ""
     _disabled: bool = False
-    _lock = asyncio.Lock(**loop_kwargs())
     _supported: Optional[bool] = None
     _heartbeat_interval: Optional[timedelta] = None
 
@@ -56,6 +55,7 @@ class SessionsClient:
         self.channel = channel
         self.client = RobotServiceStub(channel)
         self._disabled = disabled
+        self._lock = asyncio.Lock(**loop_kwargs())
 
         listen(self.channel, SendRequest, self._send_request)
         listen(self.channel, RecvTrailingMetadata, self._recv_trailers)


### PR DESCRIPTION
Fixes a regression in the session client for Python versions <= 3.9 that stemmed differences in `asyncio`'s before and after this version: https://docs.python.org/3/whatsnew/3.10.html#removed. This regression was exposed by our [integration tests](https://github.com/viamrobotics/sdk-integration-tests/actions/runs/5259145464).

```
=========================== short test summary info ============================
FAILED tests/test.py::TestIntegration::test_unary - RuntimeError: Task <Task pending name='Task-6' coro=<MovementSensorClient.get_linear_velocity() running at /usr/local/lib/python3.8/site-packages/viam/components/movement_sensor/client.py:51> cb=[gather.<locals>._done_callback() at /usr/local/lib/python3.8/asyncio/tasks.py:769]> got Future <Future pending> attached to a different loop
```

Testing:
* Built a new package from this branch via `poetry build`
* [Ran integration tests](https://github.com/viamrobotics/sdk-integration-tests/actions/runs/5260293298) against this package