### PR TITLE
[RSDK 3953] change binary_data_by_ids() return type

### DIFF
--- a/src/viam/app/data/client.py
+++ b/src/viam/app/data/client.py
@@ -329,7 +329,6 @@ class DataClient:
         response: BoundingBoxLabelsByFilterResponse = await self._data_client.BoundingBoxLabelsByFilter(request, metadata=self._metadata)
         return response.labels
 
-    # TODO [DATA-1663]: Fix Timestamps bug.
     async def binary_data_capture_upload(
         self,
         part_id: str,
@@ -337,7 +336,6 @@ class DataClient:
         component_name: str,
         method_name: str,
         method_parameters: Optional[Mapping[str, Any]],
-        file_extension: Optional[str],
         tags: Optional[List[str]],
         timestamps: Optional[tuple[Timestamp, Timestamp]],
         binary_data: bytes
@@ -353,10 +351,9 @@ class DataClient:
             component_name (str): Name of the component used to capture the data.
             method_name (str): Name of the method used to capture the data.
             method_parameters (Optional[Mapping[str, Any]]): Optional dictionary of method parameters. No longer in active use.
-            file_extension (Optional[str]): Optional file extension of data being uploaded.
-            tags (Optional[List[str]]): Optional list of tags to allow for tag-based data filtering.
+            tags (Optional[List[str]]): Optional list of tags to allow for tag-based data filtering when retrieving data.
             timestamps (Optional[tuple[google.protobuf.timestamp_pb2.Timestamp, google.protobuf.timestamp_pb2.Timestamp]]): Optional tuple
-                containing Timestamps denoting the times this data was requested[0] and received[1] by the appropriate sensor.
+                containing `Timestamp`s denoting the times this data was requested[0] and received[1] by the appropriate sensor.
             binary_data (bytes): The data to be uploaded, respresented in bytes.
 
         Raises:
@@ -378,12 +375,11 @@ class DataClient:
             type=DataType.DATA_TYPE_BINARY_SENSOR,
             file_name=None,  # Not used in app.
             method_parameters=method_parameters if method_parameters else None,
-            file_extension=file_extension if file_extension else None,
+            file_extension=None,  # Will be stored as empty string "".
             tags=tags if tags else None,
         )
         _: DataCaptureUploadResponse = await self._data_capture_upload(metadata=metadata, sensor_contents=[sensor_contents])
 
-    # TODO [DATA-1663]: Fix Timestamps bug.
     async def tabular_data_capture_upload(
         self,
         part_id: str,
@@ -391,7 +387,6 @@ class DataClient:
         component_name: str,
         method_name: str,
         method_parameters: Optional[Mapping[str, Any]],
-        file_extension: Optional[str],
         tags: Optional[List[str]],
         timestamps: Optional[List[tuple[Timestamp, Timestamp]]],
         tabular_data: List[Mapping[str, Any]]
@@ -407,11 +402,10 @@ class DataClient:
             component_name (str): Name of the component used to capture the data.
             method_name (str): Name of the method used to capture the data.
             method_parameters (Optional[Mapping[str, Any]]): Optional dictionary of method parameters. No longer in active use.
-            file_extension (Optional[str]): Optional file extension of data being uploaded.
-            tags (Optional[List[str]]): Optional list of tags to allow for tag-based data filtering.
+            tags (Optional[List[str]]): Optional list of tags to allow for tag-based data filtering when retrieving data.
             timestamps (Optional[List[tuple[google.protobuf.timestamp_pb2.Timestamp, google.protobuf.timestamp_pb2.Timestamp]]]): Optional
-                list of tuples, each containing Timestamps denoting the times this data was requested[0] and received[1] by the appropriate
-                sensor.
+                list of tuples, each containing `Timestamp`s denoting the times this data was requested[0] and received[1] by the
+                appropriate sensor.
             tabular_data (List[Mapping[str, Any]]): List of the data to be uploaded, represented tabularly as a collection of dictionaries.
 
         Passing a list of tabular data and Timestamps with length n > 1 will result in n datapoints being uploaded, all tied to the same
@@ -419,7 +413,7 @@ class DataClient:
 
         Raises:
             GRPCError: If an invalid part ID is passed.
-            AssertionError: If a list of Timestamps is provided and its length does not match the length of the list of tabular data.
+            AssertionError: If a list of `Timestamp`s is provided and its length does not match the length of the list of tabular data.
         """
         sensor_contents = [None] * len(tabular_data)
         if timestamps:
@@ -444,7 +438,7 @@ class DataClient:
             type=DataType.DATA_TYPE_TABULAR_SENSOR,
             file_name=None,  # Not used in app.
             method_parameters=method_parameters if method_parameters else None,
-            file_extension=file_extension if file_extension else None,
+            file_extension=None,  # Will be stored as empty string "".
             tags=tags if tags else None,
         )
         _: DataCaptureUploadResponse = await self._data_capture_upload(metadata=metadata, sensor_contents=sensor_contents)
@@ -475,10 +469,12 @@ class DataClient:
             component_type (Optional[str]): Optional type of the component associated with the file (e.g., "movement_sensor").
             component_name (Optional[str]): Optional name of the component associated with the file.
             method_name (Optional[str]): Optional name of the method associated with the file.
-            file_name (Optional[str]): Optional name of the file.
+            file_name (Optional[str]): Optional name of the file. The empty string "" will be assigned as the file name if a one isn't
+                provided.
             method_parameters (Optional[str]): Optional dicitonary of the method parameters. No longer in active use.
-            file_extension (Optional[str]): Optional file extension.
-            tags (Optional[List[str]]): Optional list of tags to allow for tag-based filtering.
+            file_extension (Optional[str]): Optional file extension. The empty string "" will be assigned as the file extension if one isn't
+                provided.
+            tags (Optional[List[str]]): Optional list of tags to allow for tag-based filtering when retrieving data.
             data: (Optional[bytes]): Optional bytes representing file data to upload.
 
         Raises:
@@ -517,7 +513,7 @@ class DataClient:
             component_name (Optional[str]): Optional name of the component associated with the file.
             method_name (Optional[str]): Optional name of the method associated with the file.
             method_parameters (Optional[str]): Optional dictionary of the method parameters. No longer in active use.
-            tags (Optional[List[str]]): Optional list of tags to allow for tag-based filtering.
+            tags (Optional[List[str]]): Optional list of tags to allow for tag-based filtering when retrieving data.
             filepath (str): Absolute filepath of file to be uploaded.
 
         Raises:

--- a/src/viam/app/data/client.py
+++ b/src/viam/app/data/client.py
@@ -1,6 +1,9 @@
+from pathlib import Path
 from typing import Any, List, Mapping, Optional
 
 from grpclib.client import Channel
+from google.protobuf.timestamp_pb2 import Timestamp
+from google.protobuf.struct_pb2 import Struct
 
 from viam import logging
 from viam.proto.app.data import (
@@ -41,7 +44,9 @@ from viam.proto.app.datasync import (
     DataCaptureUploadRequest,
     DataCaptureUploadResponse,
     FileUploadRequest,
-    FileUploadResponse
+    FileUploadResponse,
+    DataType,
+    SensorMetadata
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -209,6 +214,9 @@ class DataClient:
         Args:
             binary_ids (List[viam.proto.app.BinaryID]): The binary IDs of the data to be deleted. Must be non-empty.
 
+        Returns:
+            int: the number of items deleted
+
         Raises:
             GRPCError: if no binary_ids are provided.
         """
@@ -243,7 +251,7 @@ class DataClient:
         request = AddTagsToBinaryDataByFilterRequest(filter=filter, tags=tags)
         _: AddTagsToBinaryDataByFilterResponse = await self._data_client.AddTagsToBinaryDataByFilter(request, metadata=self._metadata)
 
-    async def remove_tags_from_binary_data_by_ids(self, tags: List[str], binary_ids: List[BinaryID]) -> None:
+    async def remove_tags_from_binary_data_by_ids(self, tags: List[str], binary_ids: List[BinaryID]) -> int:
         """Remove tags from binary data using BinaryIDs
 
         Args:
@@ -263,7 +271,7 @@ class DataClient:
         )
         return response.deleted_count
 
-    async def remove_tags_from_binary_data_by_filter(self, tags: List[str], filter: Optional[Filter] = None) -> None:
+    async def remove_tags_from_binary_data_by_filter(self, tags: List[str], filter: Optional[Filter] = None) -> int:
         """Remove tags from binary data using a filter
 
         Args:
@@ -320,41 +328,226 @@ class DataClient:
         response: BoundingBoxLabelsByFilterResponse = await self._data_client.BoundingBoxLabelsByFilter(request, metadata=self._metadata)
         return response.labels
 
-    async def data_capture_upload(self, metadata: UploadMetadata , sensor_contents: List[SensorData]) -> None:
-        """Upload binary or tabular sensor data.
+    # TODO [DATA-1663]: Fix Timestamps bug.
+    async def binary_data_capture_upload(
+        self,
+        part_id: str,
+        component_type: str,
+        component_name: str,
+        method_name: str,
+        method_parameters: Optional[Mapping[str, Any]],
+        file_extension: Optional[str],
+        tags: Optional[List[str]],
+        timestamps: Optional[tuple[Timestamp, Timestamp]],
+        binary_data: bytes
+    ) -> None:
+        """Upload binary sensor data.
 
-        Sync binary or tabular data collected on a robot through a specific component (i.e. a motor) along with the relevant metadata with
-        app.viam.com.
+        Sync binary data collected on a robot through a specific component (i.e., a motor) along with the relevant metadata with
+        app.viam.com. Binary data can be found under the "Files" tab in Data on app.viam.com.
 
         Args:
-            metadata (viam.app.proto.datasync.UploadMetaData): Metadata relating the data collected with the corresponding robot part. Must
-                specify a part ID, component type, component name, method name, and data type.
-            sensor_contents (List[viam.app.proto.datasync.SensorData]): A list of the data to be uploaded. If the metadata specifies a
-                binary data type, the "binary" field of sensor_contents will be uploaded. Alternatively, the "struct" field will be uploaded
-                if the data type is tabular. Length of sensor_contents must be 1 if uploading a binary data capture. Otherwise, must simply
-                be nonempty.
+            part_id (str): Part ID of the component used to captuer the data.
+            component_type (str): Type of the component used to capture the data (i.e., "movement_sensor").
+            component_name (str): Name of the component used to capture the data.
+            method_name (str): Name of the method used to capture the data.
+            method_parameters (Optional[Mapping[str, Any]]): Optional dictionary of method parameters. No longer in active use.
+            file_extension (Optional[str]): Optional file extension of data being uploaded.
+            tags (Optional[List[str]]): (Optional) Optional list of tags to allow for tag-based data filtering.
+            timestamps (Optional[tuple[google.protobuf.timestamp_pb2.Timestamp, google.protobuf.timestamp_pb2.Timestamp]]): Optional tuple
+                containing Timestamps denoting the times this data was requested[0] and received[1] by the appropriate sensor.
+            binary_data (bytes): The data to be uploaded, respresented in bytes.
 
         Raises:
-            GRPCError: If a required data field is not defined.
+            GRPCError: If an invalid part ID is passed.
         """
-        request = DataCaptureUploadRequest(metadata=metadata, sensor_contents=sensor_contents)
-        _: DataCaptureUploadResponse = await self._data_sync_client.DataCaptureUpload(request, metadata=self._metadata)
+        metadata = UploadMetadata(
+            part_id=part_id,
+            component_type=component_type,
+            component_name=component_name,
+            method_name=method_name,
+            type=DataType.DATA_TYPE_BINARY_SENSOR,
+            file_name=None,  # Not used in app.
+            method_parameters=method_parameters if method_parameters else None,
+            file_extension=file_extension if file_extension else None,
+            tags=tags if tags else None,
+        )
+        sensor_contents = SensorData(
+            metadata=SensorMetadata(
+                time_requested=timestamps[0] if timestamps[0] else None,
+                time_received=timestamps[1] if timestamps[1] else None,
+            ),
+            struct=None,  # Used for tabular data.
+            binary=binary_data
+        )
+        _: DataCaptureUploadResponse = await self._data_capture_upload(metadata=metadata, sensor_contents=[sensor_contents])
 
-    async def file_upload(self, metadata: UploadMetadata, file_contents: Optional[FileData]) -> None:
+    # TODO [DATA-1663]: Fix Timestamps bug.
+    async def tabular_data_capture_upload(
+        self,
+        part_id: str,
+        component_type: str,
+        component_name: str,
+        method_name: str,
+        method_parameters: Optional[Mapping[str, Any]],
+        file_extension: Optional[str],
+        tags: Optional[List[str]],
+        timestamps: Optional[List[tuple[Timestamp, Timestamp]]],
+        tabular_data: List[Mapping[str, Any]]
+    ) -> None:
+        """Upload tabular sensor data.
+
+        Sync tabular data collected on a robot through a specific component (i.e., a motor) along with the relevant metadata with
+        app.viam.com. Tabular data can be found under the "Sensors" tab in Data on app.viam.com.
+
+        Args:
+            part_id (str): Part ID of the component used to captuer the data.
+            component_type (str): Type of the component used to capture the data (i.e., "movement_sensor").
+            component_name (str): Name of the component used to capture the data.
+            method_name (str): Name of the method used to capture the data.
+            method_parameters (Optional[Mapping[str, Any]]): Optional dictionary of method parameters. No longer in active use.
+            file_extension (Optional[str]): Optional file extension of data being uploaded.
+            tags (Optional[List[str]]): Optional list of tags to allow for tag-based data filtering.
+            timestamps (Optional[List[tuple[google.protobuf.timestamp_pb2.Timestamp, google.protobuf.timestamp_pb2.Timestamp]]]): Optional
+                list of tuples, each containing Timestamps denoting the times this data was requested[0] and received[1] by the appropriate
+                sensor.
+            tabular_data (List[Mapping[str, Any]]): List of the data to be uploaded, represented tabularly as a collection of dictionaries.
+
+        Passing a list of tabular data and Timestamps with length n > 1 will result in n datapoints being uploaded, all tied to the same
+        metadata.
+
+        Raises:
+            GRPCError: If an invalid part ID is passed.
+            AssertionError: If a list of Timestamps is provided and its length does not match the length of the list of tabular data.
+        """
+        sensor_contents = [None] * len(tabular_data)
+        if timestamps:
+            assert len(timestamps) == len(tabular_data)
+
+        for i in range(len(tabular_data)):
+            s = Struct()
+            s.update(tabular_data[i])
+            sensor_contents[i] = SensorData(
+                metadata=SensorMetadata(
+                    time_requested=timestamps[i][0] if timestamps and timestamps[i][0] else None,
+                    time_received=timestamps[i][1] if timestamps and timestamps[i][1] else None
+                ),
+                struct=s
+            )
+
+        metadata = UploadMetadata(
+            part_id=part_id,
+            component_type=component_type,
+            component_name=component_name,
+            method_name=method_name,
+            type=DataType.DATA_TYPE_TABULAR_SENSOR,
+            file_name=None,  # Not used in app.
+            method_parameters=method_parameters if method_parameters else None,
+            file_extension=file_extension if file_extension else None,
+            tags=tags if tags else None,
+        )
+        _: DataCaptureUploadResponse = await self._data_capture_upload(metadata=metadata, sensor_contents=sensor_contents)
+
+    async def _data_capture_upload(self, metadata: UploadMetadata, sensor_contents: List[SensorData]) -> DataCaptureUploadResponse:
+        request = DataCaptureUploadRequest(metadata=metadata, sensor_contents=sensor_contents)
+        response: DataCaptureUploadResponse = await self._data_sync_client.DataCaptureUpload(request, metadata=self._metadata)
+        return response
+
+    async def file_upload(
+        self,
+        part_id: str,
+        component_type: Optional[str],
+        component_name: Optional[str],
+        method_name: Optional[str],
+        file_name: Optional[str],
+        method_parameters: Optional[Mapping[str, Any]],
+        file_extension: Optional[str],
+        tags: Optional[List[str]],
+        data: Optional[bytes]
+    ) -> None:
         """Upload arbitrary file data.
 
         Sync file data that may be stored on a robot along with the relevant metadata to app.viam.com.
 
         Args:
-            metadata (viam.app.proto.datasync.UploadMetaData): Metadata for the file to be uploaded. Must specify a part ID.
-            file_contents (List[viam.app.proto.datasync.FileData]): A FileData object containing binary data to upload as a file.
+            part_id (str): Part ID of the component associated with the file.
+            component_type (Optional[str]): Optional type of the component associated with the file (i.e., "movement_sensor").
+            component_name (Optional[str]): Optional name of the component associated with the file.
+            method_name (Optional[str]): Optional name of the method associated with the file.
+            file_name (Optional[str]): Optional name of the file.
+            method_parameters (Optional[str]): Optoinal dicitonary of the method parameters. No longer in active use.
+            file_extension (Optional[str]): Optional file extension.
+            tags (Optional[List[str]]): Optional list of tags to allow for tag-based filtering.
+            data: (Optional[bytes]): Optional bytes representing file data to upload.
 
         Raises:
-            GRPCError: If an invalid part ID is provided as metadata.
+            GRPCError: If an invalid part ID is passed.
         """
+        metadata = UploadMetadata(
+            part_id=part_id,
+            component_type=component_type if component_type else None,
+            component_name=component_name if component_name else None,
+            method_name=method_name if method_name else None,
+            type=DataType.DATA_TYPE_FILE,
+            file_name=file_name if file_name else None,
+            method_parameters=method_parameters if method_parameters else None,
+            file_extension=file_extension if file_extension else None,
+            tags=tags if tags else None,
+        )
+        _: FileUploadResponse = await self._file_upload(metadata=metadata, file_contents=FileData(data=data))
+
+    async def file_upload_from_path(
+        self,
+        part_id: str,
+        component_type: Optional[str],
+        component_name: Optional[str],
+        method_name: Optional[str],
+        method_parameters: Optional[Mapping[str, Any]],
+        tags: Optional[List[str]],
+        filepath: str
+    ) -> None:
+        """Upload arbitrary file data.
+
+        Sync file data that may be stored on a robot along with the relevant metadata to app.viam.com.
+
+        Args:
+            part_id (str): Part ID of the component associated with the file.
+            component_type (Optional[str]): Optional type of the component associated with the file (i.e., "movement_sensor").
+            component_name (Optional[str]): Optional name of the component associated with the file.
+            method_name (Optional[str]): Optional name of the method associated with the file.
+            method_parameters (Optional[str]): Optional dicitonary of the method parameters. No longer in active use.
+            tags (Optional[List[str]]): Optional list of tags to allow for tag-based filtering.
+            filepath (str): Absolute filepath of file to be uploaded.
+
+        Raises:
+            GRPCError: If an invalid part ID is passed.
+            FileNotFoundError: If the provided filepath is not found.
+        """
+        path = Path(filepath)
+        file_name = path.stem
+        file_extension = path.suffix if path.suffix != "" else None
+        f = open(filepath, "rb")
+        data = f.read()
+        f.close()
+
+        metadata = UploadMetadata(
+            part_id=part_id,
+            component_type=component_type if component_type else None,
+            component_name=component_name if component_name else None,
+            method_name=method_name if method_name else None,
+            type=DataType.DATA_TYPE_FILE,
+            file_name=file_name,
+            method_parameters=method_parameters if method_parameters else None,
+            file_extension=file_extension,
+            tags=tags if tags else None,
+        )
+        _: FileUploadResponse = await self._file_upload(metadata=metadata, file_contents=FileData(data=data))
+
+    async def _file_upload(self, metadata: UploadMetadata, file_contents: FileData) -> FileUploadResponse:
         request_metadata = FileUploadRequest(metadata=metadata)
         request_file_contents = FileUploadRequest(file_contents=file_contents)
-        async with self._data_sync_client.FileUpload.open(metadata=self._metadata, timeout=10) as stream:
+        async with self._data_sync_client.FileUpload.open(metadata=self._metadata) as stream:
             await stream.send_message(request_metadata)
             await stream.send_message(request_file_contents, end=True)
-            _: FileUploadResponse = await stream.recv_message()
+            response: FileUploadResponse = await stream.recv_message()
+            return response

--- a/src/viam/app/data/client.py
+++ b/src/viam/app/data/client.py
@@ -54,7 +54,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class DataClient:
-    """gRPC client for uploading and retreiving data from app
+    """gRPC client for uploading and retrieving data from app
 
     Constructor is used by AppClient to instantiate relevant service stubs. Calls to DataClient methods should be made through AppClient
     """
@@ -177,7 +177,7 @@ class DataClient:
                 file.write(f"{response.data}")
             except Exception as e:
                 LOGGER.error(f"Failed to write binary data to file {dest}", exc_info=e)
-        return response.data
+        return [binary_data.binary for binary_data in response.data]
 
     async def delete_tabular_data_by_filter(self, filter: Optional[Filter]) -> int:
         """Delete tabular data
@@ -297,7 +297,7 @@ class DataClient:
         """Get a list of tags using a filter
 
         Args:
-            filter (viam.app.proto.Filter): Filter specifying data to retreive from. If no filter is provided, all data tags will return
+            filter (viam.app.proto.Filter): Filter specifying data to retrieve from. If no filter is provided, all data tags will return
 
         Returns:
             List[str]: The list of tags
@@ -319,7 +319,7 @@ class DataClient:
         """Get a list of bounding box labels using a filter
 
         Args:
-            filter (viam.app.proto.Filter): Filter specifying data to retreive from. If no filter is provided, all labels will return
+            filter (viam.app.proto.Filter): Filter specifying data to retrieve from. If no filter is provided, all labels will return
 
         Returns:
             List[str]: The list of bounding box labels

--- a/src/viam/app/data/client.py
+++ b/src/viam/app/data/client.py
@@ -515,7 +515,7 @@ class DataClient:
             component_type (Optional[str]): Optional type of the component associated with the file (i.e., "movement_sensor").
             component_name (Optional[str]): Optional name of the component associated with the file.
             method_name (Optional[str]): Optional name of the method associated with the file.
-            method_parameters (Optional[str]): Optional dicitonary of the method parameters. No longer in active use.
+            method_parameters (Optional[str]): Optional dictionary of the method parameters. No longer in active use.
             tags (Optional[List[str]]): Optional list of tags to allow for tag-based filtering.
             filepath (str): Absolute filepath of file to be uploaded.
 

--- a/src/viam/app/data/client.py
+++ b/src/viam/app/data/client.py
@@ -361,6 +361,14 @@ class DataClient:
         Raises:
             GRPCError: If an invalid part ID is passed.
         """
+        sensor_contents = SensorData(
+            metadata=SensorMetadata(
+                time_requested=timestamps[0] if timestamps[0] else None,
+                time_received=timestamps[1] if timestamps[1] else None,
+            ),
+            struct=None,  # Used for tabular data.
+            binary=binary_data
+        )
         metadata = UploadMetadata(
             part_id=part_id,
             component_type=component_type,
@@ -371,14 +379,6 @@ class DataClient:
             method_parameters=method_parameters if method_parameters else None,
             file_extension=file_extension if file_extension else None,
             tags=tags if tags else None,
-        )
-        sensor_contents = SensorData(
-            metadata=SensorMetadata(
-                time_requested=timestamps[0] if timestamps[0] else None,
-                time_received=timestamps[1] if timestamps[1] else None,
-            ),
-            struct=None,  # Used for tabular data.
-            binary=binary_data
         )
         _: DataCaptureUploadResponse = await self._data_capture_upload(metadata=metadata, sensor_contents=[sensor_contents])
 
@@ -446,7 +446,7 @@ class DataClient:
             file_extension=file_extension if file_extension else None,
             tags=tags if tags else None,
         )
-        _: DataCaptureUploadResponse = await self._data_capture_upload(metadata=metadata, sensor_contents=sensor_contents)
+        _: DataCaptureUploadResponse = await self._data_capture_upload(metadata=metadata, sensor_contents=[sensor_contents])
 
     async def _data_capture_upload(self, metadata: UploadMetadata, sensor_contents: List[SensorData]) -> DataCaptureUploadResponse:
         request = DataCaptureUploadRequest(metadata=metadata, sensor_contents=sensor_contents)
@@ -475,7 +475,7 @@ class DataClient:
             component_name (Optional[str]): Optional name of the component associated with the file.
             method_name (Optional[str]): Optional name of the method associated with the file.
             file_name (Optional[str]): Optional name of the file.
-            method_parameters (Optional[str]): Optoinal dicitonary of the method parameters. No longer in active use.
+            method_parameters (Optional[str]): Optional dicitonary of the method parameters. No longer in active use.
             file_extension (Optional[str]): Optional file extension.
             tags (Optional[List[str]]): Optional list of tags to allow for tag-based filtering.
             data: (Optional[bytes]): Optional bytes representing file data to upload.

--- a/src/viam/app/data/client.py
+++ b/src/viam/app/data/client.py
@@ -6,6 +6,7 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from google.protobuf.struct_pb2 import Struct
 
 from viam import logging
+from viam.utils import struct_to_dict
 from viam.proto.app.data import (
     AddTagsToBinaryDataByFilterRequest,
     AddTagsToBinaryDataByFilterResponse,
@@ -101,7 +102,7 @@ class DataClient:
             response: TabularDataByFilterResponse = await self._data_client.TabularDataByFilter(request, metadata=self._metadata)
             if not response.data or len(response.data) == 0:
                 break
-            data += [struct.data for struct in response.data]
+            data += [struct_to_dict(struct.data) for struct in response.data]
             last = response.last
 
         if dest:
@@ -343,17 +344,17 @@ class DataClient:
     ) -> None:
         """Upload binary sensor data.
 
-        Sync binary data collected on a robot through a specific component (i.e., a motor) along with the relevant metadata with
+        Sync binary data collected on a robot through a specific component (e.g., a motor) along with the relevant metadata with
         app.viam.com. Binary data can be found under the "Files" tab in Data on app.viam.com.
 
         Args:
             part_id (str): Part ID of the component used to captuer the data.
-            component_type (str): Type of the component used to capture the data (i.e., "movement_sensor").
+            component_type (str): Type of the component used to capture the data (e.g., "movement_sensor").
             component_name (str): Name of the component used to capture the data.
             method_name (str): Name of the method used to capture the data.
             method_parameters (Optional[Mapping[str, Any]]): Optional dictionary of method parameters. No longer in active use.
             file_extension (Optional[str]): Optional file extension of data being uploaded.
-            tags (Optional[List[str]]): (Optional) Optional list of tags to allow for tag-based data filtering.
+            tags (Optional[List[str]]): Optional list of tags to allow for tag-based data filtering.
             timestamps (Optional[tuple[google.protobuf.timestamp_pb2.Timestamp, google.protobuf.timestamp_pb2.Timestamp]]): Optional tuple
                 containing Timestamps denoting the times this data was requested[0] and received[1] by the appropriate sensor.
             binary_data (bytes): The data to be uploaded, respresented in bytes.
@@ -397,12 +398,12 @@ class DataClient:
     ) -> None:
         """Upload tabular sensor data.
 
-        Sync tabular data collected on a robot through a specific component (i.e., a motor) along with the relevant metadata with
+        Sync tabular data collected on a robot through a specific component (e.g., a motor) along with the relevant metadata with
         app.viam.com. Tabular data can be found under the "Sensors" tab in Data on app.viam.com.
 
         Args:
             part_id (str): Part ID of the component used to captuer the data.
-            component_type (str): Type of the component used to capture the data (i.e., "movement_sensor").
+            component_type (str): Type of the component used to capture the data (e.g., "movement_sensor").
             component_name (str): Name of the component used to capture the data.
             method_name (str): Name of the method used to capture the data.
             method_parameters (Optional[Mapping[str, Any]]): Optional dictionary of method parameters. No longer in active use.
@@ -470,8 +471,8 @@ class DataClient:
         Sync file data that may be stored on a robot along with the relevant metadata to app.viam.com.
 
         Args:
-            part_id (str): Part ID of the component associated with the file.
-            component_type (Optional[str]): Optional type of the component associated with the file (i.e., "movement_sensor").
+            part_id (str): Part ID of the resource associated with the file.
+            component_type (Optional[str]): Optional type of the component associated with the file (e.g., "movement_sensor").
             component_name (Optional[str]): Optional name of the component associated with the file.
             method_name (Optional[str]): Optional name of the method associated with the file.
             file_name (Optional[str]): Optional name of the file.
@@ -512,7 +513,7 @@ class DataClient:
 
         Args:
             part_id (str): Part ID of the component associated with the file.
-            component_type (Optional[str]): Optional type of the component associated with the file (i.e., "movement_sensor").
+            component_type (Optional[str]): Optional type of the component associated with the file (e.g., "movement_sensor").
             component_name (Optional[str]): Optional name of the component associated with the file.
             method_name (Optional[str]): Optional name of the method associated with the file.
             method_parameters (Optional[str]): Optional dictionary of the method parameters. No longer in active use.

--- a/src/viam/app/data/client.py
+++ b/src/viam/app/data/client.py
@@ -446,7 +446,7 @@ class DataClient:
             file_extension=file_extension if file_extension else None,
             tags=tags if tags else None,
         )
-        _: DataCaptureUploadResponse = await self._data_capture_upload(metadata=metadata, sensor_contents=[sensor_contents])
+        _: DataCaptureUploadResponse = await self._data_capture_upload(metadata=metadata, sensor_contents=sensor_contents)
 
     async def _data_capture_upload(self, metadata: UploadMetadata, sensor_contents: List[SensorData]) -> DataCaptureUploadResponse:
         request = DataCaptureUploadRequest(metadata=metadata, sensor_contents=sensor_contents)


### PR DESCRIPTION
This PR updates binary_data_by_ids() so that instead of a list of protobuf messages, the method return a list of binary data--each corresponding to one of the BinaryID's provided. Also included in this PR is a series of spelling error fixes.