### PR TITLE
RSDK-4756 - add `Options` api-key helper function

### DIFF
--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 from dataclasses import dataclass
 from threading import RLock
 from typing import Any, Dict, List, Optional, Union
@@ -110,9 +111,17 @@ class RobotClient:
                 api_key (str): your API key
                 api_key_id (str): your API key ID
 
-            returns:
+            Raises:
+                ValueError: Raised if the `api_key_id` is not a valid uuid
+
+            Returns:
                 Self: the RobotClient options
             """
+            key_id_regex = re.compile(r"^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$")
+            match = key_id_regex.match(api_key_id)
+            if not match:
+                raise ValueError(f"{api_key_id} is not a valid UUID")
+
             credentials = Credentials(type="api-key", payload=api_key)
             dial_opts = DialOptions(credentials=credentials, auth_entity=api_key_id)
             self = cls()

--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -1,5 +1,4 @@
 import asyncio
-import re
 from dataclasses import dataclass
 from threading import RLock
 from typing import Any, Dict, List, Optional, Union
@@ -42,7 +41,7 @@ from viam.resource.manager import ResourceManager
 from viam.resource.registry import Registry
 from viam.resource.rpc_client_base import ReconfigurableResourceRPCClientBase, ResourceRPCClientBase
 from viam.resource.types import RESOURCE_TYPE_COMPONENT, RESOURCE_TYPE_SERVICE, Subtype
-from viam.rpc.dial import Credentials, DialOptions, ViamChannel, dial
+from viam.rpc.dial import DialOptions, ViamChannel, dial
 from viam.services.service_base import ServiceBase
 from viam.sessions_client import SessionsClient
 from viam.utils import dict_to_struct

--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -105,25 +105,19 @@ class RobotClient:
         @classmethod
         def with_api_key(cls, api_key: str, api_key_id: str) -> Self:
             """
-            Create dial options with an API key for credentials and default values for other arguments.
+            Create RobotClient.Options with an API key for credentials and default values for other arguments.
 
             Args:
                 api_key (str): your API key
-                api_key_id (str): your API key ID
+                api_key_id (str): your API key ID. Must be a valid UUID
 
             Raises:
-                ValueError: Raised if the `api_key_id` is not a valid uuid
+                ValueError: Raised if the api_key_id is not a valid UUID
 
             Returns:
-                Self: the RobotClient options
+                Self: the RobotClient.Options
             """
-            key_id_regex = re.compile(r"^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$")
-            match = key_id_regex.match(api_key_id)
-            if not match:
-                raise ValueError(f"{api_key_id} is not a valid UUID")
-
-            credentials = Credentials(type="api-key", payload=api_key)
-            dial_opts = DialOptions(credentials=credentials, auth_entity=api_key_id)
+            dial_opts = DialOptions.with_api_key(api_key, api_key_id)
             self = cls()
             self.dial_options = dial_opts
             return self

--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -41,7 +41,7 @@ from viam.resource.manager import ResourceManager
 from viam.resource.registry import Registry
 from viam.resource.rpc_client_base import ReconfigurableResourceRPCClientBase, ResourceRPCClientBase
 from viam.resource.types import RESOURCE_TYPE_COMPONENT, RESOURCE_TYPE_SERVICE, Subtype
-from viam.rpc.dial import DialOptions, ViamChannel, dial
+from viam.rpc.dial import Credentials, DialOptions, ViamChannel, dial
 from viam.services.service_base import ServiceBase
 from viam.sessions_client import SessionsClient
 from viam.utils import dict_to_struct
@@ -100,6 +100,24 @@ class RobotClient:
         """
         Whether sessions are disabled
         """
+
+        @classmethod
+        def with_api_key(cls, api_key: str, api_key_id: str) -> Self:
+            """
+            Create dial options with an API key for credentials and default values for other arguments.
+
+            Args:
+                api_key (str): your API key
+                api_key_id (str): your API key ID
+
+            returns:
+                Self: the RobotClient options
+            """
+            credentials = Credentials(type="api-key", payload=api_key)
+            dial_opts = DialOptions(credentials=credentials, auth_entity=api_key_id)
+            self = cls()
+            self.dial_options = dial_opts
+            return self
 
     @classmethod
     async def at_address(cls, address: str, options: Options) -> Self:

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -94,7 +94,7 @@ class DialOptions:
 
     @classmethod
     def with_api_key(cls, api_key: str, api_key_id: str) -> Self:
-        """Create `DialOptions` with an API key for credentials and default values for other arguments.
+        """Create DialOptions with an API key for credentials and default values for other arguments.
 
         Args:
             api_key (str): your API key

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -98,13 +98,13 @@ class DialOptions:
 
         Args:
             api_key (str): your API key
-            api_key_id (str): your API key ID. Must be a valid UUID.
+            api_key_id (str): your API key ID. Must be a valid UUID
 
         Raises:
-            ValueError: Raised if the `api_key_id` is not a valid UUID
+            ValueError: Raised if the api_key_id is not a valid UUID
 
         Returns:
-            Self: the `DialOptions`
+            Self: the DialOptions
         """
         try:
             uuid.UUID(api_key_id)

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -4,9 +4,11 @@ import re
 import socket
 import ssl
 import sys
+import uuid
 import warnings
 from dataclasses import dataclass
 from typing import Callable, Literal, Optional, Tuple, Type, Union
+from typing_extensions import Self
 
 from grpclib.client import Channel, Stream
 from grpclib.const import Cardinality
@@ -89,6 +91,28 @@ class DialOptions:
         self.allow_insecure_with_creds_downgrade = allow_insecure_with_creds_downgrade
         self.max_reconnect_attempts = max_reconnect_attempts
         self.timeout = timeout
+
+    @classmethod
+    def with_api_key(cls, api_key: str, api_key_id: str) -> Self:
+        """Create `DialOptions` with an API key for credentials and default values for other arguments.
+
+        Args:
+            api_key (str): your API key
+            api_key_id (str): your API key ID. Must be a valid UUID.
+
+        Raises:
+            ValueError: Raised if the `api_key_id` is not a valid UUID
+
+        Returns:
+            Self: the `DialOptions`
+        """
+        try:
+            uuid.UUID(api_key_id)
+        except ValueError:
+            raise ValueError(f"{api_key_id} is not a valid UUID")
+
+        credentials = Credentials(type="api-key", payload=api_key)
+        return cls(credentials=credentials, auth_entity=api_key_id)
 
 
 def _host_port_from_url(url) -> Tuple[Optional[str], Optional[int]]:


### PR DESCRIPTION
#### Major changes

Adds a simple helper function for creating connection `Options` for an api-key, with default values elsewhere.