### PR TITLE
[RSDK-3898] Implement Tests for Data Cloud API's

### DIFF
--- a/src/viam/app/data/client.py
+++ b/src/viam/app/data/client.py
@@ -359,8 +359,8 @@ class DataClient:
         """
         sensor_contents = SensorData(
             metadata=SensorMetadata(
-                time_requested=timestamps[0] if timestamps[0] else None,
-                time_received=timestamps[1] if timestamps[1] else None,
+                time_requested=timestamps[0][0] if timestamps[0] else None,
+                time_received=timestamps[0][1] if timestamps[0] else None,
             ),
             struct=None,  # Used for tabular data.
             binary=binary_data,

--- a/src/viam/app/data/client.py
+++ b/src/viam/app/data/client.py
@@ -140,7 +140,7 @@ class DataClient:
             response: BinaryDataByFilterResponse = await self._data_client.BinaryDataByFilter(request, metadata=self._metadata)
             if not response.data or len(response.data) == 0:
                 break
-            data += list(response.data)
+            data += [data.binary for data in response.data]
             last = response.last
 
         if dest:

--- a/src/viam/app/data/client.py
+++ b/src/viam/app/data/client.py
@@ -359,8 +359,8 @@ class DataClient:
         """
         sensor_contents = SensorData(
             metadata=SensorMetadata(
-                time_requested=timestamps[0][0] if timestamps[0] else None,
-                time_received=timestamps[0][1] if timestamps[0] else None,
+                time_requested=timestamps[0] if timestamps and timestamps[0] else None,
+                time_received=timestamps[1] if timestamps and timestamps[1] else None,
             ),
             struct=None,  # Used for tabular data.
             binary=binary_data,

--- a/src/viam/app/data/client.py
+++ b/src/viam/app/data/client.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Any, List, Mapping, Optional
 
 from google.protobuf.struct_pb2 import Struct
-from google.protobuf.timestamp_pb2 import Timestamp
+# from google.protobuf.timestamp_pb2 import Timestamp
 from grpclib.client import Channel
 
 from viam import logging
@@ -386,7 +386,7 @@ class DataClient:
         method_name: str,
         method_parameters: Optional[Mapping[str, Any]],
         tags: Optional[List[str]],
-        timestamps: Optional[List[tuple[Timestamp, Timestamp]]],
+        timestamps: Any,
         tabular_data: List[Mapping[str, Any]],
     ) -> None:
         """Upload tabular sensor data.

--- a/src/viam/app/data/client.py
+++ b/src/viam/app/data/client.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, List, Mapping, Optional
+from typing import Any, List, Mapping, Optional, Tuple
 
 from google.protobuf.struct_pb2 import Struct
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -335,7 +335,7 @@ class DataClient:
         method_name: str,
         method_parameters: Optional[Mapping[str, Any]],
         tags: Optional[List[str]],
-        timestamps: Optional[List[tuple[Optional[Timestamp], Optional[Timestamp]]]],
+        timestamps: Optional[List[Tuple[Optional[Timestamp], Optional[Timestamp]]]],
         binary_data: bytes,
     ) -> None:
         """Upload binary sensor data.
@@ -350,7 +350,7 @@ class DataClient:
             method_name (str): Name of the method used to capture the data.
             method_parameters (Optional[Mapping[str, Any]]): Optional dictionary of method parameters. No longer in active use.
             tags (Optional[List[str]]): Optional list of tags to allow for tag-based data filtering when retrieving data.
-            timestamps (Optional[tuple[google.protobuf.timestamp_pb2.Timestamp, google.protobuf.timestamp_pb2.Timestamp]]): Optional tuple
+            timestamps (Optional[Tuple[google.protobuf.timestamp_pb2.Timestamp, google.protobuf.timestamp_pb2.Timestamp]]): Optional tuple
                 containing `Timestamp`s denoting the times this data was requested[0] and received[1] by the appropriate sensor.
             binary_data (bytes): The data to be uploaded, respresented in bytes.
 
@@ -388,7 +388,7 @@ class DataClient:
         method_name: str,
         method_parameters: Optional[Mapping[str, Any]],
         tags: Optional[List[str]],
-        timestamps: Optional[List[tuple[Optional[Timestamp], Optional[Timestamp]]]],
+        timestamps: Optional[List[Tuple[Optional[Timestamp], Optional[Timestamp]]]],
         tabular_data: List[Mapping[str, Any]],
     ) -> None:
         """Upload tabular sensor data.
@@ -403,7 +403,7 @@ class DataClient:
             method_name (str): Name of the method used to capture the data.
             method_parameters (Optional[Mapping[str, Any]]): Optional dictionary of method parameters. No longer in active use.
             tags (Optional[List[str]]): Optional list of tags to allow for tag-based data filtering when retrieving data.
-            timestamps (Optional[List[tuple[google.protobuf.timestamp_pb2.Timestamp, google.protobuf.timestamp_pb2.Timestamp]]]): Optional
+            timestamps (Optional[List[Tuple[google.protobuf.timestamp_pb2.Timestamp, google.protobuf.timestamp_pb2.Timestamp]]]): Optional
                 list of tuples, each containing `Timestamp`s denoting the times this data was requested[0] and received[1] by the
                 appropriate sensor.
             tabular_data (List[Mapping[str, Any]]): List of the data to be uploaded, represented tabularly as a collection of dictionaries.

--- a/src/viam/app/data/client.py
+++ b/src/viam/app/data/client.py
@@ -335,7 +335,7 @@ class DataClient:
         method_name: str,
         method_parameters: Optional[Mapping[str, Any]],
         tags: Optional[List[str]],
-        timestamps: Optional[List[tuple[Timestamp, Timestamp]]],
+        timestamps: Any,
         binary_data: bytes,
     ) -> None:
         """Upload binary sensor data.

--- a/src/viam/app/data/client.py
+++ b/src/viam/app/data/client.py
@@ -335,7 +335,7 @@ class DataClient:
         method_name: str,
         method_parameters: Optional[Mapping[str, Any]],
         tags: Optional[List[str]],
-        timestamps: Optional[tuple[Timestamp, Timestamp]],
+        timestamps: Optional[List[tuple[Timestamp, Timestamp]]],
         binary_data: bytes,
     ) -> None:
         """Upload binary sensor data.
@@ -359,8 +359,8 @@ class DataClient:
         """
         sensor_contents = SensorData(
             metadata=SensorMetadata(
-                time_requested=timestamps[0] if timestamps and timestamps[0] else None,
-                time_received=timestamps[1] if timestamps and timestamps[1] else None,
+                time_requested=timestamps[0][0] if timestamps and timestamps[0] and timestamps[0][0] else None,
+                time_received=timestamps[0][1] if timestamps and timestamps[0] and timestamps[0][1] else None,
             ),
             struct=None,  # Used for tabular data.
             binary=binary_data,

--- a/src/viam/app/data/client.py
+++ b/src/viam/app/data/client.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Any, List, Mapping, Optional
 
 from google.protobuf.struct_pb2 import Struct
-# from google.protobuf.timestamp_pb2 import Timestamp
+from google.protobuf.timestamp_pb2 import Timestamp
 from grpclib.client import Channel
 
 from viam import logging
@@ -335,7 +335,7 @@ class DataClient:
         method_name: str,
         method_parameters: Optional[Mapping[str, Any]],
         tags: Optional[List[str]],
-        timestamps: Any,
+        timestamps: Optional[List[tuple[Optional[Timestamp], Optional[Timestamp]]]],
         binary_data: bytes,
     ) -> None:
         """Upload binary sensor data.
@@ -356,7 +356,9 @@ class DataClient:
 
         Raises:
             GRPCError: If an invalid part ID is passed.
+            AssrtionError: If len(timestamps) is not 1.
         """
+        assert len(timestamps) == 1
         sensor_contents = SensorData(
             metadata=SensorMetadata(
                 time_requested=timestamps[0][0] if timestamps and timestamps[0] and timestamps[0][0] else None,
@@ -386,7 +388,7 @@ class DataClient:
         method_name: str,
         method_parameters: Optional[Mapping[str, Any]],
         tags: Optional[List[str]],
-        timestamps: Any,
+        timestamps: Optional[List[tuple[Optional[Timestamp], Optional[Timestamp]]]],
         tabular_data: List[Mapping[str, Any]],
     ) -> None:
         """Upload tabular sensor data.

--- a/src/viam/app/data/client.py
+++ b/src/viam/app/data/client.py
@@ -335,7 +335,7 @@ class DataClient:
         method_name: str,
         method_parameters: Optional[Mapping[str, Any]],
         tags: Optional[List[str]],
-        timestamps: Optional[List[Tuple[Optional[Timestamp], Optional[Timestamp]]]],
+        timestamps: Optional[Tuple[Optional[Timestamp], Optional[Timestamp]]],
         binary_data: bytes,
     ) -> None:
         """Upload binary sensor data.
@@ -356,13 +356,11 @@ class DataClient:
 
         Raises:
             GRPCError: If an invalid part ID is passed.
-            AssrtionError: If len(timestamps) is not 1.
         """
-        assert len(timestamps) == 1
         sensor_contents = SensorData(
             metadata=SensorMetadata(
-                time_requested=timestamps[0][0] if timestamps and timestamps[0] and timestamps[0][0] else None,
-                time_received=timestamps[0][1] if timestamps and timestamps[0] and timestamps[0][1] else None,
+                time_requested=timestamps[0] if timestamps and timestamps[0] else None,
+                time_received=timestamps[1] if timestamps and timestamps[1] else None,
             ),
             struct=None,  # Used for tabular data.
             binary=binary_data,

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -312,7 +312,7 @@ class MockSLAM(SLAM):
         return {"command": command}
 
 
-class MockData(DataServiceBase, DataSyncServiceBase):
+class MockData(DataServiceBase):
     def __init__(
         self,
         tabular_response: List[Mapping[str, Any]],
@@ -437,6 +437,8 @@ class MockData(DataServiceBase, DataSyncServiceBase):
         self.filter = request.filter
         await stream.send_message(BoundingBoxLabelsByFilterResponse(labels=self.bbox_labels_response))
 
+
+class MockDataSync(DataSyncServiceBase):
     async def DataCaptureUpload(self, stream: Stream[DataCaptureUploadRequest, DataCaptureUploadResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -5,6 +5,44 @@ from PIL import Image
 
 from viam.media.video import RawImage
 from viam.proto.common import DoCommandRequest, DoCommandResponse, PointCloudObject, Pose, PoseInFrame, ResourceName
+from viam.proto.app.data import (
+    AddBoundingBoxToImageByIDRequest,
+    AddBoundingBoxToImageByIDResponse,
+    AddTagsToBinaryDataByFilterRequest,
+    AddTagsToBinaryDataByFilterResponse,
+    AddTagsToBinaryDataByIDsRequest,
+    AddTagsToBinaryDataByIDsResponse,
+    BinaryDataByFilterRequest,
+    BinaryDataByFilterResponse,
+    BinaryDataByIDsRequest,
+    BinaryDataByIDsResponse,
+    BoundingBoxLabelsByFilterRequest,
+    BoundingBoxLabelsByFilterResponse,
+    DeleteBinaryDataByFilterRequest,
+    DeleteBinaryDataByFilterResponse,
+    DeleteBinaryDataByIDsRequest,
+    DeleteBinaryDataByIDsResponse,
+    DeleteTabularDataByFilterRequest,
+    DeleteTabularDataByFilterResponse,
+    RemoveBoundingBoxFromImageByIDRequest,
+    RemoveBoundingBoxFromImageByIDResponse,
+    RemoveTagsFromBinaryDataByFilterRequest,
+    RemoveTagsFromBinaryDataByFilterResponse,
+    RemoveTagsFromBinaryDataByIDsRequest,
+    RemoveTagsFromBinaryDataByIDsResponse,
+    TabularDataByFilterRequest,
+    TabularDataByFilterResponse,
+    TagsByFilterRequest,
+    TagsByFilterResponse,
+    DataServiceBase
+)
+from viam.proto.app.datasync import (
+    DataCaptureUploadRequest,
+    DataCaptureUploadResponse,
+    FileUploadRequest,
+    FileUploadResponse,
+    DataSyncServiceBase
+)
 from viam.proto.service.motion import (
     Constraints,
     GetPoseRequest,
@@ -269,3 +307,70 @@ class MockSLAM(SLAM):
 
     async def do_command(self, command: Mapping[str, ValueTypes], *, timeout: Optional[float] = None, **kwargs) -> Mapping[str, ValueTypes]:
         return {"command": command}
+
+
+class MockData(DataServiceBase, DataSyncServiceBase):
+    def __init__(
+        self,
+    ):
+        pass
+
+    async def TabularDataByFilter(self, stream: Stream[TabularDataByFilterRequest, TabularDataByFilterResponse]) -> None:
+        pass
+
+    async def BinaryDataByFilter(self, stream: Stream[BinaryDataByFilterRequest, BinaryDataByFilterResponse]) -> None:
+        pass
+
+    async def BinaryDataByIDs(self, stream: Stream[BinaryDataByIDsRequest, BinaryDataByIDsResponse]) -> None:
+        pass
+
+    async def DeleteTabularDataByFilter(self, stream: Stream[DeleteTabularDataByFilterRequest, DeleteTabularDataByFilterResponse]) -> None:
+        pass
+
+    async def DeleteBinaryDataByFilter(self, stream: Stream[DeleteBinaryDataByFilterRequest, DeleteBinaryDataByFilterResponse]) -> None:
+        pass
+
+    async def DeleteBinaryDataByIDs(self, stream: Stream[DeleteBinaryDataByIDsRequest, DeleteBinaryDataByIDsResponse]) -> None:
+        pass
+
+    async def AddTagsToBinaryDataByIDs(self, stream: Stream[AddTagsToBinaryDataByIDsRequest, AddTagsToBinaryDataByIDsResponse]) -> None:
+        pass
+
+    async def AddTagsToBinaryDataByFilter(
+        self,
+        stream: Stream[AddTagsToBinaryDataByFilterRequest, AddTagsToBinaryDataByFilterResponse]
+    ) -> None:
+        pass
+
+    async def RemoveTagsFromBinaryDataByIDs(
+        self,
+        stream: Stream[RemoveTagsFromBinaryDataByIDsRequest, RemoveTagsFromBinaryDataByIDsResponse]
+    ) -> None:
+        pass
+
+    async def RemoveTagsFromBinaryDataByFilter(
+        self,
+        stream: Stream[RemoveTagsFromBinaryDataByFilterRequest, RemoveTagsFromBinaryDataByFilterResponse]
+    ) -> None:
+        pass
+
+    async def TagsByFilter(self, stream: Stream[TagsByFilterRequest, TagsByFilterResponse]) -> None:
+        pass
+
+    async def AddBoundingBoxToImageByID(self, stream: Stream[AddBoundingBoxToImageByIDRequest, AddBoundingBoxToImageByIDResponse]) -> None:
+        pass
+
+    async def RemoveBoundingBoxFromImageByID(
+        self,
+        stream: Stream[RemoveBoundingBoxFromImageByIDRequest, RemoveBoundingBoxFromImageByIDResponse]
+    ) -> None:
+        pass
+
+    async def BoundingBoxLabelsByFilter(self, stream: Stream[BoundingBoxLabelsByFilterRequest, BoundingBoxLabelsByFilterResponse]) -> None:
+        pass
+
+    async def DataCaptureUpload(self, stream: Stream[DataCaptureUploadRequest, DataCaptureUploadResponse]) -> None:
+        pass
+
+    async def FileUpload(self, stream: Stream[FileUploadRequest, FileUploadResponse]) -> None:
+        pass

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Mapping, Optional, Union
 
 from grpclib.server import Stream
 from PIL import Image
+from google.protobuf.struct_pb2 import Struct
 
 from viam.media.video import RawImage
 from viam.proto.common import DoCommandRequest, DoCommandResponse, PointCloudObject, Pose, PoseInFrame, ResourceName
@@ -12,6 +13,7 @@ from viam.proto.app.data import (
     AddTagsToBinaryDataByFilterResponse,
     AddTagsToBinaryDataByIDsRequest,
     AddTagsToBinaryDataByIDsResponse,
+    BinaryData,
     BinaryDataByFilterRequest,
     BinaryDataByFilterResponse,
     BinaryDataByIDsRequest,
@@ -30,6 +32,7 @@ from viam.proto.app.data import (
     RemoveTagsFromBinaryDataByFilterResponse,
     RemoveTagsFromBinaryDataByIDsRequest,
     RemoveTagsFromBinaryDataByIDsResponse,
+    TabularData,
     TabularDataByFilterRequest,
     TabularDataByFilterResponse,
     TagsByFilterRequest,
@@ -312,50 +315,102 @@ class MockSLAM(SLAM):
 class MockData(DataServiceBase, DataSyncServiceBase):
     def __init__(
         self,
+        tabular_response: List[Mapping[str, Any]],
+        binary_response: List[bytes],
+        delete_remove_response: int,
+        tags_response: List[str],
+        bbox_labels_response: List[str]
     ):
-        pass
+        self.tabular_response = tabular_response
+        self.binary_response = binary_response
+        self.delete_remove_response = delete_remove_response
+        self.tags_response = tags_response
+        self.bbox_labels_response = bbox_labels_response
 
     async def TabularDataByFilter(self, stream: Stream[TabularDataByFilterRequest, TabularDataByFilterResponse]) -> None:
-        pass
+        request = await stream.recv_message()
+        assert request is not None
+        self.filter = request.data_request.filter
+        n = len(self.tabular_response)
+        tabular_response_structs = [None] * n
+        for i in range(n):
+            s = Struct()
+            s.update(self.tabular_response[i])
+            tabular_response_structs[i] = s
+        await stream.send_message(TabularDataByFilterResponse(data=[TabularData(data=struct) for struct in tabular_response_structs]))
 
     async def BinaryDataByFilter(self, stream: Stream[BinaryDataByFilterRequest, BinaryDataByFilterResponse]) -> None:
-        pass
+        request = await stream.recv_message()
+        assert request is not None
+        self.filter = request.data_request.filter
+        await stream.send_message(BinaryDataByFilterResponse(data=[BinaryData(binary=binary_data) for binary_data in self.binary_response]))
 
     async def BinaryDataByIDs(self, stream: Stream[BinaryDataByIDsRequest, BinaryDataByIDsResponse]) -> None:
-        pass
+        request = await stream.recv_message()
+        assert request is not None
+        self.binary_ids = request.binary_ids
+        await stream.send_message(BinaryDataByIDsResponse(data=[BinaryData(binary=binary_data) for binary_data in self.binary_response]))
 
     async def DeleteTabularDataByFilter(self, stream: Stream[DeleteTabularDataByFilterRequest, DeleteTabularDataByFilterResponse]) -> None:
-        pass
+        request = await stream.recv_message()
+        assert request is not None
+        self.filter = request.filter
+        await stream.send_message(DeleteTabularDataByFilterResponse(deleted_count=self.delete_remove_response))
 
     async def DeleteBinaryDataByFilter(self, stream: Stream[DeleteBinaryDataByFilterRequest, DeleteBinaryDataByFilterResponse]) -> None:
-        pass
+        request = await stream.recv_message()
+        assert request is not None
+        self.filter = request.filter
+        await stream.send_message(DeleteBinaryDataByFilterResponse(deleted_count=self.delete_remove_response))
 
     async def DeleteBinaryDataByIDs(self, stream: Stream[DeleteBinaryDataByIDsRequest, DeleteBinaryDataByIDsResponse]) -> None:
-        pass
+        request = await stream.recv_message()
+        assert request is not None
+        self.binary_ids = request.binary_ids
+        await stream.send_message(DeleteBinaryDataByIDsResponse(deleted_count=self.delete_remove_response))
 
     async def AddTagsToBinaryDataByIDs(self, stream: Stream[AddTagsToBinaryDataByIDsRequest, AddTagsToBinaryDataByIDsResponse]) -> None:
-        pass
+        request = await stream.recv_message()
+        assert request is not None
+        self.binary_ids = request.binary_ids
+        self.tags = request.tags
+        await stream.send_message(AddTagsToBinaryDataByIDsResponse())
 
     async def AddTagsToBinaryDataByFilter(
         self,
         stream: Stream[AddTagsToBinaryDataByFilterRequest, AddTagsToBinaryDataByFilterResponse]
     ) -> None:
-        pass
+        request = await stream.recv_message()
+        assert request is not None
+        self.filter = request.filter
+        self.tags = request.tags
+        await stream.send_message(AddTagsToBinaryDataByFilterResponse())
 
     async def RemoveTagsFromBinaryDataByIDs(
         self,
         stream: Stream[RemoveTagsFromBinaryDataByIDsRequest, RemoveTagsFromBinaryDataByIDsResponse]
     ) -> None:
-        pass
+        request = await stream.recv_message()
+        assert request is not None
+        self.binary_ids = request.binary_ids
+        self.tags = request.tags
+        await stream.send_message(RemoveTagsFromBinaryDataByFilterResponse(deleted_count=self.delete_remove_response))
 
     async def RemoveTagsFromBinaryDataByFilter(
         self,
         stream: Stream[RemoveTagsFromBinaryDataByFilterRequest, RemoveTagsFromBinaryDataByFilterResponse]
     ) -> None:
-        pass
+        request = await stream.recv_message()
+        assert request is not None
+        self.filter = request.filter
+        self.tags = request.tags
+        await stream.send_message(RemoveTagsFromBinaryDataByFilterResponse(deleted_count=len(request.tags)))
 
     async def TagsByFilter(self, stream: Stream[TagsByFilterRequest, TagsByFilterResponse]) -> None:
-        pass
+        request = await stream.recv_message()
+        assert request is not None
+        self.filter = request.filter
+        await stream.send_message(TagsByFilterResponse(tags=self.tags_response))
 
     async def AddBoundingBoxToImageByID(self, stream: Stream[AddBoundingBoxToImageByIDRequest, AddBoundingBoxToImageByIDResponse]) -> None:
         pass
@@ -367,10 +422,21 @@ class MockData(DataServiceBase, DataSyncServiceBase):
         pass
 
     async def BoundingBoxLabelsByFilter(self, stream: Stream[BoundingBoxLabelsByFilterRequest, BoundingBoxLabelsByFilterResponse]) -> None:
-        pass
+        request = await stream.recv_message()
+        assert request is not None
+        self.filter = request.filter
+        await stream.send_message(BoundingBoxLabelsByFilterResponse(labels=self.bbox_labels_response))
 
     async def DataCaptureUpload(self, stream: Stream[DataCaptureUploadRequest, DataCaptureUploadResponse]) -> None:
-        pass
+        request = await stream.recv_message()
+        assert request is not None
+        self.metadata = request.metadata
+        self.sensor_contents = request.sensor_contents
+        await stream.send_message(DataCaptureUploadResponse())
 
     async def FileUpload(self, stream: Stream[FileUploadRequest, FileUploadResponse]) -> None:
-        pass
+        request = await stream.recv_message()
+        assert request is not None
+        self.metadata = request.metadata
+        self.binary_data = request.file_contents.data
+        await stream.send_message(FileUploadResponse)

--- a/tests/test_data_client.py
+++ b/tests/test_data_client.py
@@ -1,0 +1,90 @@
+import pytest
+
+from grpclib.testing import ChannelFor
+
+from viam.app.data import DataClient
+
+from .mocks.services import MockData
+
+AUTH_TOKEN = "auth_token"
+DATA_SERVICE_METADATA = {"authorization": f"Bearer {AUTH_TOKEN}"}
+
+
+@pytest.fixture(scope="function")
+def service() -> MockData:
+    return MockData()
+
+
+class TestClient:
+    @pytest.mark.asyncio
+    async def test_tabular_data_by_filter(self, service: MockData):
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+
+    @pytest.mark.asyncio
+    async def test_binary_data_by_filter(self, service: MockData):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_binary_data_by_ids(self, service: MockData):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_delete_tabular_data_by_filter(self, service: MockData):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_delete_binary_data_by_filter(self, service: MockData):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_delete_binary_data_by_ids(self, service: MockData):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_add_tags_to_binary_data_by_ids(self, service: MockData):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_add_tags_to_binary_data_by_filter(self, service: MockData):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_remove_tags_from_binary_data_by_ids(self, service: MockData):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_remove_tags_from_binary_data_by_filter(self, service: MockData):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_tags_by_filter(self, service: MockData):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_add_bounding_box_to_image_by_id(self, service: MockData):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_remove_bounding_box_from_image_by_id(self, service: MockData):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_bounding_box_labels_by_filter(self, service: MockData):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_binary_data_capture_upload(self, service: MockData):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_tabular_data_capture_upload(self, service: MockData):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_file_upload(self, service: MockData):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_file_upload_from_path(self, service: MockData):
+        pass

--- a/tests/test_data_client.py
+++ b/tests/test_data_client.py
@@ -11,11 +11,6 @@ from viam.proto.app.data import (
     CaptureInterval,
     TagsFilter
 )
-from viam.proto.app.datasync import (
-    UploadMetadata,
-    SensorData
-)
-from viam.utils import struct_to_dict
 
 from .mocks.services import MockData
 
@@ -30,8 +25,7 @@ LOCATION_ID = "location_id"
 LOCATION_IDS = [LOCATION_ID]
 ORG_ID = "organization_id"
 ORG_IDS = [ORG_ID]
-MIME_TYPE = "mime_type"
-MIME_TYPES = [MIME_TYPE]
+MIME_TYPES = ["mime_type"]
 SECONDS_START = 1689256710
 NANOS_START = 10
 SECONDS_END = 1689256810
@@ -63,17 +57,14 @@ FILTER = Filter(
         tags=TAGS
     ),
     bbox_labels=BBOX_LABELS,
-
 )
 FILE_ID = "file_id"
-LOCATION_ID = "location_id"
 BINARY_IDS = [BinaryID(
     file_id=FILE_ID,
     organization_id=ORG_ID,
     location_id=LOCATION_ID
 )]
 BINARY_DATA = b'binary_data'
-METHOD_NAME = "method_name"
 TIMESTAMPS = [(
     Timestamp(
         seconds=SECONDS_START,
@@ -84,12 +75,11 @@ TIMESTAMPS = [(
         nanos=NANOS_END
     )
 )]
-METHOD_PARAMETERS = None
 TABULAR_DATA = [{"key": "value"}]
 FILE_NAME = "file_name"
 FILE_EXT = "file_extension"
 
-TABULAR_RESPONSE = [{"key": "value"}]
+TABULAR_RESPONSE = TABULAR_DATA
 BINARY_RESPONSE = [BINARY_DATA]
 DELETE_REMOVE_RESPONSE = 1
 TAGS_RESPONSE = ["tag"]
@@ -117,7 +107,7 @@ class TestClient:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             tabular_data = await client.tabular_data_by_filter(filter=FILTER)
             assert tabular_data == TABULAR_RESPONSE
-            TestClient.assert_filter(filter=service.filter)
+            self.assert_filter(filter=service.filter)
 
     @pytest.mark.asyncio
     async def test_binary_data_by_filter(self, service: MockData):
@@ -125,7 +115,7 @@ class TestClient:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             binary_data = await client.binary_data_by_filter(filter=FILTER)
             assert binary_data == BINARY_RESPONSE
-            TestClient.assert_filter(filter=service.filter)
+            self.assert_filter(filter=service.filter)
 
     @pytest.mark.asyncio
     async def test_binary_data_by_ids(self, service: MockData):
@@ -133,7 +123,7 @@ class TestClient:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             binary_data = await client.binary_data_by_ids(binary_ids=BINARY_IDS)
             assert binary_data == BINARY_RESPONSE
-            TestClient.assert_binary_ids(binary_ids=service.binary_ids)
+            self.assert_binary_ids(binary_ids=service.binary_ids)
 
     @pytest.mark.asyncio
     async def test_delete_tabular_data_by_filter(self, service: MockData):
@@ -141,7 +131,7 @@ class TestClient:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             deleted_count = await client.delete_tabular_data_by_filter(filter=FILTER)
             assert deleted_count == DELETE_REMOVE_RESPONSE
-            TestClient.assert_filter(service.filter)
+            self.assert_filter(service.filter)
 
     @pytest.mark.asyncio
     async def test_delete_binary_data_by_filter(self, service: MockData):
@@ -149,7 +139,7 @@ class TestClient:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             deleted_count = await client.delete_binary_data_by_filter(filter=FILTER)
             assert deleted_count == DELETE_REMOVE_RESPONSE
-            TestClient.assert_filter(service.filter)
+            self.assert_filter(service.filter)
 
     @pytest.mark.asyncio
     async def test_delete_binary_data_by_ids(self, service: MockData):
@@ -157,7 +147,7 @@ class TestClient:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             deleted_count = await client.delete_binary_data_by_ids(binary_ids=BINARY_IDS)
             assert deleted_count == DELETE_REMOVE_RESPONSE
-            TestClient.assert_binary_ids(service.binary_ids)
+            self.assert_binary_ids(service.binary_ids)
 
     @pytest.mark.asyncio
     async def test_add_tags_to_binary_data_by_ids(self, service: MockData):
@@ -165,7 +155,7 @@ class TestClient:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             await client.add_tags_to_binary_data_by_ids(tags=TAGS, binary_ids=BINARY_IDS)
             assert service.tags == TAGS
-            TestClient.assert_binary_ids(service.binary_ids)
+            self.assert_binary_ids(service.binary_ids)
 
     @pytest.mark.asyncio
     async def test_add_tags_to_binary_data_by_filter(self, service: MockData):
@@ -173,7 +163,7 @@ class TestClient:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             await client.add_tags_to_binary_data_by_filter(tags=TAGS, filter=FILTER)
             assert service.tags == TAGS
-            TestClient.assert_filter(service.filter)
+            self.assert_filter(service.filter)
 
     @pytest.mark.asyncio
     async def test_remove_tags_from_binary_data_by_ids(self, service: MockData):
@@ -182,7 +172,7 @@ class TestClient:
             deleted_count = await client.remove_tags_from_binary_data_by_ids(tags=TAGS, binary_ids=BINARY_IDS)
             assert deleted_count == DELETE_REMOVE_RESPONSE
             assert service.tags == TAGS
-            TestClient.assert_binary_ids(service.binary_ids)
+            self.assert_binary_ids(service.binary_ids)
 
     @pytest.mark.asyncio
     async def test_remove_tags_from_binary_data_by_filter(self, service: MockData):
@@ -191,7 +181,7 @@ class TestClient:
             deleted_count = await client.remove_tags_from_binary_data_by_filter(tags=TAGS, filter=FILTER)
             assert deleted_count == DELETE_REMOVE_RESPONSE
             assert service.tags == TAGS
-            TestClient.assert_filter(service.filter)
+            self.assert_filter(service.filter)
 
     @pytest.mark.asyncio
     async def test_tags_by_filter(self, service: MockData):
@@ -199,7 +189,7 @@ class TestClient:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             tags = await client.tags_by_filter(filter=FILTER)
             assert tags == TAGS_RESPONSE
-            TestClient.assert_filter(service.filter)
+            self.assert_filter(service.filter)
 
     @pytest.mark.asyncio
     async def test_add_bounding_box_to_image_by_id(self, service: MockData):
@@ -215,83 +205,9 @@ class TestClient:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             bbox_labels = await client.bounding_box_labels_by_filter(filter=FILTER)
             assert bbox_labels == BBOX_LABELS_RESPONSE
-            TestClient.assert_filter(service.filter)
+            self.assert_filter(service.filter)
 
-    @pytest.mark.asyncio
-    async def test_binary_data_capture_upload(self, service: MockData):
-        async with ChannelFor([service]) as channel:
-            client = DataClient(channel, DATA_SERVICE_METADATA)
-            await client.binary_data_capture_upload(
-                part_id=PART_ID,
-                component_type=COMPONENT_TYPE,
-                component_name=COMPONENT_NAME,
-                method_name=METHOD_NAME,
-                method_parameters=METHOD_PARAMETERS,
-                tags=TAGS,
-                timestamps=TIMESTAMPS,
-                binary_data=BINARY_DATA
-            )
-            TestClient.assert_sensor_contents(service.sensor_contents)
-            TestClient.assert_metadata(service.metadata)
-
-    @pytest.mark.asyncio
-    async def test_tabular_data_capture_upload(self, service: MockData):
-        async with ChannelFor([service]) as channel:
-            client = DataClient(channel, DATA_SERVICE_METADATA)
-            await client.tabular_data_capture_upload(
-                part_id=PART_ID,
-                component_type=COMPONENT_TYPE,
-                component_name=COMPONENT_NAME,
-                method_name=METHOD_NAME,
-                method_parameters=METHOD_PARAMETERS,
-                tags=TAGS,
-                timestamps=TIMESTAMPS,
-                tabular_data=TABULAR_DATA
-            )
-            TestClient.assert_sensor_contents(service.sensor_contents)
-            TestClient.assert_metadata(service.metadata)
-
-    @pytest.mark.asyncio
-    async def test_file_upload(self, service: MockData):
-        async with ChannelFor([service]) as channel:
-            client = DataClient(channel, DATA_SERVICE_METADATA)
-            await client.file_upload(
-                part_id=PART_ID,
-                component_type=COMPONENT_TYPE,
-                component_name=COMPONENT_NAME,
-                method_name=METHOD_NAME,
-                file_name=FILE_NAME,
-                method_parameters=METHOD_PARAMETERS,
-                file_extension=FILE_EXT,
-                tags=TAGS,
-                data=BINARY_DATA
-            )
-            TestClient.assert_metadata(service.metadata)
-            assert service.metadata.file_name == FILE_NAME
-            assert service.metadata.file_extension == FILE_EXT
-            assert service.binary_data == BINARY_DATA
-
-    @pytest.mark.asyncio
-    async def test_file_upload_from_path(self, service: MockData, tmp_path):
-        async with ChannelFor([service]) as channel:
-            client = DataClient(channel, DATA_SERVICE_METADATA)
-            path = tmp_path / (FILE_NAME + FILE_EXT)
-            path.write_bytes(BINARY_DATA)
-            await client.file_upload_from_path(
-                part_id=PART_ID,
-                component_type=COMPONENT_TYPE,
-                component_name=COMPONENT_NAME,
-                method_name=METHOD_NAME,
-                method_parameters=METHOD_PARAMETERS,
-                tags=TAGS,
-                filepath=path.resolve()
-            )
-            TestClient.assert_metadata(service.metadata)
-            assert service.metadata.file_name == FILE_NAME
-            assert service.metadata.file_extension == FILE_EXT
-            assert service.binary_data == BINARY_DATA
-
-    def assert_filter(filter: Filter) -> None:
+    def assert_filter(self, filter: Filter) -> None:
         assert filter.component_name == COMPONENT_NAME
         assert filter.component_type == COMPONENT_TYPE
         assert filter.method == METHOD
@@ -309,27 +225,8 @@ class TestClient:
         assert filter.tags_filter.tags == TAGS
         assert filter.bbox_labels == BBOX_LABELS
 
-    def assert_binary_ids(binary_ids: List[BinaryID]) -> None:
+    def assert_binary_ids(self, binary_ids: List[BinaryID]) -> None:
         for binary_id in binary_ids:
             assert binary_id.file_id == FILE_ID
             assert binary_id.organization_id == ORG_ID
             assert binary_id.location_id == LOCATION_ID
-
-    def assert_sensor_contents(sensor_contents: List[SensorData], is_binary: bool):
-        for i, data in sensor_contents:
-            assert data.metadata.time_requested.seconds == TIMESTAMPS[i][0].seconds
-            assert data.metadata.time_requested.nanos == TIMESTAMPS[i][0].nanos
-            assert data.metadata.time_reeived.seconds == TIMESTAMPS[i][1].seconds
-            assert data.metadata.time_received.nanos == TIMESTAMPS[i][1].nanos
-            if is_binary:
-                assert data.binary == BINARY_DATA
-            else:
-                assert struct_to_dict(data.struct) == TABULAR_DATA[i]
-
-    def assert_metadata(metadata: UploadMetadata) -> None:
-        assert metadata.part_id == PART_ID
-        assert metadata.component_type == COMPONENT_TYPE
-        assert metadata.component_name == COMPONENT_NAME
-        assert metadata.method_name == METHOD_NAME
-        assert metadata.method_parameters == METHOD_PARAMETERS
-        assert metadata.tags == TAGS

--- a/tests/test_data_client.py
+++ b/tests/test_data_client.py
@@ -1,10 +1,96 @@
 import pytest
+from typing import List
 
 from grpclib.testing import ChannelFor
+from google.protobuf.timestamp_pb2 import Timestamp
 
-from viam.app.data import DataClient
+from viam.app.data.client import DataClient
+from viam.proto.app.data import (
+    Filter,
+    BinaryID,
+    CaptureInterval,
+    TagsFilter
+)
+from viam.proto.app.datasync import (
+    UploadMetadata,
+    SensorData
+)
+from viam.utils import struct_to_dict
 
 from .mocks.services import MockData
+
+COMPONENT_NAME = "component_name"
+COMPONENT_TYPE = "component_type"
+METHOD = "method"
+ROBOT_NAME = "robot_name"
+ROBOT_ID = "robot_id"
+PART_NAME = "part_name"
+PART_ID = "part_id"
+LOCATION_ID = "location_id"
+ORG_ID = "organization_id"
+MIME_TYPE = "mime_type"
+SECONDS_START = 1689256710
+NANOS_START = 10
+SECONDS_END = 1689256810
+NANOS_END = 10
+TAGS = ["tag"]
+BBOX_LABELS = ["bbox_label"]
+FILTER = Filter(
+    component_name=COMPONENT_NAME,
+    component_type=COMPONENT_TYPE,
+    method=METHOD,
+    robot_name=ROBOT_NAME,
+    robot_id=ROBOT_ID,
+    part_name=PART_NAME,
+    part_id=PART_ID,
+    location_ids=[LOCATION_ID],
+    organization_ids=[ORG_ID],
+    mime_type=[MIME_TYPE],
+    interval=CaptureInterval(
+        start=Timestamp(
+            seconds=SECONDS_START,
+            nanos=NANOS_START,
+        ),
+        end=Timestamp(
+            seconds=SECONDS_END,
+            nanos=NANOS_END
+        )
+    ),
+    tags_filter=TagsFilter(
+        tags=TAGS
+    ),
+    bbox_labels=BBOX_LABELS,
+
+)
+FILE_ID = "file_id"
+LOCATION_ID = "location_id"
+BINARY_IDS = [BinaryID(
+    file_id=FILE_ID,
+    organization_id=ORG_ID,
+    location_id=LOCATION_ID
+)]
+BINARY_DATA = b'binary_data'
+METHOD_NAME = "method_name"
+TIMESTAMPS = (
+    Timestamp(
+        seconds=SECONDS_START,
+        nanos=NANOS_START
+    ),
+    Timestamp(
+        seconds=SECONDS_END,
+        nanos=NANOS_END
+    )
+)
+METHOD_PARAMETERS = None
+TABULAR_DATA = [{"key": "value"}]
+FILE_NAME = "file_name"
+FILE_EXT = "file_extension"
+
+TABULAR_RESPONSE = [{"key": "value"}]
+BINARY_RESPONSE = [b'binary_data']
+DELETE_REMOVE_RESPONSE = 1
+TAGS_RESPONSE = ["tag"]
+BBOX_LABELS_RESPONSE = ["bbox_label"]
 
 AUTH_TOKEN = "auth_token"
 DATA_SERVICE_METADATA = {"authorization": f"Bearer {AUTH_TOKEN}"}
@@ -12,7 +98,13 @@ DATA_SERVICE_METADATA = {"authorization": f"Bearer {AUTH_TOKEN}"}
 
 @pytest.fixture(scope="function")
 def service() -> MockData:
-    return MockData()
+    return MockData(
+        tabular_response=TABULAR_RESPONSE,
+        binary_response=BINARY_RESPONSE,
+        delete_remove_response=DELETE_REMOVE_RESPONSE,
+        tags_response=TAGS_RESPONSE,
+        bbox_labels_response=BBOX_LABELS
+    )
 
 
 class TestClient:
@@ -20,71 +112,221 @@ class TestClient:
     async def test_tabular_data_by_filter(self, service: MockData):
         async with ChannelFor([service]) as channel:
             client = DataClient(channel, DATA_SERVICE_METADATA)
+            tabular_data = await client.tabular_data_by_filter(filter=FILTER)
+            assert tabular_data == TABULAR_RESPONSE
+            TestClient.assert_filter(filter=service.filter)
 
     @pytest.mark.asyncio
     async def test_binary_data_by_filter(self, service: MockData):
-        pass
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            binary_data = await client.binary_data_by_filter(filter=FILTER)
+            assert binary_data == BINARY_RESPONSE
+            TestClient.assert_filter(filter=service.filter)
 
     @pytest.mark.asyncio
     async def test_binary_data_by_ids(self, service: MockData):
-        pass
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            binary_data = await client.binary_data_by_ids(binary_ids=BINARY_IDS)
+            assert binary_data == BINARY_RESPONSE
+            TestClient.assert_binary_ids(binary_ids=service.binary_ids)
 
     @pytest.mark.asyncio
     async def test_delete_tabular_data_by_filter(self, service: MockData):
-        pass
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            deleted_count = await client.delete_tabular_data_by_filter(filter=FILTER)
+            assert deleted_count == DELETE_REMOVE_RESPONSE
+            TestClient.assert_filter(service.filter)
 
     @pytest.mark.asyncio
     async def test_delete_binary_data_by_filter(self, service: MockData):
-        pass
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            deleted_count = await client.delete_binary_data_by_filter(filter=FILTER)
+            assert deleted_count == DELETE_REMOVE_RESPONSE
+            TestClient.assert_filter(service.filter)
 
     @pytest.mark.asyncio
     async def test_delete_binary_data_by_ids(self, service: MockData):
-        pass
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            deleted_count = await client.delete_binary_data_by_ids(binary_ids=BINARY_IDS)
+            assert deleted_count == DELETE_REMOVE_RESPONSE
+            TestClient.assert_binary_ids(service.binary_ids)
 
     @pytest.mark.asyncio
     async def test_add_tags_to_binary_data_by_ids(self, service: MockData):
-        pass
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            await client.add_tags_to_binary_data_by_ids(tags=TAGS, binary_ids=BINARY_IDS)
+            assert service.tags == TAGS
+            TestClient.assert_binary_ids(service.binary_ids)
 
     @pytest.mark.asyncio
     async def test_add_tags_to_binary_data_by_filter(self, service: MockData):
-        pass
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            await client.add_tags_to_binary_data_by_filter(tags=TAGS, filter=FILTER)
+            assert service.tags == TAGS
+            TestClient.assert_filter(service.filter)
 
     @pytest.mark.asyncio
     async def test_remove_tags_from_binary_data_by_ids(self, service: MockData):
-        pass
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            deleted_count = await client.remove_tags_from_binary_data_by_ids(tags=TAGS, binary_ids=BINARY_IDS)
+            assert deleted_count == DELETE_REMOVE_RESPONSE
+            assert service.tags == TAGS
+            TestClient.assert_binary_ids(service.binary_ids)
 
     @pytest.mark.asyncio
     async def test_remove_tags_from_binary_data_by_filter(self, service: MockData):
-        pass
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            deleted_count = await client.remove_tags_from_binary_data_by_filter(tags=TAGS, filter=FILTER)
+            assert deleted_count == DELETE_REMOVE_RESPONSE
+            assert service.tags == TAGS
+            TestClient.assert_binary_ids(service.binary_ids)
 
     @pytest.mark.asyncio
     async def test_tags_by_filter(self, service: MockData):
-        pass
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            tags = await client.tags_by_filter(filter=FILTER)
+            assert tags == TAGS_RESPONSE
+            TestClient.assert_filter(service.filter)
 
     @pytest.mark.asyncio
     async def test_add_bounding_box_to_image_by_id(self, service: MockData):
-        pass
+        assert True
 
     @pytest.mark.asyncio
     async def test_remove_bounding_box_from_image_by_id(self, service: MockData):
-        pass
+        assert True
 
     @pytest.mark.asyncio
     async def test_bounding_box_labels_by_filter(self, service: MockData):
-        pass
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            bbox_labels = client.bounding_box_labels_by_filter(filter=FILTER)
+            assert bbox_labels == BBOX_LABELS_RESPONSE
+            TestClient.assert_filter(service.filter)
 
     @pytest.mark.asyncio
     async def test_binary_data_capture_upload(self, service: MockData):
-        pass
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            await client.binary_data_capture_upload(
+                part_id=PART_ID,
+                component_type=COMPONENT_TYPE,
+                component_name=COMPONENT_NAME,
+                method_name=METHOD_NAME,
+                method_parameters=METHOD_PARAMETERS,
+                tags=TAGS,
+                timestamps=TIMESTAMPS,
+                binary_data=BINARY_DATA
+            )
+            TestClient.assert_sensor_contents(service.sensor_contents)
+            TestClient.assert_metadata(service.metadata)
 
     @pytest.mark.asyncio
     async def test_tabular_data_capture_upload(self, service: MockData):
-        pass
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            await client.binary_data_capture_upload(
+                part_id=PART_ID,
+                component_type=COMPONENT_TYPE,
+                component_name=COMPONENT_NAME,
+                method_name=METHOD_NAME,
+                method_parameters=METHOD_PARAMETERS,
+                tags=TAGS,
+                timestamps=TIMESTAMPS,
+                tabular_data=TABULAR_DATA
+            )
+            TestClient.assert_sensor_contents(service.sensor_contents)
+            TestClient.assert_metadata(service.metadata)
 
     @pytest.mark.asyncio
     async def test_file_upload(self, service: MockData):
-        pass
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            await client.file_upload(
+                part_id=PART_ID,
+                component_type=COMPONENT_TYPE,
+                component_name=COMPONENT_NAME,
+                method_name=METHOD_NAME,
+                file_name=FILE_NAME,
+                method_parameters=METHOD_PARAMETERS,
+                file_extension=FILE_EXT,
+                tags=TAGS,
+                data=BINARY_DATA
+            )
+            TestClient.assert_metadata(service.metadata)
+            assert service.metadata.file_name == FILE_NAME
+            assert service.metadata.file_extension == FILE_EXT
+            assert service.binary_data == BINARY_DATA
 
     @pytest.mark.asyncio
-    async def test_file_upload_from_path(self, service: MockData):
-        pass
+    async def test_file_upload_from_path(self, service: MockData, tmp_path):
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            path = tmp_path / (FILE_NAME + FILE_EXT)
+            path.write_bytes(BINARY_DATA)
+            await client.file_upload(
+                part_id=PART_ID,
+                component_type=COMPONENT_TYPE,
+                component_name=COMPONENT_NAME,
+                method_name=METHOD_NAME,
+                method_parameters=METHOD_PARAMETERS,
+                tags=TAGS,
+                filepath=path.resolve()
+            )
+            TestClient.assert_metadata(service.metadata)
+            assert service.metadata.file_name == FILE_NAME
+            assert service.metadata.file_extension == FILE_EXT
+            assert service.binary_data == BINARY_DATA
+
+    def assert_filter(filter: Filter) -> None:
+        assert filter.component_name == COMPONENT_NAME
+        assert filter.component_type == COMPONENT_TYPE
+        assert filter.method == METHOD
+        assert filter.robot_name == ROBOT_NAME
+        assert filter.robot_id == ROBOT_ID
+        assert filter.part_name == PART_NAME
+        assert filter.part_id == PART_ID
+        assert filter.location_id == LOCATION_ID
+        assert filter.org_id == ORG_ID
+        assert filter.mime_type == MIME_TYPE
+        assert filter.interval.start.seconds_start == SECONDS_START
+        assert filter.interval.start.nanos_start == NANOS_START
+        assert filter.interval.end.seconds_end == SECONDS_END
+        assert filter.interval.end.nanos_end == NANOS_END
+        assert filter.tags_filter.tags == TAGS
+        assert filter.bbox_labels == BBOX_LABELS
+
+    def assert_binary_ids(binary_ids: List[BinaryID]) -> None:
+        for binary_id in binary_ids:
+            assert binary_id.file_id == FILE_ID
+            assert binary_id.organization_id == ORG_ID
+            assert binary_id.location_id == LOCATION_ID
+
+    def assert_sensor_contents(sensor_contents: List[SensorData], is_binary: bool):
+        for i, data in sensor_contents:
+            assert data.metadata.time_requested.seconds == TIMESTAMPS[0].seconds
+            assert data.metadata.time_requested.nanos == TIMESTAMPS[0].nanos
+            assert data.metadata.time_reeived.seconds == TIMESTAMPS[1].seconds
+            assert data.metadata.time_received.nanos == TIMESTAMPS[1].nanos
+            if is_binary:
+                assert data.binary == BINARY_DATA
+            else:
+                assert struct_to_dict(data.struct) == TABULAR_DATA[i]
+
+    def assert_metadata(metadata: UploadMetadata) -> None:
+        assert metadata.part_id == PART_ID
+        assert metadata.component_type == COMPONENT_TYPE
+        assert metadata.component_name == COMPONENT_NAME
+        assert metadata.method_name == METHOD_NAME
+        assert metadata.method_parameters == METHOD_PARAMETERS
+        assert metadata.tags == TAGS

--- a/tests/test_data_client.py
+++ b/tests/test_data_client.py
@@ -131,7 +131,7 @@ class TestClient:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             deleted_count = await client.delete_tabular_data_by_filter(filter=FILTER)
             assert deleted_count == DELETE_REMOVE_RESPONSE
-            self.assert_filter(service.filter)
+            self.assert_filter(filter=service.filter)
 
     @pytest.mark.asyncio
     async def test_delete_binary_data_by_filter(self, service: MockData):
@@ -139,7 +139,7 @@ class TestClient:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             deleted_count = await client.delete_binary_data_by_filter(filter=FILTER)
             assert deleted_count == DELETE_REMOVE_RESPONSE
-            self.assert_filter(service.filter)
+            self.assert_filter(filter=service.filter)
 
     @pytest.mark.asyncio
     async def test_delete_binary_data_by_ids(self, service: MockData):
@@ -163,7 +163,7 @@ class TestClient:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             await client.add_tags_to_binary_data_by_filter(tags=TAGS, filter=FILTER)
             assert service.tags == TAGS
-            self.assert_filter(service.filter)
+            self.assert_filter(filter=service.filter)
 
     @pytest.mark.asyncio
     async def test_remove_tags_from_binary_data_by_ids(self, service: MockData):
@@ -181,7 +181,7 @@ class TestClient:
             deleted_count = await client.remove_tags_from_binary_data_by_filter(tags=TAGS, filter=FILTER)
             assert deleted_count == DELETE_REMOVE_RESPONSE
             assert service.tags == TAGS
-            self.assert_filter(service.filter)
+            self.assert_filter(filter=service.filter)
 
     @pytest.mark.asyncio
     async def test_tags_by_filter(self, service: MockData):
@@ -189,7 +189,7 @@ class TestClient:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             tags = await client.tags_by_filter(filter=FILTER)
             assert tags == TAGS_RESPONSE
-            self.assert_filter(service.filter)
+            self.assert_filter(filter=service.filter)
 
     @pytest.mark.asyncio
     async def test_add_bounding_box_to_image_by_id(self, service: MockData):
@@ -205,7 +205,7 @@ class TestClient:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             bbox_labels = await client.bounding_box_labels_by_filter(filter=FILTER)
             assert bbox_labels == BBOX_LABELS_RESPONSE
-            self.assert_filter(service.filter)
+            self.assert_filter(filter=service.filter)
 
     def assert_filter(self, filter: Filter) -> None:
         assert filter.component_name == COMPONENT_NAME

--- a/tests/test_data_sync_client.py
+++ b/tests/test_data_sync_client.py
@@ -1,8 +1,8 @@
 import pytest
+from datetime import datetime
 from typing import List
 
 from grpclib.testing import ChannelFor
-from google.protobuf.timestamp_pb2 import Timestamp
 
 from viam.app.data.client import DataClient
 from viam.proto.app.datasync import (
@@ -23,16 +23,8 @@ NANOS_END = 10
 TAGS = ["tag"]
 BINARY_DATA = b'binary_data'
 METHOD_NAME = "method_name"
-TIMESTAMPS = (
-    Timestamp(
-        seconds=SECONDS_START,
-        nanos=NANOS_START
-    ),
-    Timestamp(
-        seconds=SECONDS_END,
-        nanos=NANOS_END
-    )
-)
+DATETIMES = (datetime.now(), datetime.now())
+TIMESTAMPS = (DataClient.datetime_to_timestamp(DATETIMES[0]), DataClient.datetime_to_timestamp(DATETIMES[1]))
 METHOD_PARAMETERS = {}
 TABULAR_DATA = [{"key": "value"}]
 FILE_NAME = "file_name"
@@ -59,7 +51,7 @@ class TestClient:
                 method_name=METHOD_NAME,
                 method_parameters=METHOD_PARAMETERS,
                 tags=TAGS,
-                timestamps=TIMESTAMPS,
+                datetimes=DATETIMES,
                 binary_data=BINARY_DATA
             )
             self.assert_sensor_contents(sensor_contents=service.sensor_contents, is_binary=True)
@@ -76,7 +68,7 @@ class TestClient:
                 method_name=METHOD_NAME,
                 method_parameters=METHOD_PARAMETERS,
                 tags=TAGS,
-                timestamps=[TIMESTAMPS],
+                datetimes=[DATETIMES],
                 tabular_data=TABULAR_DATA
             )
             self.assert_sensor_contents(sensor_contents=service.sensor_contents, is_binary=False)

--- a/tests/test_data_sync_client.py
+++ b/tests/test_data_sync_client.py
@@ -59,7 +59,7 @@ class TestClient:
                 method_name=METHOD_NAME,
                 method_parameters=METHOD_PARAMETERS,
                 tags=TAGS,
-                timestamps=TIMESTAMPS,
+                timestamps=TIMESTAMPS[0],
                 binary_data=BINARY_DATA
             )
             self.assert_sensor_contents(sensor_contents=service.sensor_contents, is_binary=True)

--- a/tests/test_data_sync_client.py
+++ b/tests/test_data_sync_client.py
@@ -51,7 +51,7 @@ class TestClient:
                 method_name=METHOD_NAME,
                 method_parameters=METHOD_PARAMETERS,
                 tags=TAGS,
-                datetimes=DATETIMES,
+                data_request_times=DATETIMES,
                 binary_data=BINARY_DATA
             )
             self.assert_sensor_contents(sensor_contents=service.sensor_contents, is_binary=True)
@@ -68,7 +68,7 @@ class TestClient:
                 method_name=METHOD_NAME,
                 method_parameters=METHOD_PARAMETERS,
                 tags=TAGS,
-                datetimes=[DATETIMES],
+                data_request_times=[DATETIMES],
                 tabular_data=TABULAR_DATA
             )
             self.assert_sensor_contents(sensor_contents=service.sensor_contents, is_binary=False)

--- a/tests/test_data_sync_client.py
+++ b/tests/test_data_sync_client.py
@@ -23,7 +23,7 @@ NANOS_END = 10
 TAGS = ["tag"]
 BINARY_DATA = b'binary_data'
 METHOD_NAME = "method_name"
-TIMESTAMPS = [(
+TIMESTAMPS = (
     Timestamp(
         seconds=SECONDS_START,
         nanos=NANOS_START
@@ -32,7 +32,7 @@ TIMESTAMPS = [(
         seconds=SECONDS_END,
         nanos=NANOS_END
     )
-)]
+)
 METHOD_PARAMETERS = {}
 TABULAR_DATA = [{"key": "value"}]
 FILE_NAME = "file_name"
@@ -76,7 +76,7 @@ class TestClient:
                 method_name=METHOD_NAME,
                 method_parameters=METHOD_PARAMETERS,
                 tags=TAGS,
-                timestamps=TIMESTAMPS,  # tabular_upload takes in a list of tuples.
+                timestamps=[TIMESTAMPS],
                 tabular_data=TABULAR_DATA
             )
             self.assert_sensor_contents(sensor_contents=service.sensor_contents, is_binary=False)
@@ -124,14 +124,14 @@ class TestClient:
 
     def assert_sensor_contents(self, sensor_contents: List[SensorData], is_binary: bool):
         for i in range(len(sensor_contents)):
-            assert sensor_contents[i].metadata.time_requested.seconds == TIMESTAMPS[i][0].seconds
-            assert sensor_contents[i].metadata.time_requested.nanos == TIMESTAMPS[i][0].nanos
-            assert sensor_contents[i].metadata.time_received.seconds == TIMESTAMPS[i][1].seconds
-            assert sensor_contents[i].metadata.time_received.nanos == TIMESTAMPS[i][1].nanos
-            if is_binary:
-                assert sensor_contents[i].binary == BINARY_DATA
-            else:
-                assert struct_to_dict(sensor_contents[i].struct) == TABULAR_DATA[i]
+            assert sensor_contents[i].metadata.time_requested.seconds == TIMESTAMPS[0].seconds
+            assert sensor_contents[i].metadata.time_requested.nanos == TIMESTAMPS[0].nanos
+            assert sensor_contents[i].metadata.time_received.seconds == TIMESTAMPS[1].seconds
+            assert sensor_contents[i].metadata.time_received.nanos == TIMESTAMPS[1].nanos
+        if is_binary:
+            assert sensor_contents[0].binary == BINARY_DATA
+        else:
+            assert struct_to_dict(sensor_contents[i].struct) == TABULAR_DATA[i]
 
     def assert_metadata(self, metadata: UploadMetadata) -> None:
         assert metadata.part_id == PART_ID

--- a/tests/test_data_sync_client.py
+++ b/tests/test_data_sync_client.py
@@ -1,0 +1,142 @@
+import pytest
+from typing import List
+
+from grpclib.testing import ChannelFor
+from google.protobuf.timestamp_pb2 import Timestamp
+
+from viam.app.data.client import DataClient
+from viam.proto.app.datasync import (
+    UploadMetadata,
+    SensorData
+)
+from viam.utils import struct_to_dict
+
+from .mocks.services import MockDataSync
+
+COMPONENT_NAME = "component_name"
+COMPONENT_TYPE = "component_type"
+PART_ID = "part_id"
+SECONDS_START = 1689256710
+NANOS_START = 10
+SECONDS_END = 1689256810
+NANOS_END = 10
+TAGS = ["tag"]
+BINARY_DATA = b'binary_data'
+METHOD_NAME = "method_name"
+TIMESTAMPS = [(
+    Timestamp(
+        seconds=SECONDS_START,
+        nanos=NANOS_START
+    ),
+    Timestamp(
+        seconds=SECONDS_END,
+        nanos=NANOS_END
+    )
+)]
+METHOD_PARAMETERS = {}
+TABULAR_DATA = [{"key": "value"}]
+FILE_NAME = "file_name"
+FILE_EXT = ".file_extension"
+
+AUTH_TOKEN = "auth_token"
+DATA_SERVICE_METADATA = {"authorization": f"Bearer {AUTH_TOKEN}"}
+
+
+@pytest.fixture(scope="function")
+def service() -> MockDataSync:
+    return MockDataSync()
+
+
+class TestClient:
+    @pytest.mark.asyncio
+    async def test_binary_data_capture_upload(self, service: MockDataSync):
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            await client.binary_data_capture_upload(
+                part_id=PART_ID,
+                component_type=COMPONENT_TYPE,
+                component_name=COMPONENT_NAME,
+                method_name=METHOD_NAME,
+                method_parameters=METHOD_PARAMETERS,
+                tags=TAGS,
+                timestamps=TIMESTAMPS,
+                binary_data=BINARY_DATA
+            )
+            self.assert_sensor_contents(sensor_contents=service.sensor_contents, is_binary=True)
+            self.assert_metadata(metadata=service.metadata)
+
+    @pytest.mark.asyncio
+    async def test_tabular_data_capture_upload(self, service: MockDataSync):
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            await client.tabular_data_capture_upload(
+                part_id=PART_ID,
+                component_type=COMPONENT_TYPE,
+                component_name=COMPONENT_NAME,
+                method_name=METHOD_NAME,
+                method_parameters=METHOD_PARAMETERS,
+                tags=TAGS,
+                timestamps=TIMESTAMPS,
+                tabular_data=TABULAR_DATA
+            )
+            self.assert_sensor_contents(sensor_contents=service.sensor_contents, is_binary=False)
+            self.assert_metadata(metadata=service.metadata)
+
+    @pytest.mark.asyncio
+    async def test_file_upload(self, service: MockDataSync):
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            await client.file_upload(
+                part_id=PART_ID,
+                component_type=COMPONENT_TYPE,
+                component_name=COMPONENT_NAME,
+                method_name=METHOD_NAME,
+                file_name=FILE_NAME,
+                method_parameters=METHOD_PARAMETERS,
+                file_extension=FILE_EXT,
+                tags=TAGS,
+                data=BINARY_DATA
+            )
+            self.assert_metadata(service.metadata)
+            assert service.metadata.file_name == FILE_NAME
+            assert service.metadata.file_extension == FILE_EXT
+            assert service.binary_data == BINARY_DATA
+
+    @pytest.mark.asyncio
+    async def test_file_upload_from_path(self, service: MockDataSync, tmp_path):
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            path = tmp_path / (FILE_NAME + FILE_EXT)
+            path.write_bytes(BINARY_DATA)
+            await client.file_upload_from_path(
+                part_id=PART_ID,
+                component_type=COMPONENT_TYPE,
+                component_name=COMPONENT_NAME,
+                method_name=METHOD_NAME,
+                method_parameters=METHOD_PARAMETERS,
+                tags=TAGS,
+                filepath=path.resolve()
+            )
+            self.assert_metadata(service.metadata)
+            assert service.metadata.file_name == FILE_NAME
+            assert service.metadata.file_extension == FILE_EXT
+            assert service.binary_data == BINARY_DATA
+
+    def assert_sensor_contents(self, sensor_contents: List[SensorData], is_binary: bool):
+        for i in range(len(sensor_contents)):
+            assert sensor_contents[i].metadata.time_requested.seconds == TIMESTAMPS[i][0].seconds
+            assert sensor_contents[i].metadata.time_requested.nanos == TIMESTAMPS[i][0].nanos
+            assert sensor_contents[i].metadata.time_received.seconds == TIMESTAMPS[i][1].seconds
+            assert sensor_contents[i].metadata.time_received.nanos == TIMESTAMPS[i][1].nanos
+            if is_binary:
+                assert sensor_contents[i].binary == BINARY_DATA
+            else:
+                assert struct_to_dict(sensor_contents[i].struct) == TABULAR_DATA[i]
+
+    def assert_metadata(self, metadata: UploadMetadata) -> None:
+        assert metadata.part_id == PART_ID
+        assert metadata.component_type == COMPONENT_TYPE
+        assert metadata.component_name == COMPONENT_NAME
+        assert metadata.method_name == METHOD_NAME
+        assert metadata.method_parameters == METHOD_PARAMETERS
+        assert metadata.tags == TAGS

--- a/tests/test_data_sync_client.py
+++ b/tests/test_data_sync_client.py
@@ -59,7 +59,7 @@ class TestClient:
                 method_name=METHOD_NAME,
                 method_parameters=METHOD_PARAMETERS,
                 tags=TAGS,
-                timestamps=TIMESTAMPS[0],
+                timestamps=TIMESTAMPS,
                 binary_data=BINARY_DATA
             )
             self.assert_sensor_contents(sensor_contents=service.sensor_contents, is_binary=True)
@@ -76,7 +76,7 @@ class TestClient:
                 method_name=METHOD_NAME,
                 method_parameters=METHOD_PARAMETERS,
                 tags=TAGS,
-                timestamps=TIMESTAMPS,
+                timestamps=TIMESTAMPS,  # tabular_upload takes in a list of tuples.
                 tabular_data=TABULAR_DATA
             )
             self.assert_sensor_contents(sensor_contents=service.sensor_contents, is_binary=False)


### PR DESCRIPTION
This PR implements two separate test clients that combine to test every gRPC method wrapper defined in our DataClient class. Tthe PR also implements two mock services that simulate responses from app. One test client/mock service duo is for the data methods, and the other is for the data sync (upload) methods. Finally, the PR also updates binary_data_by_filter() to return a list of bytes--as opposed to a list of SensorData objects.