### PR TITLE
Fix tiny typos in example ipynb

### DIFF
--- a/docs/examples/example.ipynb
+++ b/docs/examples/example.ipynb
@@ -1188,7 +1188,7 @@
    "outputs": [],
    "source": [
     "time_requested_1 = datetime(2023, 6, 5, 11)\n",
-    "time_recieved_1 = datetime(2023, 6, 5, 11, 0, 3)\n",
+    "time_received_1 = datetime(2023, 6, 5, 11, 0, 3)\n",
     "\n",
     "await data_client.tabular_data_capture_upload(\n",
     "    part_id=\"<ID>\", # Unique ID of the relevant robot part.\n",
@@ -1197,7 +1197,7 @@
     "    method_name='IsPowered',\n",
     "    method_parameters=None,\n",
     "    tags=[\"tag_1\", \"tag_2\"],\n",
-    "    data_request_times=[(time_requested_1, time_recieved_1)],\n",
+    "    data_request_times=[(time_requested_1, time_received_1)],\n",
     "    tabular_data=[{'PowerPCT': 0, 'IsPowered': False}]\n",
     ")"
    ]
@@ -1288,7 +1288,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Certain types returned by `AppClient` methods (namely, `RobotPart`, `LogEntry`, `Fragment`, and `RobotPartHistoryEntry` objects) are wrapped in mirror classes that convert proto data into a friendlier, more readable format. Each of these mirrors still allows access to the intial proto type returned by the response as a property."
+    "Certain types returned by `AppClient` methods (namely, `RobotPart`, `LogEntry`, `Fragment`, and `RobotPartHistoryEntry` objects) are wrapped in mirror classes that convert proto data into a friendlier, more readable format. Each of these mirrors still allows access to the initial proto type returned by the response as a property."
    ]
   },
   {


### PR DESCRIPTION
Trying in GH code editor view, but LMK if ipynb building is behind the ominous `1,394 additions and 1,394 deletions` count to this 3 character change PR, can do this a different way. Thanks!