### PR TITLE
RSDK-3922 No hardcoding credential type in Python

### DIFF
--- a/examples/module/client.py
+++ b/examples/module/client.py
@@ -9,8 +9,11 @@ from viam.rpc.dial import Credentials, DialOptions
 
 
 async def connect():
-    creds = Credentials(type="<your authentication type here>", payload="<your authentication payload here>")
-    opts = RobotClient.Options(refresh_interval=0, dial_options=DialOptions(credentials=creds), log_level=logging.DEBUG)
+    creds = Credentials(type="<your authentication type here>",
+                        payload="<your authentication payload here>")
+    opts = RobotClient.Options(refresh_interval=0,
+                               dial_options=DialOptions(credentials=creds),
+                               log_level=logging.DEBUG)
     return await RobotClient.at_address("<your robot uri here>", opts)
 
 

--- a/examples/module/client.py
+++ b/examples/module/client.py
@@ -31,16 +31,16 @@ async def main():
     resp = await gizmo.do_two(False)
     print("do_two result:", resp)
 
-    # Certain types of streams are not currently supported by the viam-rust-utils library that python uses internally.
-    # If you are not using WebRTC, you can uncomment the following lines.
+    # # Certain types of streams are not currently supported by the viam-rust-utils library that python uses internally.
+    # # If you are not using WebRTC, you can uncomment the following lines.
 
-    # resp = await gizmo.do_one_server_stream("arg1")
-    # print("do_one_server_stream result:", resp)
+    # # resp = await gizmo.do_one_server_stream("arg1")
+    # # print("do_one_server_stream result:", resp)
 
-    # resp = await gizmo.do_one_bidi_stream(["arg1", "arg2", "arg3"])
-    # print("do_one_bidi_stream result:", resp)
+    # # resp = await gizmo.do_one_bidi_stream(["arg1", "arg2", "arg3"])
+    # # print("do_one_bidi_stream result:", resp)
 
-    # ####### SUMMATION ####### #
+    # # ####### SUMMATION ####### #
     summer = SummationService.from_robot(robot, name="mysum1")
     sum = await summer.sum([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     print(f"The sum of the numbers [0, 10) is {sum}")

--- a/examples/module/client.py
+++ b/examples/module/client.py
@@ -9,9 +9,9 @@ from viam.rpc.dial import Credentials, DialOptions
 
 
 async def connect():
-    creds = Credentials(type="robot-location-secret", payload="znm8jwc5ossauwmy24x7b9ts7ptb750ajg8bzmxv9utkoic2")
+    creds = Credentials(type="<your authentication type here>", payload="<your authentication payload here>")
     opts = RobotClient.Options(refresh_interval=0, dial_options=DialOptions(credentials=creds), log_level=logging.DEBUG)
-    return await RobotClient.at_address("rover1-main.myj4cbg09b.viam.cloud", opts)
+    return await RobotClient.at_address("<your robot uri here>", opts)
 
 
 async def main():

--- a/examples/module/client.py
+++ b/examples/module/client.py
@@ -9,12 +9,9 @@ from viam.rpc.dial import Credentials, DialOptions
 
 
 async def connect():
-    creds = Credentials(type="<your authentication type here>",
-                        payload="<your authentication payload here>")
-    opts = RobotClient.Options(refresh_interval=0,
-                               dial_options=DialOptions(credentials=creds),
-                               log_level=logging.DEBUG)
-    return await RobotClient.at_address("<your robot uri here>", opts)
+    creds = Credentials(type="robot-location-secret", payload="znm8jwc5ossauwmy24x7b9ts7ptb750ajg8bzmxv9utkoic2")
+    opts = RobotClient.Options(refresh_interval=0, dial_options=DialOptions(credentials=creds), log_level=logging.DEBUG)
+    return await RobotClient.at_address("rover1-main.myj4cbg09b.viam.cloud", opts)
 
 
 async def main():

--- a/examples/module/client.py
+++ b/examples/module/client.py
@@ -9,9 +9,9 @@ from viam.rpc.dial import Credentials, DialOptions
 
 
 async def connect():
-    creds = Credentials(type="robot-location-secret", payload="<ROBOT_LOCATION_SECRET>")
+    creds = Credentials(type="<your authentication type here>", payload="<your authentication payload here>")
     opts = RobotClient.Options(refresh_interval=0, dial_options=DialOptions(credentials=creds), log_level=logging.DEBUG)
-    return await RobotClient.at_address("<ROBOT_ADDRESS>", opts)
+    return await RobotClient.at_address("<your robot uri here>", opts)
 
 
 async def main():

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -30,7 +30,7 @@ class Credentials:
     Currently only supports robot location secret.
     """
 
-    type: Literal["robot-location-secret", "robot-secret"]
+    type: Union[Literal["robot-location-secret"], Literal["robot-secret"]]
     """The type of credential
     """
 

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -6,7 +6,7 @@ import ssl
 import sys
 import warnings
 from dataclasses import dataclass
-from typing import Callable, Optional, Tuple, Type, Union
+from typing import Callable, Literal, Optional, Tuple, Type, Union
 
 from grpclib.client import Channel, Stream
 from grpclib.const import Cardinality
@@ -30,7 +30,7 @@ class Credentials:
     Currently only supports robot location secret.
     """
 
-    type: str
+    type: Literal["robot-location-secret", "robot-secret"]
     """The type of credential
     """
 
@@ -98,11 +98,13 @@ def _host_port_from_url(url) -> Tuple[Optional[str], Optional[int]]:
     return (host, port)
 
 
-async def _get_access_token(channel: Channel, address: str, opts: DialOptions) -> str:
-    entity = opts.auth_entity if opts.auth_entity else re.sub(r"^(.*:\/\/)/", "", address)
+async def _get_access_token(channel: Channel, address: str,
+                            opts: DialOptions) -> str:
+    entity = opts.auth_entity if opts.auth_entity else re.sub(
+        r"^(.*:\/\/)/", "", address)
     creds = PBCredentials(
-        type=opts.credentials.type if opts.credentials else "", payload=opts.credentials.payload if opts.credentials else ""
-    )
+        type=opts.credentials.type if opts.credentials else "",
+        payload=opts.credentials.payload if opts.credentials else "")
     request = AuthenticateRequest(entity=entity, credentials=creds)
 
     auth_service = AuthServiceStub(channel=channel)
@@ -147,7 +149,13 @@ class AuthenticatedChannel(Channel):
     ) -> Stream[_SendType, _RecvType]:
         if not metadata and hasattr(self, "_metadata"):
             metadata = self._metadata
-        return super().request(name, cardinality, request_type, reply_type, timeout=timeout, deadline=deadline, metadata=metadata)
+        return super().request(name,
+                               cardinality,
+                               request_type,
+                               reply_type,
+                               timeout=timeout,
+                               deadline=deadline,
+                               metadata=metadata)
 
 
 @dataclass
@@ -163,7 +171,9 @@ class ViamChannel:
             except RuntimeError as e:
                 # ignore event loop is closed errors - robot is getting shutdown
                 if len(e.args) > 0 and e.args[0] == "Event loop is closed":
-                    LOGGER.debug("ViamChannel might not have shut down cleanly - Event loop was closed")
+                    LOGGER.debug(
+                        "ViamChannel might not have shut down cleanly - Event loop was closed"
+                    )
                     return
                 raise
             finally:
@@ -186,26 +196,32 @@ class _Runtime:
 
     def __init__(self) -> None:
         LOGGER.debug("Creating new viam-rust-utils runtime")
-        libname = pathlib.Path(__file__).parent.absolute() / f"libviam_rust_utils.{'dylib' if sys.platform == 'darwin' else 'so'}"
+        libname = pathlib.Path(__file__).parent.absolute(
+        ) / f"libviam_rust_utils.{'dylib' if sys.platform == 'darwin' else 'so'}"
         self._lib = ctypes.CDLL(libname.__str__())
         self._lib.init_rust_runtime.argtypes = ()
         self._lib.init_rust_runtime.restype = ctypes.c_void_p
 
-        self._lib.dial.argtypes = (ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_bool, ctypes.c_void_p)
+        self._lib.dial.argtypes = (ctypes.c_char_p, ctypes.c_char_p,
+                                   ctypes.c_char_p, ctypes.c_bool,
+                                   ctypes.c_void_p)
         self._lib.dial.restype = ctypes.c_void_p
 
-        self._lib.free_rust_runtime.argtypes = (ctypes.c_void_p,)
+        self._lib.free_rust_runtime.argtypes = (ctypes.c_void_p, )
         self._lib.free_rust_runtime.restype = None
 
-        self._lib.free_string.argtypes = (ctypes.c_void_p,)
+        self._lib.free_string.argtypes = (ctypes.c_void_p, )
         self._lib.free_string.restype = None
 
         self._ptr = self._lib.init_rust_runtime()
 
-    async def dial(self, address: str, options: DialOptions) -> Tuple[Optional[str], ctypes.c_void_p]:
+    async def dial(
+            self, address: str,
+            options: DialOptions) -> Tuple[Optional[str], ctypes.c_void_p]:
         type = options.credentials.type if options.credentials else ""
         payload = options.credentials.payload if options.credentials else ""
-        insecure = options.insecure or options.allow_insecure_with_creds_downgrade or (not type and not payload and options.allow_insecure_downgrade)
+        insecure = options.insecure or options.allow_insecure_with_creds_downgrade or (
+            not type and not payload and options.allow_insecure_downgrade)
 
         LOGGER.debug(f"Dialing {address} using viam-rust-utils library")
         path_ptr = await to_thread(
@@ -229,7 +245,8 @@ class _Runtime:
         self._lib.free_string(ptr)
 
 
-async def dial(address: str, options: Optional[DialOptions] = None) -> ViamChannel:
+async def dial(address: str,
+               options: Optional[DialOptions] = None) -> ViamChannel:
     opts = options if options else DialOptions()
     if opts.disable_webrtc:
         channel = await _dial_direct(address, options)
@@ -251,7 +268,8 @@ async def dial(address: str, options: Optional[DialOptions] = None) -> ViamChann
     raise ViamError(f"Unable to establish a connection to {address}")
 
 
-async def _dial_direct(address: str, options: Optional[DialOptions] = None) -> Channel:
+async def _dial_direct(address: str,
+                       options: Optional[DialOptions] = None) -> Channel:
     opts = options if options else DialOptions()
     insecure = opts.insecure
 
@@ -278,7 +296,8 @@ async def _dial_direct(address: str, options: Optional[DialOptions] = None) -> C
         downgrade = False
         with socket.create_connection((host, port)) as sock:
             try:
-                with ctx.wrap_socket(sock, server_hostname=server_hostname) as ssock:
+                with ctx.wrap_socket(sock,
+                                     server_hostname=server_hostname) as ssock:
                     _ = ssock.version()
             except ssl.SSLError as e:
                 if e.reason != "WRONG_VERSION_NUMBER":
@@ -294,7 +313,10 @@ async def _dial_direct(address: str, options: Optional[DialOptions] = None) -> C
             ctx = None
 
     if opts.credentials:
-        channel = AuthenticatedChannel(host, port, ssl=ctx, server_hostname=server_hostname)
+        channel = AuthenticatedChannel(host,
+                                       port,
+                                       ssl=ctx,
+                                       server_hostname=server_hostname)
         access_token = await _get_access_token(channel, address, opts)
         metadata = {"authorization": f"Bearer {access_token}"}
         channel._metadata = metadata
@@ -304,8 +326,11 @@ async def _dial_direct(address: str, options: Optional[DialOptions] = None) -> C
     return channel
 
 
-async def dial_direct(address: str, options: Optional[DialOptions] = None) -> Channel:
-    warnings.warn("dial_direct is deprecated. Use rpc.dial.dial instead.", DeprecationWarning, stacklevel=2)
+async def dial_direct(address: str,
+                      options: Optional[DialOptions] = None) -> Channel:
+    warnings.warn("dial_direct is deprecated. Use rpc.dial.dial instead.",
+                  DeprecationWarning,
+                  stacklevel=2)
     return await _dial_direct(address, options)
 
 


### PR DESCRIPTION
Credential type is currently hard-coded as robot-location-secret, but we’re starting to also use robot-secret. We should update to make this a configurable value. We made this change first in cpp-sdk but also needs to be done in python-sdk.