### PR TITLE
RSDK-4544: Clean up leftover move_single_component mocks in tests

### DIFF
--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -315,11 +315,9 @@ class MockMotion(MotionServiceBase):
     def __init__(
         self,
         move_responses: Dict[str, bool],
-        move_single_component_responses: Dict[str, bool],
         get_pose_responses: Dict[str, PoseInFrame],
     ):
         self.move_responses = move_responses
-        self.move_single_component_responses = move_single_component_responses
         self.get_pose_responses = get_pose_responses
         self.constraints: Optional[Constraints] = None
         self.extra: Optional[Mapping[str, Any]] = None

--- a/tests/test_motion_service.py
+++ b/tests/test_motion_service.py
@@ -12,7 +12,6 @@ from .mocks.services import MockMotion
 
 MOVE_CONSTRAINTS = Constraints(linear_constraint=[LinearConstraint(), LinearConstraint(line_tolerance_mm=2)])
 MOVE_RESPONSES = {"arm": False, "gantry": True}
-MOVE_SINGLE_COMPONENT_RESPONSES = {"arm": True, "gantry": False}
 GET_POSE_RESPONSES = {
     "arm": PoseInFrame(reference_frame="arm", pose=Pose(x=1, y=2, z=3, o_x=2, o_y=3, o_z=4, theta=20)),
     "gantry": PoseInFrame(reference_frame="gantry", pose=Pose(x=2, y=3, z=4, o_x=3, o_y=4, o_z=5, theta=21)),
@@ -33,7 +32,6 @@ MOTION_SERVICE_NAME = "motion1"
 def service() -> MockMotion:
     return MockMotion(
         move_responses=MOVE_RESPONSES,
-        move_single_component_responses=MOVE_SINGLE_COMPONENT_RESPONSES,
         get_pose_responses=GET_POSE_RESPONSES,
     )
 


### PR DESCRIPTION
[RSDK-4544](https://viam.atlassian.net/browse/RSDK-4544)

MoveSingleComponent had already been removed, but there were a couple residual instances of move_single_component in tests, which were removed

[RSDK-4544]: https://viam.atlassian.net/browse/RSDK-4544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ