### PR TITLE
Fix tox to include typechecking

### DIFF
--- a/src/viam/components/camera/camera.py
+++ b/src/viam/components/camera/camera.py
@@ -1,5 +1,6 @@
 import abc
-from typing import TYPE_CHECKING, Any, Dict, Final, List, Optional, Tuple
+import sys
+from typing import Any, Dict, Final, List, Optional, Tuple
 
 from viam.media.video import NamedImage, ViamImage
 from viam.proto.common import ResponseMetadata
@@ -8,8 +9,10 @@ from viam.resource.types import RESOURCE_NAMESPACE_RDK, RESOURCE_TYPE_COMPONENT,
 
 from ..component_base import ComponentBase
 
-if TYPE_CHECKING:
+if sys.version_info >= (3, 10):
     from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
 
 
 class Camera(ComponentBase):

--- a/src/viam/operations.py
+++ b/src/viam/operations.py
@@ -1,14 +1,15 @@
 import asyncio
 import functools
+import sys
 import time
 from typing import Any, Callable, Coroutine, Mapping, Optional, TypeVar, cast
 from uuid import UUID, uuid4
 
 from typing_extensions import Self
 
-try:
+if sys.version_info >= (3, 10):
     from typing import ParamSpec
-except ImportError:
+else:
     from typing_extensions import ParamSpec
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,17 @@ envlist =
 [testenv]
 allowlist_externals =
     make
+deps =
+    coverage
+    pyright
+    pytest
+    pytest-asyncio
+extras =
+    mlmodel
 recreate = True
 commands =
-    make test
+    make _typecheck
+    make _test
 
 [testenv:docs]
 allowlist_externals =


### PR DESCRIPTION
Previously, I wrote the code to assume we were typechecking only on the most recent version of python. That proved short-sighted. 

Fix the issues around type checking pre-py310, and update tox to also typecheck 