### PR TITLE
[RSDK-5823] Remove unused Board.Attributes code

### DIFF
--- a/src/viam/components/board/board.py
+++ b/src/viam/components/board/board.py
@@ -25,13 +25,6 @@ class Board(ComponentBase):
 
     SUBTYPE: Final = Subtype(RESOURCE_NAMESPACE_RDK, RESOURCE_TYPE_COMPONENT, "board")
 
-    @dataclass
-    class Attributes:
-        remote: bool
-        """
-        Indicates whether this board is accessed over a remote connection, e.g. gRPC.
-        """
-
     class AnalogReader(ComponentBase):
         """
         AnalogReader represents an analog pin reader that resides on a Board.


### PR DESCRIPTION
This should have been removed in https://github.com/viamrobotics/viam-python-sdk/pull/491, but I forgot. It's dead code. Grepping the codebase for `Attributes` turns up only 1 result (in src/viam/errors.py), and that's a false positive.

Linking things up: I noticed this while reviewing https://github.com/viamrobotics/docs/pull/2313