### PR TITLE
[RSDK-3634] Implement data.proto APIs that Add/Remove Tags

### DIFF
--- a/src/viam/app/client.py
+++ b/src/viam/app/client.py
@@ -1,5 +1,7 @@
-from grpclib.client import Channel
+from typing import Mapping
 from typing_extensions import Self
+
+from grpclib.client import Channel
 
 from viam import logging
 from viam.app.data.client import DataClient
@@ -9,11 +11,13 @@ LOGGER = logging.getLogger(__name__)
 
 
 class AppClient:
-    """gRPC client for all communication and interaction with app.
+    """
+    gRPC client for all communication and interaction with app.
 
     Use create() to instantiate an AppClient::
 
         AppClient.create(...)
+
     """
 
     @classmethod
@@ -34,12 +38,17 @@ class AppClient:
         return self
 
     _channel: Channel
-    _metadata: str
+    _metadata: Mapping[str, str]
     _closed: bool = False
 
     @property
     def data_client(self) -> DataClient:
         return DataClient(self._channel, self._metadata)
 
-    async def close(self):
-        raise NotImplementedError()
+    def close(self):
+        if self._closed:
+            LOGGER.debug("AppClient is already closed")
+            return
+        LOGGER.debug("Closing gRPC channel to app")
+        self._channel.close()
+        self._closed = True


### PR DESCRIPTION
This PR implements and adds docstrings to the gRPC methods that'll allow a DataClient to send a gGRPC request to app to add, remove, and retrieve tags. The PR also implements a function to retrieve bounding box labels. There are a few other minor changes throughout. Namely, some function signatures are updated to include defaults for certain parameters (i.e. empty filter), and the AppClient "close()" function is implemented with logging.