### PR TITLE
TypeAlias Camera.Properties

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ clean:
 	find . -type d -name '__pycache__' | xargs rm -rf
 
 _lint:
-	flake8 --exclude=**/gen/**,*_grpc.py,*_pb2.py,*_pb2.pyi,.tox
+	flake8 --exclude=**/gen/**,*_grpc.py,*_pb2.py,*_pb2.pyi,.tox,**/venv/**
 
 lint:
 	poetry run $(MAKE) _lint

--- a/src/viam/components/camera/__init__.py
+++ b/src/viam/components/camera/__init__.py
@@ -1,4 +1,4 @@
-from viam.media.video import RawImage
+from viam.media.video import RawImage, ViamImage
 from viam.proto.component.camera import DistortionParameters, IntrinsicParameters
 from viam.resource.registry import Registry, ResourceRegistration
 
@@ -11,6 +11,7 @@ __all__ = [
     "IntrinsicParameters",
     "DistortionParameters",
     "RawImage",
+    "ViamImage",
 ]
 
 Registry.register_subtype(

--- a/src/viam/components/camera/camera.py
+++ b/src/viam/components/camera/camera.py
@@ -1,12 +1,12 @@
 import abc
-from typing import Any, Dict, Final, List, NamedTuple, Optional, Tuple
+from typing import Any, Dict, Final, List, Optional, Tuple
 
 from viam.media.video import NamedImage, ViamImage
 from viam.proto.common import ResponseMetadata
+from viam.proto.component.camera import GetPropertiesResponse
 from viam.resource.types import RESOURCE_NAMESPACE_RDK, RESOURCE_TYPE_COMPONENT, Subtype
 
 from ..component_base import ComponentBase
-from . import DistortionParameters, IntrinsicParameters
 
 
 class Camera(ComponentBase):
@@ -20,17 +20,7 @@ class Camera(ComponentBase):
 
     SUBTYPE: Final = Subtype(RESOURCE_NAMESPACE_RDK, RESOURCE_TYPE_COMPONENT, "camera")
 
-    class Properties(NamedTuple):
-        """The camera's supported features and settings"""
-
-        supports_pcd: bool
-        """Whether the camera has a valid implementation of ``get_point_cloud``"""
-
-        intrinsic_parameters: IntrinsicParameters
-        """The properties of the camera"""
-
-        distortion_parameters: DistortionParameters
-        """The distortion parameters of the camera"""
+    type Properties = GetPropertiesResponse
 
     @abc.abstractmethod
     async def get_image(
@@ -39,7 +29,7 @@ class Camera(ComponentBase):
         """Get the next image from the camera as a ViamImage.
         Be sure to close the image when finished.
 
-        NOTE: If the mime type is ``image/vnd.viam.dep`` you can use :func:`viam.media.video.RawImage.bytes_to_depth_array`
+        NOTE: If the mime type is ``image/vnd.viam.dep`` you can use :func:`viam.media.video.ViamImage.bytes_to_depth_array`
         to convert the data to a standard representation.
 
         Args:

--- a/src/viam/components/camera/camera.py
+++ b/src/viam/components/camera/camera.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Dict, Final, List, Optional, Tuple, TypeAlias
+from typing import Any, Dict, Final, List, Optional, Tuple, TYPE_CHECKING
 
 from viam.media.video import NamedImage, ViamImage
 from viam.proto.common import ResponseMetadata
@@ -7,6 +7,9 @@ from viam.proto.component.camera import GetPropertiesResponse
 from viam.resource.types import RESOURCE_NAMESPACE_RDK, RESOURCE_TYPE_COMPONENT, Subtype
 
 from ..component_base import ComponentBase
+
+if TYPE_CHECKING:
+    from typing import TypeAlias
 
 
 class Camera(ComponentBase):
@@ -20,7 +23,7 @@ class Camera(ComponentBase):
 
     SUBTYPE: Final = Subtype(RESOURCE_NAMESPACE_RDK, RESOURCE_TYPE_COMPONENT, "camera")
 
-    Properties: TypeAlias = GetPropertiesResponse
+    Properties: "TypeAlias" = GetPropertiesResponse
 
     @abc.abstractmethod
     async def get_image(

--- a/src/viam/components/camera/camera.py
+++ b/src/viam/components/camera/camera.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Dict, Final, List, Optional, Tuple
+from typing import Any, Dict, Final, List, Optional, Tuple, TypeAlias
 
 from viam.media.video import NamedImage, ViamImage
 from viam.proto.common import ResponseMetadata
@@ -20,7 +20,7 @@ class Camera(ComponentBase):
 
     SUBTYPE: Final = Subtype(RESOURCE_NAMESPACE_RDK, RESOURCE_TYPE_COMPONENT, "camera")
 
-    type Properties = GetPropertiesResponse
+    Properties: TypeAlias = GetPropertiesResponse
 
     @abc.abstractmethod
     async def get_image(

--- a/src/viam/components/camera/client.py
+++ b/src/viam/components/camera/client.py
@@ -13,7 +13,6 @@ from viam.proto.component.camera import (
     GetPointCloudRequest,
     GetPointCloudResponse,
     GetPropertiesRequest,
-    GetPropertiesResponse,
 )
 from viam.resource.rpc_client_base import ReconfigurableResourceRPCClientBase
 from viam.utils import ValueTypes, dict_to_struct, get_geometries, struct_to_dict

--- a/src/viam/components/camera/client.py
+++ b/src/viam/components/camera/client.py
@@ -64,8 +64,7 @@ class CameraClient(Camera, ReconfigurableResourceRPCClientBase):
         return (response.point_cloud, response.mime_type)
 
     async def get_properties(self, *, timeout: Optional[float] = None) -> Camera.Properties:
-        response: GetPropertiesResponse = await self.client.GetProperties(GetPropertiesRequest(name=self.name), timeout=timeout)
-        return Camera.Properties(response.supports_pcd, response.intrinsic_parameters, response.distortion_parameters)
+        return await self.client.GetProperties(GetPropertiesRequest(name=self.name), timeout=timeout)
 
     async def do_command(self, command: Mapping[str, ValueTypes], *, timeout: Optional[float] = None) -> Mapping[str, ValueTypes]:
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))

--- a/src/viam/components/types.py
+++ b/src/viam/components/types.py
@@ -1,5 +1,0 @@
-import warnings
-
-from viam.media.video import CameraMimeType, RawImage  # noqa: F401
-
-warnings.warn("The viam.types module is deprecated. Please find the appropriate types in the media package", DeprecationWarning)

--- a/src/viam/media/video.py
+++ b/src/viam/media/video.py
@@ -18,7 +18,9 @@ LIBRARY_SUPPORTED_FORMATS = ["JPEG", "PNG", RGBA_FORMAT_LABEL]
 
 
 class RawImage(NamedTuple):
-    """A raw bytes representation of an image.
+    """**DEPRECATED** Use ``ViamImage`` instead
+
+    A raw bytes representation of an image.
 
     A RawImage should be returned instead of a PIL Image instance under one of
     the following conditions

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -398,9 +398,9 @@ class MockCamera(Camera):
         self.point_cloud = b"THIS IS A POINT CLOUD"
         self.extra = None
         self.props = Camera.Properties(
-            False,
-            IntrinsicParameters(width_px=1, height_px=2, focal_x_px=3, focal_y_px=4, center_x_px=5, center_y_px=6),
-            DistortionParameters(model="no_distortion"),
+            supports_pcd=False,
+            intrinsic_parameters=IntrinsicParameters(width_px=1, height_px=2, focal_x_px=3, focal_y_px=4, center_x_px=5, center_y_px=6),
+            distortion_parameters=DistortionParameters(model="no_distortion"),
         )
         self.timeout: Optional[float] = None
         ts = Timestamp()

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -60,9 +60,9 @@ def point_cloud() -> bytes:
 @pytest.fixture(scope="function")
 def properties() -> Camera.Properties:
     return Camera.Properties(
-        False,
-        IntrinsicParameters(width_px=1, height_px=2, focal_x_px=3, focal_y_px=4, center_x_px=5, center_y_px=6),
-        DistortionParameters(model="no_distortion"),
+        supports_pcd=False,
+        intrinsic_parameters=IntrinsicParameters(width_px=1, height_px=2, focal_x_px=3, focal_y_px=4, center_x_px=5, center_y_px=6),
+        distortion_parameters=DistortionParameters(model="no_distortion"),
     )
 
 


### PR DESCRIPTION
Prompted by https://github.com/viamrobotics/api/pull/408, we were redefining `Camera.Properties` when we could've simply `TypeAlias`ed it