### PR TITLE
RSDK-5175 - return file upload server error

### DIFF
--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -676,7 +676,8 @@ class DataClient:
             await stream.send_message(request_metadata)
             await stream.send_message(request_file_contents, end=True)
             response = await stream.recv_message()
-            assert response is not None
+            if not response:
+                await stream.recv_trailing_metadata()  # causes us to throw appropriate gRPC error.
             return response
 
     @staticmethod


### PR DESCRIPTION
#### Major changes
When there is no response to a file upload, throw the appropriate gRPC error.

Stacktrace (in relevant part) before change:
```AssertionError
...
  File "/opt/homebrew/lib/python3.11/site-packages/viam/app/data_client.py", line 682, in _file_upload
    assert response is not None
           ^^^^^^^^^^^^^^^^^^^^
```

Stacktrace (in relevant part) after change:
```
  File "/opt/homebrew/lib/python3.11/site-packages/viam/app/data_client.py", line 680, in _file_upload
    await stream.recv_trailing_metadata()  # causes us to throw appropriate gRPC error.
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/grpclib/client.py", line 484, in recv_trailing_metadata
    self._raise_for_grpc_status(status, message, details)
  File "/opt/homebrew/lib/python3.11/site-packages/grpclib/client.py", line 345, in _raise_for_grpc_status
    raise GRPCError(status, message, details)
grpclib.exceptions.GRPCError: (<Status.UNKNOWN: 2>, 'no robot part found', None)
```