### PR TITLE
RSDK-5174: Fix get_image mimetype handler in python sdk

### DIFF
--- a/src/viam/components/camera/client.py
+++ b/src/viam/components/camera/client.py
@@ -23,7 +23,7 @@ from viam.utils import ValueTypes, dict_to_struct, get_geometries, struct_to_dic
 from . import Camera, RawImage
 
 
-def get_image_from_response(data: bytes, response_mime_type: str, request_mime_type: Optional[str] = None) -> Union[Image.Image, RawImage]:
+def get_image_from_response(data: bytes, response_mime_type: str, request_mime_type: str) -> Union[Image.Image, RawImage]:
     if not request_mime_type:
         request_mime_type = response_mime_type
     mime_type, is_lazy = CameraMimeType.from_lazy(request_mime_type)

--- a/src/viam/components/camera/client.py
+++ b/src/viam/components/camera/client.py
@@ -24,7 +24,7 @@ from . import Camera, RawImage
 
 
 def get_image_from_response(data: bytes, response_mime_type: str, request_mime_type: Optional[str] = None) -> Union[Image.Image, RawImage]:
-    if request_mime_type is None:
+    if not request_mime_type:
         request_mime_type = response_mime_type
     mime_type, is_lazy = CameraMimeType.from_lazy(request_mime_type)
     if is_lazy or mime_type._should_be_raw:


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-5174

The first conditional branch of `get_image_from_response` never gets hit because the default `mime_type` value in the invoker— `get_image` in client.py —  is `""` and not `None`.