### PR TITLE
RSDK-4647: Improve python docs on how to add local module to config

### DIFF
--- a/docs/examples/example.ipynb
+++ b/docs/examples/example.ipynb
@@ -481,11 +481,11 @@
    "metadata": {},
    "source": [
     "### 5. Configure a modular resource\n",
-    "**NOTE:** *These instructions are for local development. Soon we will launch a `Registry` which will allow users to upload modules to app.viam.com directly. We will update the documentation with instructions on how to do that shortly.*\n",
+    "**NOTE:** *These instructions are for local development. If you are adding your module to the registry, follow [these instructions](https://docs.viam.com/extend/modular-resources/configure/) instead. Otherwise, continue with these instructions, which will show you how to configure the module locally.*\n",
     "\n",
     "[Configure your new module](https://docs.viam.com/extend/modular-resources/#configure-your-module) on your robot by navigating to the **Config** tab of the robot's page on the Viam app, then click on the **Modules** subtab. Add the name of your module and the executable path. For our example, the path would be `<path-on-your-filesystem>/wifi-sensor/run.sh`.\n",
     "\n",
-    "Once you have configured a module as part of your robot configuration, [configure your modular resource](https://docs.viam.com/extend/modular-resources/#configure-your-modular-resource) made available by that module by adding new components or services configured with your modular resources' new type or model. To instantiate a new resource from your module, specify the `type`, `model`, and `name` of your modular resource. This is a JSON example:\n",
+    "Once you have configured a module as part of your robot configuration, [configure your modular resource](https://docs.viam.com/extend/modular-resources/#configure-your-modular-resource) made available by that module by adding new components or services configured with your modular resources' new type or model. To instantiate a new resource from your module, specify the `type`, `model`, and `name` of your modular resource. The aforementioned `type`, `model`, and `name` should be the same as those in the `MODEL` class attribute defined in your [component class](#2-register-the-custom-component). This is a JSON example:\n",
     "\n",
     "```json\n",
     "{\n",

--- a/docs/examples/example.ipynb
+++ b/docs/examples/example.ipynb
@@ -481,7 +481,7 @@
    "metadata": {},
    "source": [
     "### 5. Configure a modular resource\n",
-    "**NOTE:** *These instructions are for local development. If you are adding your module to the registry, follow [these instructions](https://docs.viam.com/extend/modular-resources/configure/) instead. Otherwise, continue with these instructions, which will show you how to configure the module locally.*\n",
+    "**NOTE:** *If you are adding your module to the registry, follow [these instructions](https://docs.viam.com/extend/modular-resources/configure/) instead. Otherwise, continue with these instructions, which will show you how to configure the module locally.*\n",
     "\n",
     "[Configure your new module](https://docs.viam.com/extend/modular-resources/#configure-your-module) on your robot by navigating to the **Config** tab of the robot's page on the Viam app, then click on the **Modules** subtab. Add the name of your module and the executable path. For our example, the path would be `<path-on-your-filesystem>/wifi-sensor/run.sh`.\n",
     "\n",


### PR DESCRIPTION
[RSDK-4647](https://viam.atlassian.net/browse/RSDK-4647)

Added note linking to docs for adding to registry

Added sentence clarifying the relationship of the config type, model, name to the component class' type, model, name



[RSDK-4647]: https://viam.atlassian.net/browse/RSDK-4647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ