### PR TITLE
RSDK-3961: Add max_reconnect_attempts

### DIFF
--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -262,7 +262,7 @@ class RobotClient:
 
             # Failure to grab resources could be for spurious, non-networking reasons. Try three times just to be safe.
             connection_error = None
-            for attempt in range(3):
+            for _ in range(3):
                 try:
                     _: ResourceNamesResponse = await self._client.ResourceNames(ResourceNamesRequest(), timeout=1)
                     connection_error = None
@@ -283,7 +283,9 @@ class RobotClient:
             if reconnect_every <= 0:
                 continue
 
-            while not self._connected:
+            reconnect_attempts = self._options.dial_options.max_reconnect_attempts if self._options.dial_options else 3
+
+            for _ in range(reconnect_attempts):
                 try:
                     self._sessions_client.reset()
 
@@ -308,6 +310,7 @@ class RobotClient:
                     await self.refresh()
                     self._connected = True
                     LOGGER.debug("Successfully reconnected robot")
+                    break
                 except Exception as e:
                     LOGGER.error(f"Failed to reconnect, trying again in {reconnect_every}sec", exc_info=e)
                     self._sessions_client.reset()

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -67,8 +67,7 @@ class DialOptions:
     unsafe to use, but can be requested."""
 
     max_reconnect_attempts: int = 3
-    """Max number of times the client attempts to reconnect when connection
-    is lost to reduce power usage when the wifi microcontroller is asleep"""
+    """Max number of times the client attempts to reconnect when connection is lost"""
 
     def __init__(
         self,

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -66,6 +66,10 @@ class DialOptions:
     if detected, even with credentials present. This is generally
     unsafe to use, but can be requested."""
 
+    max_reconnect_attempts: int = 3
+    """Max number of times the client attempts to reconnect when connection
+    is lost to reduce power usage when the wifi microcontroller is asleep"""
+
     def __init__(
         self,
         disable_webrtc: bool = False,
@@ -74,6 +78,7 @@ class DialOptions:
         insecure: bool = False,
         allow_insecure_downgrade: bool = False,
         allow_insecure_with_creds_downgrade: bool = False,
+        max_reconnect_attempts: int = 3,
     ) -> None:
         self.disable_webrtc = disable_webrtc
         self.auth_entity = auth_entity
@@ -81,6 +86,7 @@ class DialOptions:
         self.insecure = insecure
         self.allow_insecure_downgrade = allow_insecure_downgrade
         self.allow_insecure_with_creds_downgrade = allow_insecure_with_creds_downgrade
+        self.max_reconnect_attempts = max_reconnect_attempts
 
 
 def _host_port_from_url(url) -> Tuple[Optional[str], Optional[int]]:


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-3961

> Part of the webhook functionality with ESP32s involves the use of set_power_mode(PowerMode.POWER_MODE_OFFLINE_DEEP). 
> 
> When an ESP32 is in deep sleep, it is essentially off , and will therefore not be able to respond to the SDK. This means the SDK connection will time out on a success, resulting in an error.
> 
> While the user does have control over the sdk client’s retry interval, they don’t have control over how many times a re-connect is attempted. This means that the user can’t determine how long (retry_interval x num_retries) this unnecessary reconnection attempt may live, and therefore can’t control the upper limit on network or compute utilization.
> 
> 
> In dial options, add max_reconnect_attempts

I added the above attribute and fixed the infinite loop in `_check_connection`