### PR TITLE
RSDK-6011 - Add Motion Expose Paths project RPC methods

### DIFF
--- a/src/viam/services/motion/client.py
+++ b/src/viam/services/motion/client.py
@@ -174,8 +174,14 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Mapping[str, ValueTypes]] = None,
         timeout: Optional[float] = None,
-    ) :
-        """
+    ):
+        """Stops a Plan
+
+        Args:
+            component_name (ResourceName): The component to stop
+
+        Returns:
+            None
         """
         if extra is None:
             extra = {}
@@ -197,7 +203,20 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
         extra: Optional[Mapping[str, ValueTypes]] = None,
         timeout: Optional[float] = None,
     ) -> GetPlanResponse:
-        """
+        """Returns the plan(s) & state history of the most recent execution to move a component.
+
+        Returns a result if the last execution is still executing OR changed state within the last 24 hours AND the robot has not reinitialized.
+        Plans are never mutated.
+        Replans always create new plans.
+        Replans share the execution_id of the previously executing plan.
+
+        Args:
+            component_name (ResourceName): The component to stop
+            last_plan_only (Optional[bool]): If supplied, the response will only return the last plan for the component / execution
+            execution_id (Optional[str]): If supplied, the response will only return plans with the provided execution_id
+
+        Returns:
+            ``GetPlanResponse`` (GetPlanResponse): The current PlanWithStatus & replan history which matches the request
         """
         if extra is None:
             extra = {}
@@ -221,7 +240,14 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
         extra: Optional[Mapping[str, ValueTypes]] = None,
         timeout: Optional[float] = None,
     ) -> ListPlanStatusesResponse:
-        """
+        """Returns the status of plans created by MoveOnGlobe requests that are executing
+        OR are part of an execution which changed it statewithin the a 24HR TTL OR until the robot reinitializes.
+
+        Args:
+            only_active_plans (Optional[bool]):  If supplied, the response will filter out any plans that are not executing
+
+        Returns:
+            ``ListPlanStatusesResponse`` (ListPlanStatusesResponse): List of last known statuses with the associated IDs of all plans within the TTL ordered by timestamp in ascending order
         """
         if extra is None:
             extra = {}

--- a/src/viam/services/motion/client.py
+++ b/src/viam/services/motion/client.py
@@ -205,7 +205,8 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
     ) -> GetPlanResponse:
         """Returns the plan(s) & state history of the most recent execution to move a component.
 
-        Returns a result if the last execution is still executing OR changed state within the last 24 hours AND the robot has not reinitialized.
+        Returns a result if the last execution is still executing OR changed state within the
+        last 24 hours AND the robot has not reinitialized.
         Plans are never mutated.
         Replans always create new plans.
         Replans share the execution_id of the previously executing plan.
@@ -247,7 +248,8 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
             only_active_plans (Optional[bool]):  If supplied, the response will filter out any plans that are not executing
 
         Returns:
-            ``ListPlanStatusesResponse`` (ListPlanStatusesResponse): List of last known statuses with the associated IDs of all plans within the TTL ordered by timestamp in ascending order
+            ``ListPlanStatusesResponse`` (ListPlanStatusesResponse): List of last known statuses with the
+            associated IDs of all plans within the TTL ordered by timestamp in ascending order
         """
         if extra is None:
             extra = {}

--- a/src/viam/services/motion/client.py
+++ b/src/viam/services/motion/client.py
@@ -25,6 +25,8 @@ from viam.proto.service.motion import (
     MotionServiceStub,
     MoveOnGlobeNewRequest,
     MoveOnGlobeNewResponse,
+    MoveOnGlobeRequest,
+    MoveOnGlobeResponse,
     MoveOnMapRequest,
     MoveOnMapResponse,
     MoveRequest,
@@ -107,8 +109,53 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Mapping[str, ValueTypes]] = None,
         timeout: Optional[float] = None,
-    ) -> str:
+    ) -> bool:
         """Move a component to a specific latitude and longitude, using a ``MovementSensor`` to check the location.
+
+        Note: Is non blocking.
+
+        Args:
+            component_name (ResourceName): The component to move
+            destination (GeoPoint): The destination point
+            movement_sensor_name (ResourceName): The ``MovementSensor`` which will be used to check robot location
+            obstacles (Optional[Sequence[GeoObstacle]], optional): Obstacles to be considered for motion planning. Defaults to None.
+            heading (Optional[float], optional): Compass heading to achieve at the destination, in degrees [0-360). Defaults to None.
+            linear_meters_per_sec (Optional[float], optional): Linear velocity to target when moving. Defaults to None.
+            angular_deg_per_sec (Optional[float], optional): Angular velocity to target when turning. Defaults to None.
+
+        Returns:
+            bool: Whether the request was successful
+        """
+        if extra is None:
+            extra = {}
+        request = MoveOnGlobeRequest(
+            name=self.name,
+            component_name=component_name,
+            destination=destination,
+            movement_sensor_name=movement_sensor_name,
+            obstacles=obstacles,
+            heading=heading,
+            motion_configuration=configuration,
+            extra=dict_to_struct(extra),
+        )
+        response: MoveOnGlobeResponse = await self.client.MoveOnGlobe(request, timeout=timeout)
+        return response.success
+
+    async def move_on_globe_new(
+        self,
+        component_name: ResourceName,
+        destination: GeoPoint,
+        movement_sensor_name: ResourceName,
+        obstacles: Optional[Sequence[GeoObstacle]] = None,
+        heading: Optional[float] = None,
+        configuration: Optional[MotionConfiguration] = None,
+        *,
+        extra: Optional[Mapping[str, ValueTypes]] = None,
+        timeout: Optional[float] = None,
+    ) -> str:
+        """
+        **Experimental**: use move_on_globe instead.
+        Move a component to a specific latitude and longitude, using a ``MovementSensor`` to check the location.
 
         Note: Is non blocking.
 
@@ -148,7 +195,8 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
         extra: Optional[Mapping[str, ValueTypes]] = None,
         timeout: Optional[float] = None,
     ) -> bool:
-        """Move a component to a specific pose, using a ``SlamService`` for the SLAM map
+        """
+        Move a component to a specific pose, using a ``SlamService`` for the SLAM map
 
         Args:
             component_name (ResourceName): The component to move
@@ -177,7 +225,8 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
         extra: Optional[Mapping[str, ValueTypes]] = None,
         timeout: Optional[float] = None,
     ):
-        """Stops a Plan
+        """**Experimental**
+        Stops a Plan
 
         Args:
             component_name (ResourceName): The component to stop
@@ -205,7 +254,8 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
         extra: Optional[Mapping[str, ValueTypes]] = None,
         timeout: Optional[float] = None,
     ) -> GetPlanResponse:
-        """Returns the plan(s) & state history of the most recent execution to move a component.
+        """**Experimental**
+        Returns the plan(s) & state history of the most recent execution to move a component.
 
         Returns a result if the last execution is still executing OR changed state within the
         last 24 hours AND the robot has not reinitialized.
@@ -243,7 +293,8 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
         extra: Optional[Mapping[str, ValueTypes]] = None,
         timeout: Optional[float] = None,
     ) -> ListPlanStatusesResponse:
-        """Returns the status of plans created by MoveOnGlobe requests that are executing
+        """**Experimental**
+        Returns the status of plans created by MoveOnGlobe requests that are executing
         OR are part of an execution which changed it statewithin the a 24HR TTL OR until the robot reinitializes.
 
         Args:

--- a/src/viam/services/motion/client.py
+++ b/src/viam/services/motion/client.py
@@ -232,7 +232,7 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
         timeout: Optional[float] = None,
     ):
         """**Experimental**
-        Stop a component being moved by an in progress ``move_on_globe()`` call.
+        Stop a component being moved by an in progress ``move_on_globe_new()`` call.
 
         Args:
             component_name (ResourceName): The component to stop

--- a/src/viam/services/motion/client.py
+++ b/src/viam/services/motion/client.py
@@ -110,6 +110,8 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
     ) -> str:
         """Move a component to a specific latitude and longitude, using a ``MovementSensor`` to check the location.
 
+        Note: Is non blocking.
+
         Args:
             component_name (ResourceName): The component to move
             destination (GeoPoint): The destination point
@@ -120,7 +122,7 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
             angular_deg_per_sec (Optional[float], optional): Angular velocity to target when turning. Defaults to None.
 
         Returns:
-            str: ExecutionID of the move_on_globe call
+            str: ExecutionID of the move_on_globe call, which can be used to track execution progress.
         """
         if extra is None:
             extra = {}

--- a/src/viam/services/motion/client.py
+++ b/src/viam/services/motion/client.py
@@ -112,8 +112,6 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
     ) -> bool:
         """Move a component to a specific latitude and longitude, using a ``MovementSensor`` to check the location.
 
-        Note: Is non blocking.
-
         Args:
             component_name (ResourceName): The component to move
             destination (GeoPoint): The destination point

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -269,6 +269,7 @@ from viam.proto.service.motion import (
     StopPlanRequest,
     StopPlanResponse,
 )
+from viam.gen.service.motion.v1.motion_pb2 import PLAN_STATE_IN_PROGRESS, PLAN_STATE_SUCCEEDED, PLAN_STATE_FAILED, PLAN_STATE_STOPPED
 from viam.proto.service.navigation import Mode, Waypoint, Path
 from viam.proto.service.sensors import (
     GetReadingsRequest,
@@ -443,9 +444,13 @@ class MockMotion(MotionServiceBase):
         self,
         move_responses: Dict[str, bool],
         get_pose_responses: Dict[str, PoseInFrame],
+        get_plan_response: GetPlanResponse,
+        list_plan_statuses_response: ListPlanStatusesResponse
     ):
         self.move_responses = move_responses
         self.get_pose_responses = get_pose_responses
+        self.get_plan_response = get_plan_response
+        self.list_plan_statuses_response = list_plan_statuses_response
         self.constraints: Optional[Constraints] = None
         self.extra: Optional[Mapping[str, Any]] = None
         self.timeout: Optional[float] = None
@@ -495,16 +500,46 @@ class MockMotion(MotionServiceBase):
         await stream.send_message(response)
 
     async def MoveOnGlobeNew(self, stream: Stream[MoveOnGlobeNewRequest, MoveOnGlobeNewResponse]) -> None:
-        raise NotImplementedError()
+        request = await stream.recv_message()
+        assert request is not None
+        self.component_name = request.component_name
+        self.destination = request.destination
+        self.movement_sensor = request.movement_sensor_name
+        self.obstacles = request.obstacles
+        self.heading = request.heading
+        self.configuration = request.motion_configuration
+        self.extra = struct_to_dict(request.extra)
+        self.timeout = stream.deadline.time_remaining() if stream.deadline else None
+        self.execution_id="some_execution_id"
+        await stream.send_message(MoveOnGlobeNewResponse(execution_id=self.execution_id))
 
     async def StopPlan(self, stream: Stream[StopPlanRequest, StopPlanResponse]) -> None:
-        raise NotImplementedError()
+        request = await stream.recv_message()
+        assert request is not None
+        self.component_name = request.component_name
+        self.extra = struct_to_dict(request.extra)
+        self.timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await stream.send_message(StopPlanResponse())
 
     async def ListPlanStatuses(self, stream: Stream[ListPlanStatusesRequest, ListPlanStatusesResponse]) -> None:
-        raise NotImplementedError()
+        request = await stream.recv_message()
+        assert request is not None
+        self.only_active_plans = request.only_active_plans
+        self.extra = struct_to_dict(request.extra)
+        self.timeout = stream.deadline.time_remaining() if stream.deadline else None
+        response = self.list_plan_statuses_response
+        await stream.send_message(response)
+
 
     async def GetPlan(self, stream: Stream[GetPlanRequest, GetPlanResponse]) -> None:
-        raise NotImplementedError()
+        request = await stream.recv_message()
+        assert request is not None
+        self.component_name = request.component_name
+        self.last_plan_only = request.last_plan_only
+        self.execution_id = request.execution_id
+        self.extra = struct_to_dict(request.extra)
+        self.timeout = stream.deadline.time_remaining() if stream.deadline else None
+        await stream.send_message(self.get_plan_response)
 
     async def DoCommand(self, stream: Stream[DoCommandRequest, DoCommandResponse]) -> None:
         request = await stream.recv_message()

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -269,7 +269,6 @@ from viam.proto.service.motion import (
     StopPlanRequest,
     StopPlanResponse,
 )
-from viam.gen.service.motion.v1.motion_pb2 import PLAN_STATE_IN_PROGRESS, PLAN_STATE_SUCCEEDED, PLAN_STATE_FAILED, PLAN_STATE_STOPPED
 from viam.proto.service.navigation import Mode, Waypoint, Path
 from viam.proto.service.sensors import (
     GetReadingsRequest,
@@ -510,7 +509,7 @@ class MockMotion(MotionServiceBase):
         self.configuration = request.motion_configuration
         self.extra = struct_to_dict(request.extra)
         self.timeout = stream.deadline.time_remaining() if stream.deadline else None
-        self.execution_id="some_execution_id"
+        self.execution_id = "some_execution_id"
         await stream.send_message(MoveOnGlobeNewResponse(execution_id=self.execution_id))
 
     async def StopPlan(self, stream: Stream[StopPlanRequest, StopPlanResponse]) -> None:
@@ -529,7 +528,6 @@ class MockMotion(MotionServiceBase):
         self.timeout = stream.deadline.time_remaining() if stream.deadline else None
         response = self.list_plan_statuses_response
         await stream.send_message(response)
-
 
     async def GetPlan(self, stream: Stream[GetPlanRequest, GetPlanResponse]) -> None:
         request = await stream.recv_message()

--- a/tests/test_motion_service.py
+++ b/tests/test_motion_service.py
@@ -257,6 +257,8 @@ class TestClient:
             client = MotionClient(MOTION_SERVICE_NAME, channel)
             response = await client.get_plan(component_rn)
             assert service.component_name == component_rn
+            assert not service.last_plan_only
+            assert service.execution_id == ''
             assert service.extra == {}
             assert service.timeout is None
             assert response == GET_PLAN_RESPONSE

--- a/tests/test_motion_service.py
+++ b/tests/test_motion_service.py
@@ -2,8 +2,12 @@ import pytest
 from grpclib.testing import ChannelFor
 
 from viam.components.arm import Arm
+from viam.components.base import Base
 from viam.components.gantry import Gantry
+from viam.gen.service.motion.v1.motion_pb2 import GetPlanResponse, ListPlanStatusesResponse, PlanStatusWithID, PlanWithStatus, Plan, PlanStatus, PlanStep, ComponentState
+from viam.gen.service.motion.v1.motion_pb2 import PLAN_STATE_IN_PROGRESS, PLAN_STATE_SUCCEEDED, PLAN_STATE_FAILED, PLAN_STATE_STOPPED
 from viam.proto.common import GeoObstacle, GeoPoint, Pose, PoseInFrame, ResourceName
+from google.protobuf.timestamp_pb2 import Timestamp
 from viam.proto.service.motion import Constraints, LinearConstraint, MotionConfiguration, ObstacleDetector
 from viam.services.motion import MotionClient
 
@@ -16,6 +20,72 @@ GET_POSE_RESPONSES = {
     "arm": PoseInFrame(reference_frame="arm", pose=Pose(x=1, y=2, z=3, o_x=2, o_y=3, o_z=4, theta=20)),
     "gantry": PoseInFrame(reference_frame="gantry", pose=Pose(x=2, y=3, z=4, o_x=3, o_y=4, o_z=5, theta=21)),
 }
+
+GET_PLAN_RESPONSE = GetPlanResponse(
+    current_plan_with_status=PlanWithStatus(
+        plan=Plan(
+            id="plan_id2",
+            component_name=Base.get_resource_name("get_plan_base"), 
+            execution_id="execution_id",
+            steps=[
+                PlanStep(step={"get_plan_base": ComponentState(pose=Pose(x=2, y=3, z=4, o_x=3, o_y=4, o_z=5, theta=21))}),
+                PlanStep(step={"get_plan_base": ComponentState(pose=Pose(x=6, y=7, z=8, o_x=9, o_y=10, o_z=11, theta=23))}),
+            ]
+        ),
+        status=PlanStatus(state=PLAN_STATE_SUCCEEDED, timestamp=Timestamp(seconds=4)),
+        status_history=[PlanStatus(state=PLAN_STATE_IN_PROGRESS, timestamp=Timestamp(seconds=3))],
+    ),
+    replan_history=[
+        PlanWithStatus(
+            plan=Plan(
+                id="plan_id1",
+                component_name=Base.get_resource_name("get_plan_base"), 
+                execution_id="execution_id",
+                steps=[
+                    PlanStep(step={"get_plan_base": ComponentState(pose=Pose(x=1, y=1, z=1, o_x=1, o_y=1, o_z=1, theta=20))}),
+                    PlanStep(step={"get_plan_base": ComponentState(pose=Pose(x=2, y=3, z=4, o_x=3, o_y=4, o_z=5, theta=21))}),
+                    PlanStep(step={"get_plan_base": ComponentState(pose=Pose(x=6, y=7, z=8, o_x=9, o_y=10, o_z=11, theta=23))}),
+                ]
+            ),
+        status=PlanStatus(state=PLAN_STATE_FAILED, reason="failure reason", timestamp=Timestamp(seconds=2)),
+        status_history=[PlanStatus(state=PLAN_STATE_IN_PROGRESS, timestamp=Timestamp(seconds=1))]
+        )
+    ]
+)
+
+LIST_PLAN_STATUSES_RESPONSE=ListPlanStatusesResponse(plan_statuses_with_ids=[
+    PlanStatusWithID(
+        plan_id="plan 5",
+        component_name=Base.get_resource_name("list_plan_statuses_base"),
+        execution_id="execution_id 3",
+        status=PlanStatus(state=PLAN_STATE_IN_PROGRESS, timestamp=Timestamp(seconds=10)),
+    ),
+    PlanStatusWithID(
+        plan_id="plan 4",
+        component_name=Base.get_resource_name("list_plan_statuses_base"),
+        execution_id="execution_id 2",
+        status=PlanStatus(state=PLAN_STATE_SUCCEEDED, timestamp=Timestamp(seconds=9)),
+    ),
+    PlanStatusWithID(
+        plan_id="plan 3",
+        component_name=Base.get_resource_name("list_plan_statuses_base"),
+        execution_id="execution_id 2",
+        status=PlanStatus(state=PLAN_STATE_FAILED, reason="other failure reason", timestamp=Timestamp(seconds=8)),
+    ),
+    PlanStatusWithID(
+        plan_id="plan 2",
+        component_name=Base.get_resource_name("list_plan_statuses_base"),
+        execution_id="execution_id 2",
+        status=PlanStatus(state=PLAN_STATE_FAILED, reason="failure reason", timestamp=Timestamp(seconds=7)),
+    ),
+    PlanStatusWithID(
+        plan_id="plan 1",
+        component_name=Base.get_resource_name("list_plan_statuses_base"),
+        execution_id="execution_id 1",
+        status=PlanStatus(state=PLAN_STATE_STOPPED, timestamp=Timestamp(seconds=6)),
+    ),
+])
+
 MOTION_CONFIGURATION = MotionConfiguration(
     obstacle_detectors=[ObstacleDetector(vision_service=ResourceName(namespace="rdk", type="service", subtype="vision", name="viz1"),
                                          camera=ResourceName(namespace="rdk", type="component", subtype="camera", name="cam1"))],
@@ -34,6 +104,8 @@ def service() -> MockMotion:
     return MockMotion(
         move_responses=MOVE_RESPONSES,
         get_pose_responses=GET_POSE_RESPONSES,
+        get_plan_response=GET_PLAN_RESPONSE,
+        list_plan_statuses_response=LIST_PLAN_STATUSES_RESPONSE,
     )
 
 
@@ -82,13 +154,13 @@ class TestClient:
 
     @pytest.mark.asyncio
     async def test_move_on_globe(self, service: MockMotion):
-        component_rn = Arm.get_resource_name("move_on_globe_arm")
+        component_rn = Base.get_resource_name("move_on_globe_base")
         movement_rn = ResourceName(namespace="rdk", type="component", subtype="movement_sensor", name="move_on_globe_ms")
         destination = GeoPoint(latitude=123, longitude=456)
         obstacles = [GeoObstacle(location=GeoPoint(latitude=111, longitude=222))]
         async with ChannelFor([service]) as channel:
             client = MotionClient(MOTION_SERVICE_NAME, channel)
-            success = await client.move_on_globe(
+            execution_id = await client.move_on_globe(
                 component_rn,
                 destination,
                 movement_rn,
@@ -102,7 +174,96 @@ class TestClient:
             assert service.obstacles == obstacles
             assert service.heading == 182
             assert service.configuration == MOTION_CONFIGURATION
-            assert success
+            assert service.execution_id == execution_id
+            assert service.extra == {}
+            assert service.timeout is None
+            timeout = 50
+            extra = {"max_iter": 1}
+            execution_id = await client.move_on_globe(
+                component_rn,
+                destination,
+                movement_rn,
+                obstacles,
+                heading=182,
+                configuration=MOTION_CONFIGURATION,
+                extra=extra, 
+                timeout=timeout,
+            )
+            assert service.component_name == component_rn
+            assert service.movement_sensor == movement_rn
+            assert service.destination == destination
+            assert service.obstacles == obstacles
+            assert service.heading == 182
+            assert service.configuration == MOTION_CONFIGURATION
+            assert service.execution_id == execution_id
+            assert service.extra == extra
+            assert service.timeout == loose_approx(timeout)
+
+    @pytest.mark.asyncio
+    async def test_stop_plan(self, service: MockMotion):
+        component_rn = Base.get_resource_name("stop_plan_base")
+        async with ChannelFor([service]) as channel:
+            client = MotionClient(MOTION_SERVICE_NAME, channel)
+            await client.stop_plan(component_rn)
+            assert service.component_name == component_rn
+            assert service.extra == {}
+            assert service.timeout is None
+            timeout = 50
+            extra = {"max_iter": 1}
+            await client.stop_plan(component_rn, extra=extra, timeout=timeout)
+            assert service.component_name == component_rn
+            assert service.extra == extra
+            assert service.timeout == loose_approx(timeout)
+
+    @pytest.mark.asyncio
+    async def test_get_plan(self, service: MockMotion):
+        component_rn = Base.get_resource_name("get_plan_base")
+        async with ChannelFor([service]) as channel:
+            client = MotionClient(MOTION_SERVICE_NAME, channel)
+            response = await client.get_plan(component_rn)
+            assert service.component_name == component_rn
+            assert service.extra == {}
+            assert service.timeout is None
+            assert response == GET_PLAN_RESPONSE
+            last_plan_only = True
+            execution_id="execution_id"
+            timeout = 50
+            extra = {"some": "extra"}
+            response = await client.get_plan(
+                    component_rn,
+                    last_plan_only=last_plan_only,
+                    execution_id=execution_id,
+                    extra=extra,
+                    timeout=timeout,
+                    )
+            assert service.component_name == component_rn
+            assert service.last_plan_only == last_plan_only
+            assert service.execution_id == execution_id 
+            assert service.extra == extra
+            assert service.timeout == loose_approx(timeout)
+            assert response == GET_PLAN_RESPONSE
+
+    @pytest.mark.asyncio
+    async def test_list_plan_statuses(self, service: MockMotion):
+        async with ChannelFor([service]) as channel:
+            client = MotionClient(MOTION_SERVICE_NAME, channel)
+            response = await client.list_plan_statuses()
+            assert service.only_active_plans == False
+            assert service.extra == {}
+            assert service.timeout is None
+            assert response == LIST_PLAN_STATUSES_RESPONSE 
+            only_active_plans = True
+            timeout = 50
+            extra = {"some": "extra"}
+            response = await client.list_plan_statuses(
+                    only_active_plans=only_active_plans,
+                    extra=extra,
+                    timeout=timeout,
+                    )
+            assert service.only_active_plans == only_active_plans
+            assert service.extra == extra
+            assert service.timeout == loose_approx(timeout)
+            assert response == LIST_PLAN_STATUSES_RESPONSE
 
     @pytest.mark.asyncio
     async def test_do(self, service: MockMotion):

--- a/tests/test_motion_service.py
+++ b/tests/test_motion_service.py
@@ -166,13 +166,36 @@ class TestClient:
 
     @pytest.mark.asyncio
     async def test_move_on_globe(self, service: MockMotion):
+        component_rn = Arm.get_resource_name("move_on_globe_arm")
+        movement_rn = ResourceName(namespace="rdk", type="component", subtype="movement_sensor", name="move_on_globe_ms")
+        destination = GeoPoint(latitude=123, longitude=456)
+        obstacles = [GeoObstacle(location=GeoPoint(latitude=111, longitude=222))]
+        async with ChannelFor([service]) as channel:
+            client = MotionClient(MOTION_SERVICE_NAME, channel)
+            success = await client.move_on_globe(
+                component_rn,
+                destination,
+                movement_rn,
+                obstacles,
+                heading=182,
+                configuration=MOTION_CONFIGURATION,
+            )
+            assert service.component_name == component_rn
+            assert service.movement_sensor == movement_rn
+            assert service.destination == destination
+            assert service.obstacles == obstacles
+            assert service.heading == 182
+            assert service.configuration == MOTION_CONFIGURATION
+            assert success
+
+    async def test_move_on_globe_new(self, service: MockMotion):
         component_rn = Base.get_resource_name("move_on_globe_base")
         movement_rn = ResourceName(namespace="rdk", type="component", subtype="movement_sensor", name="move_on_globe_ms")
         destination = GeoPoint(latitude=123, longitude=456)
         obstacles = [GeoObstacle(location=GeoPoint(latitude=111, longitude=222))]
         async with ChannelFor([service]) as channel:
             client = MotionClient(MOTION_SERVICE_NAME, channel)
-            execution_id = await client.move_on_globe(
+            execution_id = await client.move_on_globe_new(
                 component_rn,
                 destination,
                 movement_rn,
@@ -191,7 +214,7 @@ class TestClient:
             assert service.timeout is None
             timeout = 50
             extra = {"max_iter": 1}
-            execution_id = await client.move_on_globe(
+            execution_id = await client.move_on_globe_new(
                 component_rn,
                 destination,
                 movement_rn,

--- a/tests/test_motion_service.py
+++ b/tests/test_motion_service.py
@@ -4,8 +4,20 @@ from grpclib.testing import ChannelFor
 from viam.components.arm import Arm
 from viam.components.base import Base
 from viam.components.gantry import Gantry
-from viam.gen.service.motion.v1.motion_pb2 import GetPlanResponse, ListPlanStatusesResponse, PlanStatusWithID, PlanWithStatus, Plan, PlanStatus, PlanStep, ComponentState
-from viam.gen.service.motion.v1.motion_pb2 import PLAN_STATE_IN_PROGRESS, PLAN_STATE_SUCCEEDED, PLAN_STATE_FAILED, PLAN_STATE_STOPPED
+from viam.gen.service.motion.v1.motion_pb2 import (
+        GetPlanResponse,
+        ListPlanStatusesResponse,
+        PlanStatusWithID,
+        PlanWithStatus,
+        Plan,
+        PlanStatus,
+        PlanStep,
+        ComponentState,
+        PLAN_STATE_IN_PROGRESS,
+        PLAN_STATE_SUCCEEDED,
+        PLAN_STATE_FAILED,
+        PLAN_STATE_STOPPED
+        )
 from viam.proto.common import GeoObstacle, GeoPoint, Pose, PoseInFrame, ResourceName
 from google.protobuf.timestamp_pb2 import Timestamp
 from viam.proto.service.motion import Constraints, LinearConstraint, MotionConfiguration, ObstacleDetector
@@ -25,7 +37,7 @@ GET_PLAN_RESPONSE = GetPlanResponse(
     current_plan_with_status=PlanWithStatus(
         plan=Plan(
             id="plan_id2",
-            component_name=Base.get_resource_name("get_plan_base"), 
+            component_name=Base.get_resource_name("get_plan_base"),
             execution_id="execution_id",
             steps=[
                 PlanStep(step={"get_plan_base": ComponentState(pose=Pose(x=2, y=3, z=4, o_x=3, o_y=4, o_z=5, theta=21))}),
@@ -39,7 +51,7 @@ GET_PLAN_RESPONSE = GetPlanResponse(
         PlanWithStatus(
             plan=Plan(
                 id="plan_id1",
-                component_name=Base.get_resource_name("get_plan_base"), 
+                component_name=Base.get_resource_name("get_plan_base"),
                 execution_id="execution_id",
                 steps=[
                     PlanStep(step={"get_plan_base": ComponentState(pose=Pose(x=1, y=1, z=1, o_x=1, o_y=1, o_z=1, theta=20))}),
@@ -47,13 +59,13 @@ GET_PLAN_RESPONSE = GetPlanResponse(
                     PlanStep(step={"get_plan_base": ComponentState(pose=Pose(x=6, y=7, z=8, o_x=9, o_y=10, o_z=11, theta=23))}),
                 ]
             ),
-        status=PlanStatus(state=PLAN_STATE_FAILED, reason="failure reason", timestamp=Timestamp(seconds=2)),
-        status_history=[PlanStatus(state=PLAN_STATE_IN_PROGRESS, timestamp=Timestamp(seconds=1))]
+            status=PlanStatus(state=PLAN_STATE_FAILED, reason="failure reason", timestamp=Timestamp(seconds=2)),
+            status_history=[PlanStatus(state=PLAN_STATE_IN_PROGRESS, timestamp=Timestamp(seconds=1))]
         )
     ]
 )
 
-LIST_PLAN_STATUSES_RESPONSE=ListPlanStatusesResponse(plan_statuses_with_ids=[
+LIST_PLAN_STATUSES_RESPONSE = ListPlanStatusesResponse(plan_statuses_with_ids=[
     PlanStatusWithID(
         plan_id="plan 5",
         component_name=Base.get_resource_name("list_plan_statuses_base"),
@@ -186,7 +198,7 @@ class TestClient:
                 obstacles,
                 heading=182,
                 configuration=MOTION_CONFIGURATION,
-                extra=extra, 
+                extra=extra,
                 timeout=timeout,
             )
             assert service.component_name == component_rn
@@ -226,7 +238,7 @@ class TestClient:
             assert service.timeout is None
             assert response == GET_PLAN_RESPONSE
             last_plan_only = True
-            execution_id="execution_id"
+            execution_id = "execution_id"
             timeout = 50
             extra = {"some": "extra"}
             response = await client.get_plan(
@@ -238,7 +250,7 @@ class TestClient:
                     )
             assert service.component_name == component_rn
             assert service.last_plan_only == last_plan_only
-            assert service.execution_id == execution_id 
+            assert service.execution_id == execution_id
             assert service.extra == extra
             assert service.timeout == loose_approx(timeout)
             assert response == GET_PLAN_RESPONSE
@@ -248,10 +260,10 @@ class TestClient:
         async with ChannelFor([service]) as channel:
             client = MotionClient(MOTION_SERVICE_NAME, channel)
             response = await client.list_plan_statuses()
-            assert service.only_active_plans == False
+            assert not service.only_active_plans
             assert service.extra == {}
             assert service.timeout is None
-            assert response == LIST_PLAN_STATUSES_RESPONSE 
+            assert response == LIST_PLAN_STATUSES_RESPONSE
             only_active_plans = True
             timeout = 50
             extra = {"some": "extra"}


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-6011)

### Note:
New methods are annotated as **Experimental** until the [RPC definition of MoveOnGlobe is changed to be that of MoveOnGlobeNew](https://github.com/viamrobotics/api/pull/411). 

[Follow up PR](https://github.com/viamrobotics/viam-python-sdk/pull/496) will rename `move_on_globe_new` to `move_on_globe` & delete the old `move_on_globe` & remove the **Experimental** annotations.

I'm making these changes now so I can confirm that the [docs ](https://github.com/viamrobotics/docs/pull/2310) update links to the python documentation work as expected.

### Changes:
- Add `move_on_globe_new`, marked as **Experimental** 
- Add `stop_plan`, marked as **Experimental** 
- Add `get_plan`, marked as **Experimental** 
- Add `list_plan_statuses`, marked as **Experimental** 