### PR TITLE
[RSDK 4654] Add 'Include Binary' Option

### DIFF
--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -174,7 +174,7 @@ class DataClient:
         return data
 
     async def binary_data_by_filter(
-        self, filter: Optional[Filter] = None, dest: Optional[str] = None, include_file_data: bool = False, num_files: Optional[int] = None
+        self, filter: Optional[Filter] = None, dest: Optional[str] = None, include_file_data: bool = True, num_files: Optional[int] = None
     ) -> List[BinaryData]:
         """Filter and download binary data.
 

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -226,9 +226,7 @@ class DataClient:
 
         return data
 
-    async def _binary_data_by_filter(
-        self, filter: Filter, limit: int, include_binary: bool, last: str
-    ) -> Tuple[List[BinaryData], str]:
+    async def _binary_data_by_filter(self, filter: Filter, limit: int, include_binary: bool, last: str) -> Tuple[List[BinaryData], str]:
         data_request = DataRequest(filter=filter, limit=limit, last=last)
         request = BinaryDataByFilterRequest(data_request=data_request, count_only=False, include_binary=include_binary)
         response: BinaryDataByFilterResponse = await self._data_client.BinaryDataByFilter(request, metadata=self._metadata)

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -183,7 +183,7 @@ class DataClient:
                 binary data.
             dest (Optional[str]): Optional filepath for writing retrieved data.
             include_file_data (bool): Boolean specifying whether to actually include the binary file data with each retrieved file. Defaults
-                to false (i.e., only the files' metadata is returned).
+                to true (i.e., both the files' data and metadata are returned).
             num_files (Optional[str]): Number of binary data to return. Passing 0 returns all binary data matching the filter no matter.
                 Defaults to 100 if no binary data is requested, otherwise 10. All binary data or the first `num_files` will be returned,
                     whichever comes first.

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -179,7 +179,7 @@ class DataClient:
         """Filter and download binary data.
 
         Args:
-            filter (Optional[viam.proto.app.data.Filter]): Optional `Filter` specifying binary data to retrieve. No `Filter` implies al
+            filter (Optional[viam.proto.app.data.Filter]): Optional `Filter` specifying binary data to retrieve. No `Filter` implies all
                 binary data.
             dest (Optional[str]): Optional filepath for writing retrieved data.
             include_file_data (bool): Boolean specifying whether to actually include the binary file data with each retrieved file. Defaults

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -177,12 +177,15 @@ class DataClient:
         self,
         filter: Optional[Filter] = None,
         dest: Optional[str] = None,
+        include_binary: bool = False
     ) -> List[BinaryData]:
         """Filter and download binary data.
 
         Args:
             filter (viam.proto.app.data.Filter): Optional `Filter` specifying binary data to retrieve. No `Filter` implies all binary data.
             dest (str): Optional filepath for writing retrieved data.
+            include_binary (bool): Boolean specifying whether to actually include theh binary file data with each retrieved file. Defaults
+                to false (i.e., only the files' metadata is returned).
 
         Returns:
             List[bytes]: The binary data.
@@ -194,8 +197,8 @@ class DataClient:
         # `DataRequest`s are limited to 100 pieces of data, so we loop through calls until
         # we are certain we've received everything.
         while True:
-            data_request = DataRequest(filter=filter, limit=100, last=last)
-            request = BinaryDataByFilterRequest(data_request=data_request, count_only=False)
+            data_request = DataRequest(filter=filter, limit=1 if include_binary else 100, last=last)
+            request = BinaryDataByFilterRequest(data_request=data_request, count_only=False, include_binary=include_binary)
             response: BinaryDataByFilterResponse = await self._data_client.BinaryDataByFilter(request, metadata=self._metadata)
             if not response.data or len(response.data) == 0:
                 break

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -174,10 +174,7 @@ class DataClient:
         return data
 
     async def binary_data_by_filter(
-        self,
-        filter: Optional[Filter] = None,
-        dest: Optional[str] = None,
-        include_binary: bool = False
+        self, filter: Optional[Filter] = None, dest: Optional[str] = None, include_binary: bool = False
     ) -> List[BinaryData]:
         """Filter and download binary data.
 

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -185,8 +185,8 @@ class DataClient:
             include_file_data (bool): Boolean specifying whether to actually include the binary file data with each retrieved file. Defaults
                 to false (i.e., only the files' metadata is returned).
             num_files (Optional[str]): Number of binary data to return. Passing 0 returns all binary data matching the filter no matter.
-                Defaults to 100 if no binary data is requested, otherwise 10. All binary data or the first `num_binary_data` will be
-                returned, whichever comes first.
+                Defaults to 100 if no binary data is requested, otherwise 10. All binary data or the first `num_files` will be returned,
+                    whichever comes first.
 
         Raises:
             ValueError: If `num_files` is less than 0.

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -174,14 +174,14 @@ class DataClient:
         return data
 
     async def binary_data_by_filter(
-        self, filter: Optional[Filter] = None, dest: Optional[str] = None, include_binary: bool = False
+        self, filter: Optional[Filter] = None, dest: Optional[str] = None, include_file_data: bool = False
     ) -> List[BinaryData]:
         """Filter and download binary data.
 
         Args:
             filter (viam.proto.app.data.Filter): Optional `Filter` specifying binary data to retrieve. No `Filter` implies all binary data.
             dest (str): Optional filepath for writing retrieved data.
-            include_binary (bool): Boolean specifying whether to actually include theh binary file data with each retrieved file. Defaults
+            include_file_data (bool): Boolean specifying whether to actually include the binary file data with each retrieved file. Defaults
                 to false (i.e., only the files' metadata is returned).
 
         Returns:
@@ -194,8 +194,8 @@ class DataClient:
         # `DataRequest`s are limited to 100 pieces of data, so we loop through calls until
         # we are certain we've received everything.
         while True:
-            data_request = DataRequest(filter=filter, limit=1 if include_binary else 100, last=last)
-            request = BinaryDataByFilterRequest(data_request=data_request, count_only=False, include_binary=include_binary)
+            data_request = DataRequest(filter=filter, limit=1 if include_file_data else 100, last=last)
+            request = BinaryDataByFilterRequest(data_request=data_request, count_only=False, include_binary=include_file_data)
             response: BinaryDataByFilterResponse = await self._data_client.BinaryDataByFilter(request, metadata=self._metadata)
             if not response.data or len(response.data) == 0:
                 break

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -528,6 +528,7 @@ class MockData(DataServiceBase):
             await stream.send_message(BinaryDataByFilterResponse())
             return
         self.filter = request.data_request.filter
+        self.include_binary = request.include_binary
         await stream.send_message(
             BinaryDataByFilterResponse(data=[BinaryData(binary=data.data, metadata=data.metadata) for data in self.binary_response])
         )

--- a/tests/test_data_client.py
+++ b/tests/test_data_client.py
@@ -16,6 +16,7 @@ from viam.proto.app.data import (
 
 from .mocks.services import MockData
 
+INCLUDE_BINARY = True
 COMPONENT_NAME = "component_name"
 COMPONENT_TYPE = "component_type"
 METHOD = "method"
@@ -136,7 +137,8 @@ class TestClient:
     async def test_binary_data_by_filter(self, service: MockData):
         async with ChannelFor([service]) as channel:
             client = DataClient(channel, DATA_SERVICE_METADATA)
-            binary_data = await client.binary_data_by_filter(filter=FILTER)
+            binary_data = await client.binary_data_by_filter(filter=FILTER, include_binary=INCLUDE_BINARY)
+            assert service.include_binary == INCLUDE_BINARY
             assert binary_data == BINARY_RESPONSE
             self.assert_filter(filter=service.filter)
 

--- a/tests/test_data_client.py
+++ b/tests/test_data_client.py
@@ -137,7 +137,7 @@ class TestClient:
     async def test_binary_data_by_filter(self, service: MockData):
         async with ChannelFor([service]) as channel:
             client = DataClient(channel, DATA_SERVICE_METADATA)
-            binary_data = await client.binary_data_by_filter(filter=FILTER, include_binary=INCLUDE_BINARY)
+            binary_data = await client.binary_data_by_filter(filter=FILTER, include_file_data=INCLUDE_BINARY)
             assert service.include_binary == INCLUDE_BINARY
             assert binary_data == BINARY_RESPONSE
             self.assert_filter(filter=service.filter)


### PR DESCRIPTION
This PR introduces a new input parameter - a boolean specifying whether or not to actually include the binary file data associated with the requested files - to a binary data retrieval method. Before, this variable was simply never passed when the requests were made, and so no actual data was ever actually returned, only metadata. The PR allows for actual data to be retrieved. Also included in the PR is an update to the relevant class's testing suite and some necessary resulting changes to the method taking on this new input parameter.. and also a docstring update.