### PR TITLE
[RSDK-5810] remove impossible-to-implement functions from digital interrupts

### DIFF
--- a/examples/server/v1/components.py
+++ b/examples/server/v1/components.py
@@ -20,7 +20,6 @@ from viam.components.arm import Arm
 from viam.components.audio_input import AudioInput
 from viam.components.base import Base
 from viam.components.board import Board
-from viam.components.board.board import PostProcessor
 from viam.components.camera import Camera
 from viam.components.encoder import Encoder
 from viam.components.gantry import Gantry

--- a/examples/server/v1/components.py
+++ b/examples/server/v1/components.py
@@ -241,26 +241,11 @@ class ExampleAnalogReader(Board.AnalogReader):
 
 class ExampleDigitalInterrupt(Board.DigitalInterrupt):
     def __init__(self, name: str):
-        self.high = False
-        self.last_tick = 0
         self.num_ticks = 0
-        self.callbacks: List[Queue] = []
-        self.post_processors: List[PostProcessor] = []
         super().__init__(name)
 
     async def value(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> int:
         return self.num_ticks
-
-    async def tick(self, high: bool, nanos: int):
-        self.high = high
-        self.last_tick = nanos
-        self.num_ticks += 1
-
-    async def add_callback(self, queue: Queue):
-        self.callbacks.append(queue)
-
-    async def add_post_processor(self, processor: PostProcessor):
-        self.post_processors.append(processor)
 
 
 class ExampleGPIOPin(Board.GPIOPin):

--- a/examples/server/v1/components.py
+++ b/examples/server/v1/components.py
@@ -10,7 +10,7 @@ else:
     from typing import AsyncIterator
 
 from datetime import timedelta
-from multiprocessing import Lock, Queue
+from multiprocessing import Lock
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 

--- a/src/viam/components/board/board.py
+++ b/src/viam/components/board/board.py
@@ -1,7 +1,6 @@
 import abc
 from datetime import timedelta
-from multiprocessing import Queue
-from typing import Any, Callable, Dict, Final, List, Optional
+from typing import Any, Dict, Final, List, Optional
 
 from viam.proto.common import BoardStatus
 from viam.proto.component.board import PowerMode

--- a/src/viam/components/board/board.py
+++ b/src/viam/components/board/board.py
@@ -57,41 +57,6 @@ class Board(ComponentBase):
             """
             ...
 
-        @abc.abstractmethod
-        async def tick(self, high: bool, nanos: int):
-            """
-            This method is to be called either manually if the interrupt
-            is a proxy to some real hardware interrupt or for tests.
-
-            Args:
-                high (bool): If the signal of the interrupt is high.
-                nanos (int): Nanoseconds from an arbitrary point in time,
-                    but always increasing and always needs to be accurate.
-                    Using ``time.time_ns()`` would be acceptable.
-            """
-            ...
-
-        @abc.abstractmethod
-        async def add_callback(self, queue: Queue):
-            """
-            Add a callback to be sent the low/high value on ``tick()``.
-
-            Args:
-                queue (Queue): The receiving queue.
-            """
-            ...
-
-        @abc.abstractmethod
-        async def add_post_processor(self, processor: PostProcessor):
-            """
-            Add a post processor that should be used to modify what
-            is returned by ``self.value()``
-
-            Args:
-                processor (PostProcessor): The post processor to add.
-            """
-            ...
-
     class GPIOPin(ComponentBase):
         """
         Abstract representation of an individual GPIO pin on a board

--- a/src/viam/components/board/board.py
+++ b/src/viam/components/board/board.py
@@ -9,8 +9,6 @@ from viam.resource.types import RESOURCE_NAMESPACE_RDK, RESOURCE_TYPE_COMPONENT,
 
 from ..component_base import ComponentBase
 
-PostProcessor = Callable[[int], int]
-
 
 class Board(ComponentBase):
     """

--- a/src/viam/components/board/client.py
+++ b/src/viam/components/board/client.py
@@ -59,15 +59,6 @@ class DigitalInterruptClient(Board.DigitalInterrupt):
         response: GetDigitalInterruptValueResponse = await self.board.client.GetDigitalInterruptValue(request, timeout=timeout)
         return response.value
 
-    async def tick(self, high: bool, nanos: int):
-        raise NotImplementedError()
-
-    async def add_callback(self, queue: Queue):
-        raise NotImplementedError()
-
-    async def add_post_processor(self, processor: PostProcessor):
-        raise NotImplementedError()
-
 
 class GPIOPinClient(Board.GPIOPin):
     def __init__(self, name: str, board: "BoardClient"):

--- a/src/viam/components/board/client.py
+++ b/src/viam/components/board/client.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from multiprocessing import Queue
 from typing import Any, Dict, List, Mapping, Optional
 
 from google.protobuf.duration_pb2 import Duration

--- a/src/viam/components/board/client.py
+++ b/src/viam/components/board/client.py
@@ -31,7 +31,6 @@ from viam.resource.rpc_client_base import ReconfigurableResourceRPCClientBase
 from viam.utils import ValueTypes, dict_to_struct, get_geometries, struct_to_dict
 
 from . import Board
-from .board import PostProcessor
 
 
 class AnalogReaderClient(Board.AnalogReader):

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -18,7 +18,6 @@ from viam.components.arm import Arm, JointPositions, KinematicsFileFormat
 from viam.components.audio_input import AudioInput
 from viam.components.base import Base
 from viam.components.board import Board
-from viam.components.board.board import PostProcessor
 from viam.components.camera import Camera, DistortionParameters, IntrinsicParameters
 from viam.components.encoder import Encoder
 from viam.components.gantry import Gantry

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -7,7 +7,6 @@ else:
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from multiprocessing import Queue
 from secrets import choice
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -262,26 +262,15 @@ class MockDigitalInterrupt(Board.DigitalInterrupt):
         self.high = False
         self.last_tick = 0
         self.num_ticks = 0
-        self.callbacks: List[Queue] = []
-        self.post_processors: List[PostProcessor] = []
-        self.timeout: Optional[float] = None
         super().__init__(name)
 
     async def value(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> int:
-        self.extra = extra
-        self.timeout = timeout
         return self.num_ticks
 
-    async def tick(self, high: bool, nanos: int):
+    async def tick(self, high: bool, nanos: int):  # Call this to get the mock interrupt to change
         self.high = high
         self.last_tick = nanos
         self.num_ticks += 1
-
-    async def add_callback(self, queue: Queue):
-        self.callbacks.append(queue)
-
-    async def add_post_processor(self, processor: PostProcessor):
-        self.post_processors.append(processor)
 
 
 class MockGPIOPin(Board.GPIOPin):

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -175,18 +175,17 @@ class TestService:
         async with ChannelFor([service]) as channel:
             client = BoardServiceStub(channel)
 
+            request = GetDigitalInterruptValueRequest(
+                board_name=board.name, digital_interrupt_name="dne"
+            )
             with pytest.raises(GRPCError, match=r".*Status.NOT_FOUND.*"):
-                request = GetDigitalInterruptValueRequest(board_name=board.name, digital_interrupt_name="dne")
                 await client.GetDigitalInterruptValue(request)
 
             request = GetDigitalInterruptValueRequest(
                 board_name=board.name, digital_interrupt_name="interrupt1"
             )
-            response: GetDigitalInterruptValueResponse = await client.GetDigitalInterruptValue(request, timeout=18.2)
+            response: GetDigitalInterruptValueResponse = await client.GetDigitalInterruptValue(request)
             assert response.value == 0
-
-            interrupt = cast(MockDigitalInterrupt, board.digital_interrupts["interrupt1"])
-            assert interrupt.timeout == loose_approx(18.2)
 
     @pytest.mark.asyncio
     async def test_set_gpio(self, board: MockBoard, service: BoardRPCService):

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -179,15 +179,13 @@ class TestService:
                 request = GetDigitalInterruptValueRequest(board_name=board.name, digital_interrupt_name="dne")
                 await client.GetDigitalInterruptValue(request)
 
-            extra = {"foo": "bar", "baz": [1, 2, 3]}
             request = GetDigitalInterruptValueRequest(
-                board_name=board.name, digital_interrupt_name="interrupt1", extra=dict_to_struct(extra)
+                board_name=board.name, digital_interrupt_name="interrupt1"
             )
             response: GetDigitalInterruptValueResponse = await client.GetDigitalInterruptValue(request, timeout=18.2)
             assert response.value == 0
 
             interrupt = cast(MockDigitalInterrupt, board.digital_interrupts["interrupt1"])
-            assert interrupt.extra == extra
             assert interrupt.timeout == loose_approx(18.2)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Within digital interrupts, the `value()` method will get the number of interrupts that have occurred. It's a good thing to have; we'll keep it. However,
- `add_callback()` cannot be implemented without changing the GPRC interface, which will require a scope doc, which will require planning how to do this right. Get rid of it for now: digital interrupts aren't really part of the API yet.
- `add_post_processor()` doesn't exist outside of raspberry pi boards; get rid of it.
- `tick()` is only used in tests (to simulate the interrupt firing). Keep it in `MockDigitalInterrupt`, but get rid of it in the "real" code.

So, how do you use digital interrupts outside of the RDK server? Unfortunately, you kinda can't, and have never been able to. You can repeatedly check its value and do something if you notice the value has changed, but a proper GRPC interface for digital interrupts doesn't currently exist. We shouldn't pretend that it does.