### PR TITLE
[hotfix] Make it such that depth images always return RawImage

### DIFF
--- a/src/viam/components/camera/client.py
+++ b/src/viam/components/camera/client.py
@@ -26,8 +26,8 @@ from . import Camera, RawImage
 def get_image_from_response(data: bytes, response_mime_type: str, request_mime_type: Optional[str] = None) -> Union[Image.Image, RawImage]:
     if request_mime_type is None:
         request_mime_type = response_mime_type
-    _, is_lazy = CameraMimeType.from_lazy(request_mime_type)
-    if is_lazy or not (CameraMimeType.is_supported(response_mime_type)):
+    mime_type, is_lazy = CameraMimeType.from_lazy(request_mime_type)
+    if is_lazy or mime_type._should_be_raw:
         image = RawImage(data=data, mime_type=response_mime_type)
         return image
     return Image.open(BytesIO(data), formats=LIBRARY_SUPPORTED_FORMATS)


### PR DESCRIPTION
With the addition of `CameraMimeType.VIAM_RAW_DEPTH`, raw depth images are *technically* supported. However, they are not supported by PIL. Our current code only looks to see if the mime type is supported by viam, but not if the mime type is supported by PIL. 

This is a hotfix that will temporarily fix this issue. I say temporarily because once [this ticket](https://viam.atlassian.net/browse/RSDK-4089) is approved and merged, it will actually be a moot point. 