### PR TITLE
[RSDK-5823] remove Board.model_attributes() from the SDK

### DIFF
--- a/examples/server/v1/components.py
+++ b/examples/server/v1/components.py
@@ -332,9 +332,6 @@ class ExampleBoard(Board):
             digital_interrupts={name: DigitalInterruptStatus(value=await di.value()) for (name, di) in self.digital_interrupts.items()},
         )
 
-    async def model_attributes(self) -> Board.Attributes:
-        return Board.Attributes(remote=True)
-
     async def set_power_mode(self, **kwargs):
         raise NotImplementedError()
 

--- a/src/viam/components/board/board.py
+++ b/src/viam/components/board/board.py
@@ -243,16 +243,6 @@ class Board(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def model_attributes(self) -> Attributes:
-        """
-        Get the attributes related to the model of this board.
-
-        Returns:
-            Attributes: The attributes.
-        """
-        ...
-
-    @abc.abstractmethod
     async def set_power_mode(
         self, mode: PowerMode.ValueType, duration: Optional[timedelta] = None, *, timeout: Optional[float] = None, **kwargs
     ):

--- a/src/viam/components/board/client.py
+++ b/src/viam/components/board/client.py
@@ -156,9 +156,6 @@ class BoardClient(Board, ReconfigurableResourceRPCClientBase):
         response: StatusResponse = await self.client.Status(request, timeout=timeout)
         return response.status
 
-    async def model_attributes(self) -> Board.Attributes:
-        return Board.Attributes(remote=True)
-
     async def do_command(self, command: Mapping[str, ValueTypes], *, timeout: Optional[float] = None) -> Mapping[str, ValueTypes]:
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
         response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -370,9 +370,6 @@ class MockBoard(Board):
             digital_interrupts={name: DigitalInterruptStatus(value=await di.value()) for (name, di) in self.digital_interrupts.items()},
         )
 
-    async def model_attributes(self) -> Board.Attributes:
-        return Board.Attributes(remote=True)
-
     async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[Geometry]:
         self.extra = extra
         self.timeout = timeout

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -122,11 +122,6 @@ class TestBoard:
         assert board.timeout == loose_approx(1.82)
 
     @pytest.mark.asyncio
-    async def test_model_attributes(self, board: MockBoard):
-        attrs = await board.model_attributes()
-        assert attrs == Board.Attributes(remote=True)
-
-    @pytest.mark.asyncio
     async def test_do(self, board: MockBoard):
         command = {"command": "args"}
         resp = await board.do_command(command)
@@ -414,14 +409,6 @@ class TestClient:
             )
             assert board.extra == extra
             assert board.timeout == loose_approx(1.1)
-
-    @pytest.mark.asyncio
-    async def test_model_attributes(self, board: MockBoard, service: BoardRPCService):
-        async with ChannelFor([service]) as channel:
-            client = BoardClient(name=board.name, channel=channel)
-
-            attrs = await client.model_attributes()
-            assert attrs == Board.Attributes(remote=True)
 
     @pytest.mark.asyncio
     async def test_do(self, board: MockBoard, service: BoardRPCService):

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -6,7 +6,7 @@ from google.protobuf.duration_pb2 import Duration
 from grpclib import GRPCError
 from grpclib.testing import ChannelFor
 
-from viam.components.board import Board, BoardClient
+from viam.components.board import BoardClient
 from viam.components.board.service import BoardRPCService
 from viam.components.generic.service import GenericRPCService
 from viam.errors import ResourceNotFoundError


### PR DESCRIPTION
This was removed from the RDK in https://github.com/viamrobotics/rdk/pull/3253. From the perspective of the Python SDK, no information is being communicated with this function: it always says that the board is remote and nothing else.

Strictly speaking, this is a breaking change because we don't know who out in the world is using this function. but my understanding is that the entire SDK is still in beta so breaking changes are okay. and anyone using it isn't getting any utility out of it, as previously stated.