### PR TITLE
RSDK-3775 - Fix unawaited warning

### DIFF
--- a/src/viam/sessions_client.py
+++ b/src/viam/sessions_client.py
@@ -35,12 +35,6 @@ def loop_kwargs():
         return {"loop": asyncio.get_running_loop()}
     return {}
 
-
-async def delay(coro, seconds):
-    await asyncio.sleep(seconds, **loop_kwargs())
-    await coro
-
-
 class SessionsClient:
     """
     A Session allows a client to express that it is actively connected and
@@ -63,9 +57,7 @@ class SessionsClient:
 
     def reset(self):
         if self._lock.locked():
-            print("psss")
             return
-        print("psss1")
 
         LOGGER.debug("resetting session")
         self._supported = None

--- a/src/viam/sessions_client.py
+++ b/src/viam/sessions_client.py
@@ -63,7 +63,9 @@ class SessionsClient:
 
     def reset(self):
         if self._lock.locked():
+            print("psss")
             return
+        print("psss1")
 
         LOGGER.debug("resetting session")
         self._supported = None
@@ -116,9 +118,21 @@ class SessionsClient:
                 self._heartbeat_interval = response.heartbeat_window.ToTimedelta()
                 self._current_id = response.id
 
+        # tick once to ensure heartbeats are supported
         await self._heartbeat_tick()
 
+        if self._supported:
+            # We send heartbeats slightly faster than the interval window to
+            # ensure that we don't fall outside of it and expire the session.
+            wait = self._heartbeat_interval.total_seconds() / 5
+            asyncio.create_task(self._heartbeat_task(wait), name=f"{_TASK_PREFIX}-heartbeat")
+
         return self._metadata
+
+    async def _heartbeat_task(self, wait: float):
+        while True:
+            await asyncio.sleep(wait)
+            await self._heartbeat_tick()
 
     async def _heartbeat_tick(self):
         if not self._supported:
@@ -139,10 +153,6 @@ class SessionsClient:
             self.reset()
         else:
             LOGGER.debug("Sent heartbeat successfully")
-            # We send heartbeats slightly faster than the interval window to
-            # ensure that we don't fall outside of it and expire the session.
-            wait = self._heartbeat_interval.total_seconds() / 5
-            asyncio.create_task(delay(self._heartbeat_tick(), wait), name=f"{_TASK_PREFIX}-heartbeat")
 
     @property
     def _metadata(self) -> _MetadataLike:

--- a/src/viam/sessions_client.py
+++ b/src/viam/sessions_client.py
@@ -122,7 +122,7 @@ class SessionsClient:
         return self._metadata
 
     async def _heartbeat_task(self, wait: float):
-        while True:
+        while self._supported:
             await asyncio.sleep(wait)
             await self._heartbeat_tick()
 


### PR DESCRIPTION
seems like having async tasks call themselves causes issues so refactored it a bit to resemble our other recurring tasks. (https://stackoverflow.com/questions/37512182/how-can-i-periodically-execute-a-function-with-asyncio)

behavior should be the same

![Screen Shot 2023-06-26 at 11 05 39 AM](https://github.com/viamrobotics/viam-python-sdk/assets/90270663/42d74a2d-9ad9-4dd6-a9b2-125e848f338c)