### PR TITLE
RSDK-4089: change camera api return types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ clean:
 	find . -type d -name '__pycache__' | xargs rm -rf
 
 _lint:
-	flake8 --exclude=**/gen/**,*_grpc.py,*_pb2.py,*_pb2.pyi,.tox
+	flake8 --exclude=**/gen/**,*_grpc.py,*_pb2.py,*_pb2.pyi,.tox,**/venv/**
 
 lint:
 	poetry run $(MAKE) _lint

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ clean:
 	find . -type d -name '__pycache__' | xargs rm -rf
 
 _lint:
-	flake8 --exclude=**/gen/**,*_grpc.py,*_pb2.py,*_pb2.pyi,.tox,**/venv/**
+	flake8 --exclude=**/gen/**,*_grpc.py,*_pb2.py,*_pb2.pyi,.tox
 
 lint:
 	poetry run $(MAKE) _lint

--- a/docs/examples/example.ipynb
+++ b/docs/examples/example.ipynb
@@ -164,7 +164,7 @@
     "robot = await connect_with_channel()\n",
     "camera = Camera.from_robot(robot, \"camera0\")\n",
     "image = await camera.get_image(CameraMimeType.JPEG)\n",
-    "image.save(\"foo.png\")\n",
+    "image.image.save(\"foo.png\")\n",
     "\n",
     "# Don't forget to close the robot when you're done!\n",
     "await robot.close()\n"

--- a/src/viam/components/camera/camera.py
+++ b/src/viam/components/camera/camera.py
@@ -1,14 +1,12 @@
 import abc
-from typing import Any, Dict, Final, List, NamedTuple, Optional, Tuple, Union
-
-from PIL.Image import Image
+from typing import Any, Dict, Final, List, NamedTuple, Optional, Tuple
 
 from viam.media.video import NamedImage, ViamImage
 from viam.proto.common import ResponseMetadata
 from viam.resource.types import RESOURCE_NAMESPACE_RDK, RESOURCE_TYPE_COMPONENT, Subtype
 
 from ..component_base import ComponentBase
-from . import DistortionParameters, IntrinsicParameters, RawImage
+from . import DistortionParameters, IntrinsicParameters
 
 
 class Camera(ComponentBase):

--- a/src/viam/components/camera/camera.py
+++ b/src/viam/components/camera/camera.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Final, List, NamedTuple, Optional, Tuple, Union
 
 from PIL.Image import Image
 
-from viam.media.video import NamedImage
+from viam.media.video import NamedImage, ViamImage
 from viam.proto.common import ResponseMetadata
 from viam.resource.types import RESOURCE_NAMESPACE_RDK, RESOURCE_TYPE_COMPONENT, Subtype
 
@@ -37,8 +37,8 @@ class Camera(ComponentBase):
     @abc.abstractmethod
     async def get_image(
         self, mime_type: str = "", *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs
-    ) -> Union[Image, RawImage]:
-        """Get the next image from the camera as an Image or RawImage.
+    ) -> ViamImage:
+        """Get the next image from the camera as a ViamImage.
         Be sure to close the image when finished.
 
         NOTE: If the mime type is ``image/vnd.viam.dep`` you can use :func:`viam.media.video.RawImage.bytes_to_depth_array`
@@ -48,7 +48,7 @@ class Camera(ComponentBase):
             mime_type (str): The desired mime type of the image. This does not guarantee output type
 
         Returns:
-            Image | RawImage: The frame
+            ViamImage: The frame
         """
         ...
 

--- a/src/viam/components/camera/client.py
+++ b/src/viam/components/camera/client.py
@@ -20,7 +20,7 @@ from viam.proto.component.camera import (
 from viam.resource.rpc_client_base import ReconfigurableResourceRPCClientBase
 from viam.utils import ValueTypes, dict_to_struct, get_geometries, struct_to_dict
 
-from . import Camera, RawImage
+from . import Camera
 
 
 def get_image_from_response(data: bytes, response_mime_type: str, request_mime_type: str) -> ViamImage:

--- a/src/viam/components/camera/client.py
+++ b/src/viam/components/camera/client.py
@@ -1,10 +1,8 @@
-from io import BytesIO
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from grpclib.client import Channel
-from PIL import Image
 
-from viam.media.video import LIBRARY_SUPPORTED_FORMATS, CameraMimeType, NamedImage, ViamImage
+from viam.media.video import CameraMimeType, NamedImage, ViamImage
 from viam.proto.common import DoCommandRequest, DoCommandResponse, Geometry, ResponseMetadata
 from viam.proto.component.camera import (
     CameraServiceStub,
@@ -40,9 +38,7 @@ class CameraClient(Camera, ReconfigurableResourceRPCClientBase):
         self.client = CameraServiceStub(channel)
         super().__init__(name)
 
-    async def get_image(
-        self, mime_type: str = "", *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None
-    ) -> ViamImage:
+    async def get_image(self, mime_type: str = "", *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> ViamImage:
         if extra is None:
             extra = {}
         request = GetImageRequest(name=self.name, mime_type=mime_type, extra=dict_to_struct(extra))

--- a/src/viam/components/camera/service.py
+++ b/src/viam/components/camera/service.py
@@ -47,7 +47,7 @@ class CameraRPCService(CameraServiceBase, ResourceRPCServiceBase):
 
                 request.mime_type = self._camera_mime_types[camera.name]
 
-            mimetype, is_lazy = CameraMimeType.from_lazy(request.mime_type)
+            mimetype, _ = CameraMimeType.from_lazy(request.mime_type)
             if CameraMimeType.is_supported(mimetype):
                 response_mime = mimetype
             else:

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -10,7 +10,7 @@ from PIL import Image
 from viam.components.camera import Camera, CameraClient
 from viam.components.camera.service import CameraRPCService
 from viam.components.generic.service import GenericRPCService
-from viam.media.video import LIBRARY_SUPPORTED_FORMATS, CameraMimeType, NamedImage, RawImage
+from viam.media.video import LIBRARY_SUPPORTED_FORMATS, CameraMimeType, NamedImage, RawImage, ViamImage
 from viam.proto.common import DoCommandRequest, DoCommandResponse, GetGeometriesRequest, GetGeometriesResponse, ResponseMetadata
 from viam.proto.component.camera import (
     CameraServiceStub,
@@ -253,27 +253,29 @@ class TestClient:
 
             # Test known mime type
             png_img = await client.get_image(timeout=1.82, mime_type=CameraMimeType.PNG)
-            assert isinstance(png_img, Image.Image)
-            assert png_img.tobytes() == image.tobytes()
+            assert isinstance(png_img.image, Image.Image)
+            assert png_img.image.tobytes() == image.tobytes()
             assert camera.timeout == loose_approx(1.82)
 
             # Test raw mime type
             rgba_img = await client.get_image(CameraMimeType.VIAM_RGBA)
-            assert isinstance(rgba_img, Image.Image)
-            rgba_bytes = rgba_img.tobytes()
+            assert isinstance(rgba_img.image, Image.Image)
+            rgba_bytes = rgba_img.image.tobytes()
             assert rgba_bytes == image.copy().convert("RGBA").tobytes()
 
             # Test lazy mime type
             raw_img = await client.get_image(CameraMimeType.PNG.with_lazy_suffix)
-            assert isinstance(raw_img, RawImage)
+            assert isinstance(raw_img, ViamImage)
+            assert raw_img.image is None
             assert raw_img.data == image.tobytes()
             assert raw_img.mime_type == CameraMimeType.PNG
 
             # Test unknown mime type
             raw_img = await client.get_image("unknown")
-            assert isinstance(raw_img, RawImage)
+            assert isinstance(raw_img, ViamImage)
+            assert raw_img.image is None
             assert raw_img.data == image.tobytes()
-            assert raw_img.mime_type == "unknown"
+            assert raw_img.mime_type == CameraMimeType.UNSUPPORTED
 
     @pytest.mark.asyncio
     async def test_get_images(self, camera: MockCamera, service: CameraRPCService, image: Image.Image, metadata: ResponseMetadata):


### PR DESCRIPTION
Return ViamImage object when using camera component.

Tested using laptop's webcam!
`mycam get_image return value: <viam.media.video.ViamImage object at 0x102f3de10>`
![tmp4wghpj1b](https://github.com/viamrobotics/viam-python-sdk/assets/31713368/de84524a-f290-43c4-8a7d-7fbef29708f4)