### PR TITLE
await example close calls

### DIFF
--- a/docs/examples/example.ipynb
+++ b/docs/examples/example.ipynb
@@ -285,7 +285,7 @@
     "    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[Geometry]:\n",
     "        raise NotImplementedError\n",
     "\n",
-    "    def close(self):\n",
+    "    async def close(self):\n",
     "        # This is a completely optional function to include. This will be called when the resource is removed from the config or the module\n",
     "        # is shutting down.\n",
     "        LOGGER.debug(f\"{self.name} is closed.\")\n",

--- a/docs/examples/module_step2.py
+++ b/docs/examples/module_step2.py
@@ -29,7 +29,7 @@ class MySensor(Sensor):
         wifi_signal = [x for x in content[2].split(" ") if x != ""]
         return {"link": wifi_signal[2], "level": wifi_signal[3], "noise": wifi_signal[4]}
 
-    def close(self):
+    async def close(self):
         # This is a completely optional function to include. This will be called when the resource is removed from the config or the module
         # is shutting down.
         LOGGER.debug(f"{self.name} is closed.")

--- a/docs/examples/module_step2_optional.py
+++ b/docs/examples/module_step2_optional.py
@@ -51,7 +51,7 @@ class MySensor(Sensor):
             multiplier = 1.0
         self.multiplier = multiplier
 
-    def close(self):
+    async def close(self):
         # This is a completely optional function to include. This will be called when the resource is removed from the config or the module
         # is shutting down.
         LOGGER.debug(f"{self.name} is closed.")

--- a/docs/examples/module_step3.py
+++ b/docs/examples/module_step3.py
@@ -30,7 +30,7 @@ class MySensor(Sensor):
         wifi_signal = [x for x in content[2].split(" ") if x != ""]
         return {"link": wifi_signal[2], "level": wifi_signal[3], "noise": wifi_signal[4]}
 
-    def close(self):
+    async def close(self):
         # This is a completely optional function to include. This will be called when the resource is removed from the config or the module
         # is shutting down.
         LOGGER.debug(f"{self.name} is closed.")

--- a/docs/examples/my_cool_arm.py
+++ b/docs/examples/my_cool_arm.py
@@ -106,7 +106,7 @@ class MyCoolArm(Arm):
     async def get_kinematics(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> Tuple[KinematicsFileFormat.ValueType, bytes]:
         return KinematicsFileFormat.KINEMATICS_FILE_FORMAT_SVA, self.kinematics
 
-    def close(self):
+    async def close(self):
         # This is a completely optional function to include. This will be called when the resource is removed from the config or the module
         # is shutting down.
         LOGGER.debug(f"{self.name} is closed.")

--- a/examples/complex_module/src/arm/my_arm.py
+++ b/examples/complex_module/src/arm/my_arm.py
@@ -109,7 +109,7 @@ class MyArm(Arm):
             file_data = f.read()
         return (KinematicsFileFormat.KINEMATICS_FILE_FORMAT_SVA, file_data)
 
-    def close(self):
+    async def close(self):
         # This is a completely optional function to include. This will be called when the resource is removed from the config or the module
         # is shutting down.
         LOGGER.debug(f"{self.name} is closed.")

--- a/examples/complex_module/src/gizmo/my_gizmo.py
+++ b/examples/complex_module/src/gizmo/my_gizmo.py
@@ -73,7 +73,7 @@ class MyGizmo(Gizmo, Reconfigurable):
     def reconfigure(self, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]):
         self.my_arg = config.attributes.fields["arg1"].string_value
 
-    def close(self):
+    async def close(self):
         # This is a completely optional function to include. This will be called when the resource is removed from the config or the module
         # is shutting down.
         LOGGER.debug(f"{self.name} is closed.")

--- a/examples/simple_module/src/main.py
+++ b/examples/simple_module/src/main.py
@@ -52,7 +52,7 @@ class MySensor(Sensor):
             multiplier = 1.0
         self.multiplier = multiplier
 
-    def close(self):
+    async def close(self):
         # This is a completely optional function to include. This will be called when the resource is removed from the config or the module
         # is shutting down.
         LOGGER.debug(f"{self.name} is closed.")


### PR DESCRIPTION
Fix from this [PR](https://github.com/viamrobotics/viam-python-sdk/pull/458).
`close()` calls have to be awaited.