### PR TITLE
RSDK-5983: await get_org_id in list_keys

### DIFF
--- a/src/viam/app/app_client.py
+++ b/src/viam/app/app_client.py
@@ -1444,7 +1444,7 @@ class AppClient:
 
         Returns:
             List[viam.proto.app.APIKeyWithAuthorizations]: The existing API keys and authorizations."""
-        org_id = self._get_organization_id()
+        org_id = await self._get_organization_id()
         request = ListKeysRequest(org_id=org_id)
         response: ListKeysResponse = await self._app_client.ListKeys(request, metadata=self._metadata)
         return response.api_keys

--- a/src/viam/app/app_client.py
+++ b/src/viam/app/app_client.py
@@ -1447,4 +1447,4 @@ class AppClient:
         org_id = await self._get_organization_id()
         request = ListKeysRequest(org_id=org_id)
         response: ListKeysResponse = await self._app_client.ListKeys(request, metadata=self._metadata)
-        return response.api_keys
+        return [key for key in response.api_keys]


### PR DESCRIPTION
Originally: 

```
Exception: bad argument type for built-in operation
/Users/nicolejung/viam/viam-python-sdk/main.py:20: RuntimeWarning: coroutine 'AppClient._get_organization_id' was never awaited
  print(f'Exception: {e}')
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
Unclosed connection: Channel('app.viam.com', 443, ..., path=None)
```

Now:
```
[api_key {
  id: "----"
  key: "----"
  created_on {
    seconds: 1695842752
    nanos: 869000000
  }
}
authorizations {
  authorization_type: "role"
  authorization_id: "robot_owner"
  resource_type: "robot"
  resource_id: "----"
  org_id: "----"
}
]
```