### PR TITLE
RSDK-4528 - Allow API keys for cloud apis + allow users to specify app url

### DIFF
--- a/src/viam/app/viam_client.py
+++ b/src/viam/app/viam_client.py
@@ -27,7 +27,7 @@ class ViamClient:
 
             dial_options (viam.rpc.dial.DialOptions): Required information for authorization and connection to app. `creds` and
                 `auth_entity` fields are required.
-            app_url: (Optional[str]): URL of app. Uses https://app.viam.com if not specified.
+            app_url: (Optional[str]): URL of app. Uses app.viam.com if not specified.
 
         Raises:
             ValueError: If the input parameters are missing a required field or simply invalid.
@@ -47,7 +47,7 @@ class ViamClient:
         if dial_options.credentials.type == "robot-location-secret":
             self._location_id = dial_options.auth_entity.split(".")[1]
         if app_url is None:
-            app_url = "https://app.viam.com"
+            app_url = "app.viam.com"
         self._channel = await _dial_app(app_url)
         access_token = await _get_access_token(self._channel, dial_options.auth_entity, dial_options)
         self._metadata = {"authorization": f"Bearer {access_token}"}

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -25,10 +25,7 @@ LOGGER = logging.getLogger(__name__)
 
 @dataclass
 class Credentials:
-    """Credentials to connect to the robot.
-
-    Currently only supports robot location secret.
-    """
+    """Credentials to connect to the robot and the Viam app."""
 
     type: Union[Literal["robot-location-secret"], Literal["robot-secret"], Literal["api-key"]]
     """The type of credential

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -30,7 +30,7 @@ class Credentials:
     Currently only supports robot location secret.
     """
 
-    type: Union[Literal["robot-location-secret"], Literal["robot-secret"]]
+    type: Union[Literal["robot-location-secret"], Literal["robot-secret"], Literal["api-key"]]
     """The type of credential
     """
 
@@ -314,5 +314,5 @@ async def dial_direct(address: str, options: Optional[DialOptions] = None) -> Ch
     return await _dial_direct(address, options)
 
 
-async def _dial_app(options: DialOptions) -> Channel:
-    return await _dial_direct("app.viam.com:443")
+async def _dial_app(app_url: str) -> Channel:
+    return await _dial_direct(app_url)


### PR DESCRIPTION
[RSDK-4528](https://viam.atlassian.net/browse/RSDK-4528)

location_id can apparently be none in app_client, so no changes needed there
allowing users to specify app url will make it easier for testing and stuff

[RSDK-4528]: https://viam.atlassian.net/browse/RSDK-4528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ