### PR TITLE
RSDK-4578: Python SDK Base Properties

### DIFF
--- a/examples/server/v1/components.py
+++ b/examples/server/v1/components.py
@@ -184,7 +184,7 @@ class ExampleBase(Base):
         self.angular_pwr = Vector3(x=0, y=0, z=0)
         self.linear_vel = Vector3(x=0, y=0, z=0)
         self.angular_vel = Vector3(x=0, y=0, z=0)
-        self.props = Base.Properties(1.0, 1.0)
+        self.props = Base.Properties(1.0, 1.0, 1.0)
         super().__init__(name)
 
     async def move_straight(self, distance: int, velocity: float, extra: Optional[Dict[str, Any]] = None, **kwargs):

--- a/src/viam/components/base/base.py
+++ b/src/viam/components/base/base.py
@@ -23,6 +23,7 @@ class Base(ComponentBase):
     class Properties:
         width_meters: float
         turning_radius_meters: float
+        wheel_circumference_meters: float
 
     @abc.abstractmethod
     async def move_straight(

--- a/src/viam/components/base/client.py
+++ b/src/viam/components/base/client.py
@@ -119,9 +119,11 @@ class BaseClient(Base, ReconfigurableResourceRPCClientBase):
             extra = {}
         request = GetPropertiesRequest(name=self.name, extra=dict_to_struct(extra))
         response: GetPropertiesResponse = await self.client.GetProperties(request, timeout=timeout)
-        return Base.Properties(width_meters=response.width_meters,
-                               turning_radius_meters=response.turning_radius_meters,
-                               wheel_circumference_meters=response.wheel_circumference_meters)
+        return Base.Properties(
+            width_meters=response.width_meters,
+            turning_radius_meters=response.turning_radius_meters,
+            wheel_circumference_meters=response.wheel_circumference_meters,
+        )
 
     async def do_command(
         self,

--- a/src/viam/components/base/client.py
+++ b/src/viam/components/base/client.py
@@ -119,7 +119,9 @@ class BaseClient(Base, ReconfigurableResourceRPCClientBase):
             extra = {}
         request = GetPropertiesRequest(name=self.name, extra=dict_to_struct(extra))
         response: GetPropertiesResponse = await self.client.GetProperties(request, timeout=timeout)
-        return Base.Properties(width_meters=response.width_meters, turning_radius_meters=response.turning_radius_meters)
+        return Base.Properties(width_meters=response.width_meters,
+                               turning_radius_meters=response.turning_radius_meters,
+                               wheel_circumference_meters=response.wheel_circumference_meters)
 
     async def do_command(
         self,

--- a/src/viam/components/base/service.py
+++ b/src/viam/components/base/service.py
@@ -112,7 +112,9 @@ class BaseRPCService(BaseServiceBase, ResourceRPCServiceBase):
         base = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         properties = await base.get_properties(timeout=timeout, metadata=stream.metadata)
-        response = GetPropertiesResponse(width_meters=properties.width_meters, turning_radius_meters=properties.turning_radius_meters)
+        response = GetPropertiesResponse(width_meters=properties.width_meters,
+                                         turning_radius_meters=properties.turning_radius_meters,
+                                         wheel_circumference_meters=properties.wheel_circumference_meters)
         await stream.send_message(response)
 
     async def DoCommand(self, stream: Stream[DoCommandRequest, DoCommandResponse]) -> None:

--- a/src/viam/components/base/service.py
+++ b/src/viam/components/base/service.py
@@ -112,9 +112,11 @@ class BaseRPCService(BaseServiceBase, ResourceRPCServiceBase):
         base = self.get_resource(name)
         timeout = stream.deadline.time_remaining() if stream.deadline else None
         properties = await base.get_properties(timeout=timeout, metadata=stream.metadata)
-        response = GetPropertiesResponse(width_meters=properties.width_meters,
-                                         turning_radius_meters=properties.turning_radius_meters,
-                                         wheel_circumference_meters=properties.wheel_circumference_meters)
+        response = GetPropertiesResponse(
+            width_meters=properties.width_meters,
+            turning_radius_meters=properties.turning_radius_meters,
+            wheel_circumference_meters=properties.wheel_circumference_meters,
+        )
         await stream.send_message(response)
 
     async def DoCommand(self, stream: Stream[DoCommandRequest, DoCommandResponse]) -> None:

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -176,7 +176,7 @@ class MockBase(Base):
         self.geometries = GEOMETRIES
         self.extra: Optional[Dict[str, Any]] = None
         self.timeout: Optional[float] = None
-        self.props = Base.Properties(1.0, 1.0)
+        self.props = Base.Properties(1.0, 1.0, 1.0)
         super().__init__(name)
 
     async def move_straight(

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -176,7 +176,7 @@ class MockBase(Base):
         self.geometries = GEOMETRIES
         self.extra: Optional[Dict[str, Any]] = None
         self.timeout: Optional[float] = None
-        self.props = Base.Properties(1.0, 1.0, 1.0)
+        self.props = Base.Properties(1.0, 2.0, 3.0)
         super().__init__(name)
 
     async def move_straight(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -108,6 +108,13 @@ class TestBase:
         assert not await base.is_moving()
 
     @pytest.mark.asyncio
+    async def test_get_properties(self, base: MockBase):
+        properties = await base.get_properties()
+        assert properties.width_meters == 1.0
+        assert properties.turning_radius_meters == 2.0
+        assert properties.wheel_circumference_meters == 3.0
+
+    @pytest.mark.asyncio
     async def test_do(self, base: MockBase):
         command = {"command": "args"}
         resp = await base.do_command(command)


### PR DESCRIPTION
Update python SDK to include new base property `wheel_circumference_meters`

Note to reviewers: I am not sure if there's something I have to do to specifically update this PR to use the most recent API changes? I'm seeing some errors which I believe are because it's not referencing the most recent version of API. 

Edit: It passed all the checks though so maybe that was just a local issue