### PR TITLE
RSDK-5501 - Move resource registration out of top level files in example

### DIFF
--- a/examples/complex_module/src/arm/__init__.py
+++ b/examples/complex_module/src/arm/__init__.py
@@ -1,9 +1,0 @@
-"""
-This file registers the MyArm model with the Python SDK.
-"""
-
-from viam.components.arm import Arm
-from viam.resource.registry import Registry, ResourceCreatorRegistration
-from .my_arm import MyArm
-
-Registry.register_resource_creator(Arm.SUBTYPE, MyArm.MODEL, ResourceCreatorRegistration(MyArm.new))

--- a/examples/complex_module/src/arm/my_arm.py
+++ b/examples/complex_module/src/arm/my_arm.py
@@ -10,6 +10,7 @@ from viam.operations import run_with_operation
 from viam.proto.app.robot import ComponentConfig
 from viam.proto.common import Capsule, Geometry, ResourceName, Sphere
 from viam.resource.base import ResourceBase
+from viam.resource.registry import Registry, ResourceCreatorRegistration
 from viam.resource.types import Model, ModelFamily
 
 LOGGER = getLogger(__name__)
@@ -112,3 +113,6 @@ class MyArm(Arm):
         # This is a completely optional function to include. This will be called when the resource is removed from the config or the module
         # is shutting down.
         LOGGER.debug(f"{self.name} is closed.")
+
+
+Registry.register_resource_creator(Arm.SUBTYPE, MyArm.MODEL, ResourceCreatorRegistration(MyArm.new))

--- a/examples/complex_module/src/base/__init__.py
+++ b/examples/complex_module/src/base/__init__.py
@@ -1,9 +1,0 @@
-"""
-This file registers the MyBase model with the Python SDK.
-"""
-
-from viam.components.base import Base
-from viam.resource.registry import Registry, ResourceCreatorRegistration
-from .my_base import MyBase
-
-Registry.register_resource_creator(Base.SUBTYPE, MyBase.MODEL, ResourceCreatorRegistration(MyBase.new, MyBase.validate_config))

--- a/examples/complex_module/src/base/my_base.py
+++ b/examples/complex_module/src/base/my_base.py
@@ -8,6 +8,7 @@ from viam.module.types import Reconfigurable
 from viam.proto.app.robot import ComponentConfig
 from viam.resource.base import ResourceBase
 from viam.proto.common import Geometry, Vector3, ResourceName
+from viam.resource.registry import Registry, ResourceCreatorRegistration
 from viam.resource.types import Model, ModelFamily
 from viam.utils import struct_to_dict
 
@@ -144,3 +145,6 @@ class MyBase(Base, Reconfigurable):
     # Not implemented
     async def get_geometries(self) -> List[Geometry]:
         raise NotImplementedError()
+
+
+Registry.register_resource_creator(Base.SUBTYPE, MyBase.MODEL, ResourceCreatorRegistration(MyBase.new, MyBase.validate_config))

--- a/examples/complex_module/src/gizmo/__init__.py
+++ b/examples/complex_module/src/gizmo/__init__.py
@@ -3,11 +3,8 @@ This file registers the Gizmo subtype with the Viam Registry, as well as the spe
 """
 
 from viam.components.motor import *  # noqa: F403 Need to import motor so the component registers itself
-from viam.resource.registry import Registry, ResourceCreatorRegistration, ResourceRegistration
+from viam.resource.registry import Registry, ResourceRegistration
 
 from .api import Gizmo, GizmoClient, GizmoService
-from .my_gizmo import MyGizmo
 
 Registry.register_subtype(ResourceRegistration(Gizmo, GizmoService, lambda name, channel: GizmoClient(name, channel)))
-
-Registry.register_resource_creator(Gizmo.SUBTYPE, MyGizmo.MODEL, ResourceCreatorRegistration(MyGizmo.new, MyGizmo.validate_config))

--- a/examples/complex_module/src/gizmo/my_gizmo.py
+++ b/examples/complex_module/src/gizmo/my_gizmo.py
@@ -7,6 +7,7 @@ from viam.module.types import Reconfigurable
 from viam.proto.app.robot import ComponentConfig
 from viam.proto.common import ResourceName
 from viam.resource.base import ResourceBase
+from viam.resource.registry import Registry, ResourceCreatorRegistration
 from viam.resource.types import Model, ModelFamily
 
 from ..gizmo.api import Gizmo
@@ -76,3 +77,6 @@ class MyGizmo(Gizmo, Reconfigurable):
         # This is a completely optional function to include. This will be called when the resource is removed from the config or the module
         # is shutting down.
         LOGGER.debug(f"{self.name} is closed.")
+
+
+Registry.register_resource_creator(Gizmo.SUBTYPE, MyGizmo.MODEL, ResourceCreatorRegistration(MyGizmo.new, MyGizmo.validate_config))

--- a/examples/complex_module/src/main.py
+++ b/examples/complex_module/src/main.py
@@ -6,8 +6,8 @@ from viam.components.base import Base
 
 from src.arm.my_arm import MyArm
 from src.base.my_base import MyBase
-from src.gizmo import Gizmo, MyGizmo
-from src.summation import MySummationService, SummationService
+from src.gizmo.my_gizmo import Gizmo, MyGizmo
+from src.summation.my_summation import MySummationService, SummationService
 
 
 async def main():

--- a/examples/complex_module/src/summation/__init__.py
+++ b/examples/complex_module/src/summation/__init__.py
@@ -2,11 +2,8 @@
 This file registers the Summation subtype with the Viam Registry, as well as the specific MySummation model.
 """
 
-from viam.resource.registry import Registry, ResourceCreatorRegistration, ResourceRegistration
+from viam.resource.registry import Registry, ResourceRegistration
 
 from .api import SummationClient, SummationRPCService, SummationService
-from .my_summation import MySummationService
 
 Registry.register_subtype(ResourceRegistration(SummationService, SummationRPCService, lambda name, channel: SummationClient(name, channel)))
-
-Registry.register_resource_creator(SummationService.SUBTYPE, MySummationService.MODEL, ResourceCreatorRegistration(MySummationService.new))

--- a/examples/complex_module/src/summation/my_summation.py
+++ b/examples/complex_module/src/summation/my_summation.py
@@ -6,6 +6,7 @@ from viam.module.types import Reconfigurable
 from viam.proto.app.robot import ComponentConfig
 from viam.proto.common import ResourceName
 from viam.resource.base import ResourceBase
+from viam.resource.registry import Registry, ResourceCreatorRegistration
 from viam.resource.types import Model
 
 from ..summation.api import SummationService
@@ -42,3 +43,6 @@ class MySummationService(SummationService, Reconfigurable):
 
     def reconfigure(self, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]):
         self.subtract = config.attributes.fields["subtract"].bool_value or False
+
+
+Registry.register_resource_creator(SummationService.SUBTYPE, MySummationService.MODEL, ResourceCreatorRegistration(MySummationService.new))


### PR DESCRIPTION
this way the resource model isn't registered implicitly if some other module imports this library to use the new apis