### PR TITLE
RSDK-5145 - better resource name representation, more info in unknown grpc errors

### DIFF
--- a/src/viam/__init__.py
+++ b/src/viam/__init__.py
@@ -41,4 +41,6 @@ sys.excepthook = _log_exceptions
 ##################
 # MONKEY PATCHES #
 ##################
-_ResourceName.__hash__ = lambda self: hash(f"{self.namespace}:{self.type}:{self.subtype}/{self.name}")
+_ResourceName.__str__ = lambda self: f"{self.namespace}:{self.type}:{self.subtype}/{self.name}"
+_ResourceName.__repr__ = lambda self: f"<viam.proto.common.ResourceName {str(self)} at {hex(id(self))}>"
+_ResourceName.__hash__ = lambda self: hash(str(self))

--- a/src/viam/rpc/server.py
+++ b/src/viam/rpc/server.py
@@ -161,7 +161,17 @@ def _grpc_error_wrapper(func: Callable):
         except ViamGRPCError as e:
             raise e.grpc_error
         except Exception as e:
-            raise GRPCError(Status.UNKNOWN, f"{e.__class__.__name__} - {e}")
+            tb = e.__traceback__
+            file_name = None
+            func_name = None
+            line_num = None
+            # only print the last entry in the stacktrace - not perfect but gives users a starting point
+            while tb is not None:
+                file_name = tb.tb_frame.f_code.co_filename
+                func_name = tb.tb_frame.f_code.co_name
+                line_num = tb.tb_lineno
+                tb = tb.tb_next
+            raise GRPCError(Status.UNKNOWN, f"{e.__class__.__name__} - {e} - {file_name=} {func_name=} {line_num=}")
 
     return interceptor
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -32,7 +32,7 @@ class TestServer:
         with pytest.raises(GRPCError) as e_info:
             await wrapped_raise_exception()
         assert e_info.value.args[0] == Status.UNKNOWN
-        assert e_info.value.args[1] == "Exception - this is a fake Exception"
+        assert "Exception - this is a fake Exception" in e_info.value.args[1]
 
         with pytest.raises(ViamGRPCError) as e_info:
             await raise_viamgrpcerror()


### PR DESCRIPTION
changes key error in cases of missing dependencies to
`KeyError - <viam.proto.common.ResourceName rdk:component:sensor/ at 0x1046165c0> - file_name='examples/simple_module/src/main.py' func_name='new' line_num=26`

from 
`KeyError - namespace: \"rdk\"\ntype: \"component\"\nsubtype: \"camera\"\nname: \"cam\"\n"}`

which should be a bit more info