### PR TITLE
Fix sensor service not resolving

### DIFF
--- a/src/viam/components/sensor/__init__.py
+++ b/src/viam/components/sensor/__init__.py
@@ -1,3 +1,4 @@
+import viam.gen.component.sensor.v1.sensor_pb2  # Need this import for Sensor service descriptors to resolve
 from viam.resource.registry import Registry, ResourceRegistration
 
 from .client import SensorClient


### PR DESCRIPTION
same thing happened with generic
if there are no messages in that proto file, for some reason the generated file does not include the import at all, even when there are methods in the service
will create a patch release as well