### PR TITLE
fix code sample warning

### DIFF
--- a/etc/code-samples-action.py
+++ b/etc/code-samples-action.py
@@ -9,4 +9,5 @@ with open("code-samples-warning.md", "w") as f:
     f.write("|component|function|\n")
     f.write("|-|-|\n")
     for k, v in data.items():
-        f.write(f"|{k}|{v}|\n")
+        func = v["func"]
+        f.write(f"|{k}|{func}|\n")


### PR DESCRIPTION
The code samples refactor changed our file format for adding code samples. This broke a script that warns users about breaking code samples. This fix adjusts that script to correctly get the component and function names