### PR TITLE
Fix reconnect logic

### DIFF
--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -310,9 +310,10 @@ class RobotClient:
                         self._channel = channel.channel
                         self._viam_channel = channel
                     self._client = RobotServiceStub(self._channel)
+                    direct_dial_address = self._channel._path if self._channel._path else f"{self._channel._host}:{self._channel._port}"
                     self._sessions_client = SessionsClient(
                         channel=self._channel,
-                        address=self._address,
+                        direct_dial_address=direct_dial_address,
                         dial_options=self._options.dial_options,
                         disabled=self._options.disable_sessions,
                     )

--- a/src/viam/sessions_client.py
+++ b/src/viam/sessions_client.py
@@ -1,4 +1,5 @@
 import asyncio
+from copy import deepcopy
 from datetime import timedelta
 from enum import IntEnum
 from threading import Lock, Thread
@@ -50,18 +51,8 @@ class SessionsClient:
         self._address = direct_dial_address
         self._dial_options = dial_options
         self._disabled = disabled
-        if dial_options is not None:
-            self._dial_options = DialOptions(
-                disable_webrtc=True,
-                auth_entity=dial_options.auth_entity,
-                credentials=dial_options.credentials,
-                insecure=dial_options.insecure,
-                allow_insecure_downgrade=dial_options.allow_insecure_downgrade,
-                allow_insecure_with_creds_downgrade=dial_options.allow_insecure_with_creds_downgrade,
-            )
-        else:
-            self._dial_options = DialOptions(disable_webrtc=True)
-
+        self._dial_options = deepcopy(dial_options) if dial_options is not None else DialOptions()
+        self._dial_options.disable_webrtc = True
         self._lock: Lock = Lock()
         self._current_id: str = ""
         self._heartbeat_interval: Optional[timedelta] = None

--- a/src/viam/sessions_client.py
+++ b/src/viam/sessions_client.py
@@ -44,12 +44,23 @@ class SessionsClient:
     supports stopping actuating components when it's not.
     """
 
-    def __init__(self, channel: Channel, address: str, dial_options: Optional[DialOptions], *, disabled: bool = False):
+    def __init__(self, channel: Channel, direct_dial_address: str, dial_options: Optional[DialOptions], *, disabled: bool = False):
         self.channel = channel
         self.client = RobotServiceStub(channel)
-        self._address = address
+        self._address = direct_dial_address
         self._dial_options = dial_options
         self._disabled = disabled
+        if dial_options is not None:
+            self._dial_options = DialOptions(
+                disable_webrtc=True,
+                auth_entity=dial_options.auth_entity,
+                credentials=dial_options.credentials,
+                insecure=dial_options.insecure,
+                allow_insecure_downgrade=dial_options.allow_insecure_downgrade,
+                allow_insecure_with_creds_downgrade=dial_options.allow_insecure_with_creds_downgrade,
+            )
+        else:
+            self._dial_options = DialOptions(disable_webrtc=True)
 
         self._lock: Lock = Lock()
         self._current_id: str = ""
@@ -70,7 +81,10 @@ class SessionsClient:
         self._current_id = ""
         self._heartbeat_interval = None
         if self._thread is not None:
-            self._thread.join(timeout=1)
+            try:
+                self._thread.join(timeout=1)
+            except RuntimeError:
+                LOGGER.debug("failed to join session heartbeat thread")
             self._thread = None
 
     async def _send_request(self, event: SendRequest):
@@ -153,10 +167,7 @@ class SessionsClient:
             LOGGER.debug("Sent heartbeat successfully")
 
     async def _heartbeat_process(self, wait: float):
-        dial_options = self._dial_options if self._dial_options is not None else DialOptions()
-        dial_options.disable_webrtc = True
-
-        channel = await dial(address=self._address, options=dial_options)
+        channel = await dial(address=self._address, options=self._dial_options)
         client = RobotServiceStub(channel.channel)
         while True:
             with self._lock:


### PR DESCRIPTION
- sessions client was overwriting dial options in the robot client, so making an actual copy
- on reconnect, sessions client actually wants the new socket address, so got that instead of the address of the robot itself