### PR TITLE
APP-2517: org API key support

### DIFF
--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -315,4 +315,4 @@ async def dial_direct(address: str, options: Optional[DialOptions] = None) -> Ch
 
 
 async def _dial_app(options: DialOptions) -> Channel:
-     return await _dial_direct("app.viam.com:443")
+    return await _dial_direct("app.viam.com:443")

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -315,5 +315,4 @@ async def dial_direct(address: str, options: Optional[DialOptions] = None) -> Ch
 
 
 async def _dial_app(options: DialOptions) -> Channel:
-#     return await _dial_direct("app.viam.com:443")
-     return await _dial_direct("localhost:8080")
+     return await _dial_direct("app.viam.com:443")

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -191,7 +191,7 @@ class _Runtime:
         self._lib.init_rust_runtime.argtypes = ()
         self._lib.init_rust_runtime.restype = ctypes.c_void_p
 
-        self._lib.dial.argtypes = (ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_bool, ctypes.c_void_p)
+        self._lib.dial.argtypes = (ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_bool, ctypes.c_void_p)
         self._lib.dial.restype = ctypes.c_void_p
 
         self._lib.free_rust_runtime.argtypes = (ctypes.c_void_p,)
@@ -215,6 +215,7 @@ class _Runtime:
         path_ptr = await to_thread(
             self._lib.dial,
             address.encode("utf-8"),
+            options.auth_entity.encode("utf-8") if options.auth_entity else None,
             type.encode("utf-8") if type else None,
             payload.encode("utf-8") if payload else None,
             insecure,
@@ -314,4 +315,5 @@ async def dial_direct(address: str, options: Optional[DialOptions] = None) -> Ch
 
 
 async def _dial_app(options: DialOptions) -> Channel:
-    return await _dial_direct("app.viam.com:443")
+#     return await _dial_direct("app.viam.com:443")
+     return await _dial_direct("localhost:8080")


### PR DESCRIPTION
[APP-2517](https://viam.atlassian.net/browse/APP-2517)

Requires changes to rust-utils, [RSDK-4755](https://github.com/viamrobotics/rust-utils/pull/75)

This script (in this case, with the little hacks in place to connect to a robot on localhost):
```python
import asyncio
from viam import logging
from viam.robot.client import RobotClient
from viam.rpc.dial import Credentials, DialOptions

async def connect_robot_location_secret():
    creds = Credentials(
        type='robot-location-secret',
        payload='qymq89tpc8m5fe7o90wf3kxn3tb55eaqj1uchx0ul89puggu')
    opts = RobotClient.Options(
        refresh_interval=0,
        dial_options=DialOptions(credentials=creds)
    )
    return await RobotClient.at_address('robot-main.gmmaqnzytw.viam.cloud', opts)

async def connect_api_key():
    creds = Credentials(
        type='api-key',
        payload='t5pp84x7yl05uldjhllxzbuwjt0p6m49')
    opts = RobotClient.Options(
        refresh_interval=0,
        log_level=logging.DEBUG,
        dial_options=DialOptions(credentials=creds, auth_entity="4bccae38-c344-4183-a454-321b9566c721")
    )
    return await RobotClient.at_address('robot-main.gmmaqnzytw.viam.cloud', opts)

async def main():
    robot = await connect_robot_location_secret()
    print('Resources (robot location secret):')
    print(robot.resource_names)

    robot = await connect_api_key()
    print('Resources (API key):')
    print(robot.resource_names)

    # Don't forget to close the robot when you're done!
    await robot.close()

if __name__ == '__main__':
    asyncio.run(main())
```

Will output this:
```bash
⇒  python localhostRobotHost.py
2023-09-01 19:22:34,768		INFO	viam.rpc.dial (dial.py:245)	Connecting to socket: /tmp/proxy-YHLqeW0A.sock
Resources (robot location secret):
[namespace: "rdk"
type: "service"
subtype: "data_manager"
name: "builtin"
, namespace: "rdk"
type: "service"
subtype: "sensors"
name: "builtin"
, namespace: "rdk"
type: "service"
subtype: "motion"
name: "builtin"
, namespace: "rdk"
type: "component"
subtype: "servo"
name: "fakeservo"
]
2023-09-01 19:22:34,808		DEBUG	viam.rpc.dial (dial.py:188)	Creating new viam-rust-utils runtime
2023-09-01 19:22:34,808		DEBUG	viam.rpc.dial (dial.py:214)	Dialing robot-main.gmmaqnzytw.viam.cloud using viam-rust-utils library
2023-09-01 19:22:36,397		INFO	viam.rpc.dial (dial.py:245)	Connecting to socket: /tmp/proxy-XeOTExCL.sock
2023-09-01 19:22:36,397		INFO	viam.rpc.dial (dial.py:245)	Connecting to socket: /tmp/proxy-XeOTExCL.sock
Resources (API key):
[namespace: "rdk"
type: "service"
subtype: "data_manager"
name: "builtin"
, namespace: "rdk"
type: "service"
subtype: "sensors"
name: "builtin"
, namespace: "rdk"
type: "service"
subtype: "motion"
name: "builtin"
, namespace: "rdk"
type: "component"
subtype: "servo"
name: "fakeservo"
]
2023-09-01 19:22:36,399		DEBUG	viam.robot.client (client.py:435)	Closing RobotClient
2023-09-01 19:22:36,399		DEBUG	viam.sessions_client (sessions_client.py:63)	resetting session
2023-09-01 19:22:36,400		DEBUG	viam.robot.client (client.py:448)	Closing tasks spawned by Viam
2023-09-01 19:22:36,400		DEBUG	viam.robot.client (client.py:451)		Closing task 455ba5166b604d25b6ef74bf20db2ad4-robot_check_connection
2023-09-01 19:22:36,400		DEBUG	viam.robot.client (client.py:451)		Closing task 455ba5166b604d25b6ef74bf20db2ad4-robot_check_connection
2023-09-01 19:22:36,400		DEBUG	viam.robot.client (client.py:456)	Closing gRPC channel to remote robot
2023-09-01 19:22:36,400		DEBUG	viam.robot.client (client.py:425)		 Closing ViamChannel instance
2023-09-01 19:22:36,400		DEBUG	viam.rpc.dial (dial.py:233)	Freeing socket string
2023-09-01 19:22:36,400		DEBUG	viam.rpc.dial (dial.py:229)	Freeing viam-rust-utils runtime
2023-09-01 19:22:36,406		DEBUG	viam.rpc.dial (dial.py:166)	ViamChannel might not have shut down cleanly - Event loop was closed
2023-09-01 19:22:36,406		DEBUG	viam.rpc.dial (dial.py:233)	Freeing socket string
2023-09-01 19:22:36,406		DEBUG	viam.rpc.dial (dial.py:229)	Freeing viam-rust-utils runtime
```

[RSDK-4755]: https://viam.atlassian.net/browse/RSDK-4755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[APP-2517]: https://viam.atlassian.net/browse/APP-2517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ