### PR TITLE
RSDK-4646 Add NoCaptureToStoreError to SDK

### DIFF
--- a/src/viam/errors.py
+++ b/src/viam/errors.py
@@ -93,3 +93,13 @@ class ValidationError(ViamGRPCError):
     def __init__(self, message: str):
         self.message = message
         self.grpc_code = Status.INVALID_ARGUMENT
+
+
+class NoCaptureToStoreError(ViamGRPCError):
+    """
+    Exception raised in filter module to signal that data capture should not be stored
+    """
+
+    def __init__(self):
+        self.message = "no capture from filter module"
+        self.grpc_code = Status.FAILED_PRECONDITION

--- a/src/viam/errors.py
+++ b/src/viam/errors.py
@@ -101,5 +101,5 @@ class NoCaptureToStoreError(ViamGRPCError):
     """
 
     def __init__(self):
-        self.message = "no capture from filter module"
+        self.message = "no capture from filter module"  # Do not change the contents of this string
         self.grpc_code = Status.FAILED_PRECONDITION


### PR DESCRIPTION
To filter captured data, the data management collectors check for a custom [grpc error](https://github.com/viamrobotics/rdk/blob/0a907bf7fdfe4b5649cb0c8598fa41766c542b6f/data/collector.go#L41). Expose this error in the SDK so that users coding in python can return this error in their modular resource code.