### PR TITLE
Bugfix: Check connection status before attempting to reconnect

### DIFF
--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -285,6 +285,9 @@ class RobotClient:
             if reconnect_every <= 0:
                 continue
 
+            if self._connected:
+                continue
+
             reconnect_attempts = self._options.dial_options.max_reconnect_attempts if self._options.dial_options else 3
 
             for _ in range(reconnect_attempts):


### PR DESCRIPTION
Essentially reverts the guard we removed [here](https://github.com/viamrobotics/viam-python-sdk/pull/418/files#diff-01517e96fd388c85a79f9361c72766cc6227aaf78e617f209f907362968bf65fL286).