### PR TITLE
Fix update-protos workflow

### DIFF
--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -43,6 +43,6 @@ jobs:
           git -c author.name=viambot -c author.email=viambot@users.noreply.github.com -c committer.name=GitHub -c committer.email=noreply@github.com commit -m "[WORKFLOW] Updating protos from ${{ github.event.client_payload.repo_name }}, commit: ${{ github.event.client_payload.sha }}"
           git -c pull.ff=only pull origin workflow/update-protos || true  # do not fail if the branch doesn't exist
           git push -f origin workflow/update-protos
-          gh pr view workflow/update-protos && gh pr reopen workflow/update-protos || gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -b "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a njooma -r njooma || true
+          gh pr view workflow/update-protos && gh pr reopen workflow/update-protos || gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -b "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a viamrobotics/sdk-netcode -r viamrobotics/sdk-netcode || true
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -41,7 +41,7 @@ jobs:
           git checkout -b workflow/update-protos || git checkout workflow/update-protos
           git add --all
           git -c author.name=viambot -c author.email=viambot@users.noreply.github.com -c committer.name=GitHub -c committer.email=noreply@github.com commit -m "[WORKFLOW] Updating protos from ${{ github.event.client_payload.repo_name }}, commit: ${{ github.event.client_payload.sha }}"
-          git pull origin workflow/update-protos || true  # do not fail if the branch doesn't exist
+          git pull --rebase=true origin workflow/update-protos || true  # do not fail if the branch doesn't exist
           git push origin workflow/update-protos
           gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -b "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a njooma -r njooma
         env:

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -42,7 +42,7 @@ jobs:
           git add --all
           git -c author.name=viambot -c author.email=viambot@users.noreply.github.com -c committer.name=GitHub -c committer.email=noreply@github.com commit -m "[WORKFLOW] Updating protos from ${{ github.event.client_payload.repo_name }}, commit: ${{ github.event.client_payload.sha }}"
           git -c pull.ff=only pull origin workflow/update-protos || true  # do not fail if the branch doesn't exist
-          git push origin workflow/update-protos
+          git push -f origin workflow/update-protos
           gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -b "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a njooma -r njooma
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -44,3 +44,5 @@ jobs:
           git add --all
           git -c author.name=viambot -c author.email=viambot@users.noreply.github.com -c committer.name=GitHub -c committer.email=noreply@github.com commit -m "[WORKFLOW] Updating protos from ${{ github.event.client_payload.repo_name }}, commit: ${{ github.event.client_payload.sha }}"
           gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -t "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a @njooma -r @njooma
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -43,6 +43,7 @@ jobs:
           git checkout -b workflow/update-protos
           git add --all
           git -c author.name=viambot -c author.email=viambot@users.noreply.github.com -c committer.name=GitHub -c committer.email=noreply@github.com commit -m "[WORKFLOW] Updating protos from ${{ github.event.client_payload.repo_name }}, commit: ${{ github.event.client_payload.sha }}"
+          git push origin workflow/update-protos
           gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -b "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a njooma -r njooma
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -43,6 +43,6 @@ jobs:
           git checkout -b workflow/update-protos
           git add --all
           git -c author.name=viambot -c author.email=viambot@users.noreply.github.com -c committer.name=GitHub -c committer.email=noreply@github.com commit -m "[WORKFLOW] Updating protos from ${{ github.event.client_payload.repo_name }}, commit: ${{ github.event.client_payload.sha }}"
-          gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -t "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a @njooma -r @njooma
+          gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -b "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a @njooma -r @njooma
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -41,7 +41,7 @@ jobs:
           git checkout -b workflow/update-protos || git checkout workflow/update-protos
           git add --all
           git -c author.name=viambot -c author.email=viambot@users.noreply.github.com -c committer.name=GitHub -c committer.email=noreply@github.com commit -m "[WORKFLOW] Updating protos from ${{ github.event.client_payload.repo_name }}, commit: ${{ github.event.client_payload.sha }}"
-          git pull --rebase=true origin workflow/update-protos || true  # do not fail if the branch doesn't exist
+          git pull --rebase=false origin workflow/update-protos || true  # do not fail if the branch doesn't exist
           git push origin workflow/update-protos
           gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -b "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a njooma -r njooma
         env:

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   update-protos:
+    if: github.repository_owner == 'viamrobotics'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -41,7 +41,7 @@ jobs:
           git checkout -b workflow/update-protos || git checkout workflow/update-protos
           git add --all
           git -c author.name=viambot -c author.email=viambot@users.noreply.github.com -c committer.name=GitHub -c committer.email=noreply@github.com commit -m "[WORKFLOW] Updating protos from ${{ github.event.client_payload.repo_name }}, commit: ${{ github.event.client_payload.sha }}"
-          git pull --rebase=false origin workflow/update-protos || true  # do not fail if the branch doesn't exist
+          git -c pull.ff=only pull origin workflow/update-protos || true  # do not fail if the branch doesn't exist
           git push origin workflow/update-protos
           gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -b "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a njooma -r njooma
         env:

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   update-protos:
-    if: github.repository_owner == 'viamrobotics'
-    runs-on: [self-hosted, x64]
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64
+    # if: github.repository_owner == 'viamrobotics'
+    runs-on: ubuntu-latest
+    # container:
+    #   image: ghcr.io/viamrobotics/canon:amd64
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: bufbuild/buf-setup-action@v1.28.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -39,13 +39,8 @@ jobs:
         run: make format
 
       - name: Add + Commit + Open PR
-        uses: peter-evans/create-pull-request@v5.0.2
-        with:
-          commit-message: "[WORKFLOW] Updating protos from ${{ github.event.client_payload.repo_name }}, commit: ${{ github.event.client_payload.sha }}"
-          branch: "workflow/update-protos"
-          delete-branch: true
-          base: main
-          title: Automated Protos Update
-          body: This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes
-          assignees: njooma
-          reviewers: njooma
+        run: |
+          git checkout -b workflow/update-protos
+          git add --all
+          git -c author.name=viambot -c author.email=viambot@users.noreply.github.com -c committer.name=GitHub -c committer.email=noreply@github.com commit -m "[WORKFLOW] Updating protos from ${{ github.event.client_payload.repo_name }}, commit: ${{ github.event.client_payload.sha }}"
+          gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -t "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a @njooma -r @njooma

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -43,6 +43,6 @@ jobs:
           git checkout -b workflow/update-protos
           git add --all
           git -c author.name=viambot -c author.email=viambot@users.noreply.github.com -c committer.name=GitHub -c committer.email=noreply@github.com commit -m "[WORKFLOW] Updating protos from ${{ github.event.client_payload.repo_name }}, commit: ${{ github.event.client_payload.sha }}"
-          gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -b "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a @njooma -r @njooma
+          gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -b "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a njooma -r njooma
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -43,6 +43,6 @@ jobs:
           git -c author.name=viambot -c author.email=viambot@users.noreply.github.com -c committer.name=GitHub -c committer.email=noreply@github.com commit -m "[WORKFLOW] Updating protos from ${{ github.event.client_payload.repo_name }}, commit: ${{ github.event.client_payload.sha }}"
           git -c pull.ff=only pull origin workflow/update-protos || true  # do not fail if the branch doesn't exist
           git push -f origin workflow/update-protos
-          gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -b "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a njooma -r njooma
+          gh pr view workflow/update-protos && gh pr reopen workflow/update-protos || gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -b "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a njooma -r njooma || true
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -43,6 +43,6 @@ jobs:
           git -c author.name=viambot -c author.email=viambot@users.noreply.github.com -c committer.name=GitHub -c committer.email=noreply@github.com commit -m "[WORKFLOW] Updating protos from ${{ github.event.client_payload.repo_name }}, commit: ${{ github.event.client_payload.sha }}"
           git -c pull.ff=only pull origin workflow/update-protos || true  # do not fail if the branch doesn't exist
           git push -f origin workflow/update-protos
-          gh pr view workflow/update-protos && gh pr reopen workflow/update-protos || gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -b "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a viamrobotics/sdk-netcode -r viamrobotics/sdk-netcode || true
+          gh pr view workflow/update-protos && gh pr reopen workflow/update-protos || gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -b "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a viamrobotics/sdk-netcode -r viamrobotics/sdk-netcode
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -8,10 +8,7 @@ on:
 
 jobs:
   update-protos:
-    # if: github.repository_owner == 'viamrobotics'
     runs-on: ubuntu-latest
-    # container:
-    #   image: ghcr.io/viamrobotics/canon:amd64
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-setup-action@v1.28.1
@@ -39,10 +36,12 @@ jobs:
         run: make format
 
       - name: Add + Commit + Open PR
+        shell: bash
         run: |
-          git checkout -b workflow/update-protos
+          git checkout -b workflow/update-protos || git checkout workflow/update-protos
           git add --all
           git -c author.name=viambot -c author.email=viambot@users.noreply.github.com -c committer.name=GitHub -c committer.email=noreply@github.com commit -m "[WORKFLOW] Updating protos from ${{ github.event.client_payload.repo_name }}, commit: ${{ github.event.client_payload.sha }}"
+          git pull origin workflow/update-protos || true  # do not fail if the branch doesn't exist
           git push origin workflow/update-protos
           gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -b "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a njooma -r njooma
         env:


### PR DESCRIPTION
The update protos workflow has been failing because of stale info. The issue is, there is no existing branch for the stale info to be coming from (the branch is auto-deleted once the PR is merged). 

I went ahead and changed the flow to use only git actions that we have more control over, rather than a third-party action.