### PR TITLE
RSDK-5731: add dataset apis

### DIFF
--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -8,9 +8,9 @@ from grpclib.client import Channel, Stream
 
 from viam import logging
 from viam.proto.app.data import (
+    AddBinaryDataToDatasetByIDsRequest,
     AddBoundingBoxToImageByIDRequest,
     AddBoundingBoxToImageByIDResponse,
-    AddBinaryDataToDatasetByIDsRequest,
     AddTagsToBinaryDataByFilterRequest,
     AddTagsToBinaryDataByIDsRequest,
     BinaryDataByFilterRequest,
@@ -502,6 +502,7 @@ class DataClient:
             organization_id (str): the organization id of the dataset.
             time_created (datetime): the time the dataset was created.
         """
+
         def __init__(self, id: str, name: str, organization_id: str, time_created: datetime) -> None:
             self.id = id
             self.name = name
@@ -522,7 +523,6 @@ class DataClient:
         response: CreateDatasetResponse = await self._dataset_client.CreateDataset(request, metadata=self._metadata)
         return response.id
 
-
     async def list_dataset_by_ids(self, ids: List[str]) -> List[Dataset]:
         """Get a list of datasets using their IDs.
 
@@ -540,7 +540,6 @@ class DataClient:
             datasets.append(DataClient.Dataset(dataset.id, dataset.name, dataset.organization_id, dataset.time_created.ToDatetime()))
         return datasets
 
-
     async def list_datasets_by_organization_id(self, organization_id: str) -> List[Dataset]:
         """Get the datasets in an organization.
 
@@ -551,7 +550,9 @@ class DataClient:
             List[Dataset]: The list of datasets in the organization.
         """
         request = ListDatasetsByOrganizationIDRequest(organization_id=organization_id)
-        response: ListDatasetsByOrganizationIDResponse = await self._dataset_client.ListDatasetsByOrganizationID(request, metadata=self._metadata)
+        response: ListDatasetsByOrganizationIDResponse = await self._dataset_client.ListDatasetsByOrganizationID(
+            request, metadata=self._metadata
+        )
 
         datasets = []
         for dataset in response.datasets:

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -806,6 +806,7 @@ class DataClient:
         end_time: Optional[datetime] = None,
         tags: Optional[List[str]] = None,
         bbox_labels: Optional[List[str]] = None,
+        dataset_id: Optional[str] = None,
     ) -> Filter:
         warnings.warn("DataClient.create_filter is deprecated. Use AppClient.create_filter instead.", DeprecationWarning, stacklevel=2)
         return create_filter(
@@ -823,4 +824,5 @@ class DataClient:
             end_time,
             tags,
             bbox_labels,
+            dataset_id,
         )

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -10,6 +10,7 @@ from viam import logging
 from viam.proto.app.data import (
     AddBoundingBoxToImageByIDRequest,
     AddBoundingBoxToImageByIDResponse,
+    AddBinaryDataToDatasetByIDsRequest,
     AddTagsToBinaryDataByFilterRequest,
     AddTagsToBinaryDataByIDsRequest,
     BinaryDataByFilterRequest,
@@ -32,6 +33,7 @@ from viam.proto.app.data import (
     Filter,
     GetDatabaseConnectionRequest,
     GetDatabaseConnectionResponse,
+    RemoveBinaryDataFromDatasetByIDsRequest,
     RemoveBoundingBoxFromImageByIDRequest,
     RemoveTagsFromBinaryDataByFilterRequest,
     RemoveTagsFromBinaryDataByFilterResponse,
@@ -477,6 +479,26 @@ class DataClient:
     # TODO(RSDK-5569): implement
     async def configure_database_user(self, organization_id: str, password: str) -> None:
         raise NotImplementedError()
+
+    async def add_binary_data_to_dataset_by_ids(self, binary_ids: List[BinaryID], dataset_id: str) -> None:
+        """Add VIAM_DATASET_{id} tag to a list of image data IDs.
+
+        Args:
+            binary_ids (List[BinaryID]): List of images to add to dataset.
+            dataset_id (str): The ID of the dataset to be added to.
+        """
+        request = AddBinaryDataToDatasetByIDsRequest(binary_ids=binary_ids, dataset_id=dataset_id)
+        await self._data_client.AddBinaryDataToDatasetByIDs(request, metadata=self._metadata)
+
+    async def remove_binary_data_from_dataset_by_ids(self, binary_ids: List[BinaryID], dataset_id: str) -> None:
+        """Removes VIAM_DATASET_{id} tag from image data IDs
+
+        Args:
+            binary_ids (List[BinaryID]): List of images to add to dataset.
+            dataset_id (str): The ID of the dataset to be removed from.
+        """
+        request = RemoveBinaryDataFromDatasetByIDsRequest(binary_ids=binary_ids, dataset_id=dataset_id)
+        await self._data_client.RemoveBinaryDataFromDatasetByIDs(request, metadata=self._metadata)
 
     async def binary_data_capture_upload(
         self,

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -514,7 +514,7 @@ class DataClient:
 
         Args:
             name (str): The name of the dataset being created.
-            organization_id (str): The organization ID of the dataset being created.
+            organization_id (str): The ID of the organization where the dataset is being created.
 
         Returns:
             str: The dataset ID of the created dataset.
@@ -579,20 +579,20 @@ class DataClient:
         await self._dataset_client.DeleteDataset(request, metadata=self._metadata)
 
     async def add_binary_data_to_dataset_by_ids(self, binary_ids: List[BinaryID], dataset_id: str) -> None:
-        """Add VIAM_DATASET_{id} tag to a list of image data IDs.
+        """Add VIAM_DATASET_{id} tag to binary data.
 
         Args:
-            binary_ids (List[BinaryID]): List of images to add to dataset.
+            binary_ids (List[BinaryID]): The IDs of binary data to add to dataset.
             dataset_id (str): The ID of the dataset to be added to.
         """
         request = AddBinaryDataToDatasetByIDsRequest(binary_ids=binary_ids, dataset_id=dataset_id)
         await self._data_client.AddBinaryDataToDatasetByIDs(request, metadata=self._metadata)
 
     async def remove_binary_data_from_dataset_by_ids(self, binary_ids: List[BinaryID], dataset_id: str) -> None:
-        """Removes VIAM_DATASET_{id} tag from image data IDs
+        """Removes VIAM_DATASET_{id} tag from binary data.
 
         Args:
-            binary_ids (List[BinaryID]): List of images to add to dataset.
+            binary_ids (List[BinaryID]): The IDs of binary data to remove from dataset.
             dataset_id (str): The ID of the dataset to be removed from.
         """
         request = RemoveBinaryDataFromDatasetByIDsRequest(binary_ids=binary_ids, dataset_id=dataset_id)

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -1,7 +1,7 @@
 import warnings
 from datetime import datetime
 from pathlib import Path
-from typing import Any, List, Mapping, Optional, Tuple
+from typing import Any, List, Mapping, Optional, Sequence, Tuple
 
 from google.protobuf.struct_pb2 import Struct
 from grpclib.client import Channel, Stream
@@ -509,35 +509,35 @@ class DataClient:
         response: CreateDatasetResponse = await self._dataset_client.CreateDataset(request, metadata=self._metadata)
         return response.id
 
-    async def list_dataset_by_ids(self, ids: List[str]) -> List[Dataset]:
+    async def list_dataset_by_ids(self, ids: List[str]) -> Sequence[Dataset]:
         """Get a list of datasets using their IDs.
 
         Args:
             ids (List[str]): The IDs of the datasets being called for.
 
         Returns:
-            List[Dataset]: The list of datasets.
+            Sequence[Dataset]: The list of datasets.
         """
         request = ListDatasetsByIDsRequest(ids=ids)
         response: ListDatasetsByIDsResponse = await self._dataset_client.ListDatasetsByIDs(request, metadata=self._metadata)
 
-        return list(response.datasets)
+        return response.datasets
 
-    async def list_datasets_by_organization_id(self, organization_id: str) -> List[Dataset]:
+    async def list_datasets_by_organization_id(self, organization_id: str) -> Sequence[Dataset]:
         """Get the datasets in an organization.
 
         Args:
             organization_id (str): The ID of the organization.
 
         Returns:
-            List[Dataset]: The list of datasets in the organization.
+            Sequence[Dataset]: The list of datasets in the organization.
         """
         request = ListDatasetsByOrganizationIDRequest(organization_id=organization_id)
         response: ListDatasetsByOrganizationIDResponse = await self._dataset_client.ListDatasetsByOrganizationID(
             request, metadata=self._metadata
         )
 
-        return list(response.datasets)
+        return response.datasets
 
     async def rename_dataset(self, id: str, name: str) -> None:
         """Rename a dataset specified by the dataset ID.
@@ -559,7 +559,9 @@ class DataClient:
         await self._dataset_client.DeleteDataset(request, metadata=self._metadata)
 
     async def add_binary_data_to_dataset_by_ids(self, binary_ids: List[BinaryID], dataset_id: str) -> None:
-        """Add VIAM_DATASET_{id} tag to binary data.
+        """Add the BinaryData to the provided dataset.
+
+        This BinaryData will be tagged with the VIAM_DATASET_{id} label.
 
         Args:
             binary_ids (List[BinaryID]): The IDs of binary data to add to dataset.
@@ -569,7 +571,9 @@ class DataClient:
         await self._data_client.AddBinaryDataToDatasetByIDs(request, metadata=self._metadata)
 
     async def remove_binary_data_from_dataset_by_ids(self, binary_ids: List[BinaryID], dataset_id: str) -> None:
-        """Removes VIAM_DATASET_{id} tag from binary data.
+        """Remove the BinaryData from the provided dataset.
+
+        This BinaryData will lose the VIAM_DATASET_{id} tag.
 
         Args:
             binary_ids (List[BinaryID]): The IDs of binary data to remove from dataset.

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, List, Mapping, Optional, Tuple
 
-from google.protobuf.internal.containers import RepeatedCompositeFieldContainer
 from google.protobuf.struct_pb2 import Struct
 from grpclib.client import Channel, Stream
 
@@ -510,7 +509,7 @@ class DataClient:
         response: CreateDatasetResponse = await self._dataset_client.CreateDataset(request, metadata=self._metadata)
         return response.id
 
-    async def list_dataset_by_ids(self, ids: List[str]) -> RepeatedCompositeFieldContainer[Dataset]:
+    async def list_dataset_by_ids(self, ids: List[str]) -> List[Dataset]:
         """Get a list of datasets using their IDs.
 
         Args:
@@ -522,9 +521,9 @@ class DataClient:
         request = ListDatasetsByIDsRequest(ids=ids)
         response: ListDatasetsByIDsResponse = await self._dataset_client.ListDatasetsByIDs(request, metadata=self._metadata)
 
-        return response.datasets
+        return list(response.datasets)
 
-    async def list_datasets_by_organization_id(self, organization_id: str) -> RepeatedCompositeFieldContainer[Dataset]:
+    async def list_datasets_by_organization_id(self, organization_id: str) -> List[Dataset]:
         """Get the datasets in an organization.
 
         Args:
@@ -538,7 +537,7 @@ class DataClient:
             request, metadata=self._metadata
         )
 
-        return response.datasets
+        return list(response.datasets)
 
     async def rename_dataset(self, id: str, name: str) -> None:
         """Rename a dataset specified by the dataset ID.

--- a/src/viam/utils.py
+++ b/src/viam/utils.py
@@ -284,6 +284,7 @@ def create_filter(
     end_time: Optional[datetime] = None,
     tags: Optional[List[str]] = None,
     bbox_labels: Optional[List[str]] = None,
+    dataset_id: Optional[str] = None,
 ) -> Filter:
     """Create a `Filter`.
 
@@ -303,6 +304,7 @@ def create_filter(
         tags (Optional[List[str]]): Optional list of tags attached to the data being filtered (e.g., ["test"]).
         bbox_labels (Optional[List[str]]): Optional list of bounding box labels attached to the data being filtered (e.g., ["square",
             "circle"]).
+        dataset_id (Optional[str]): Optional ID of dataset associated with data being filtered
 
     Returns:
         viam.proto.app.data.Filter: The `Filter` object.
@@ -328,4 +330,5 @@ def create_filter(
         else None,
         tags_filter=TagsFilter(tags=tags),
         bbox_labels=bbox_labels,
+        dataset_id=dataset_id if dataset_id else "",
     )

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -821,12 +821,20 @@ class MockData(DataServiceBase):
     async def AddBinaryDataToDatasetByIDs(
         self, stream: Stream[AddBinaryDataToDatasetByIDsRequest, AddBinaryDataToDatasetByIDsResponse]
     ) -> None:
-        raise NotImplementedError()
+        request = await stream.recv_message()
+        assert request is not None
+        self.added_data_ids = request.binary_ids
+        self.dataset_id = request.dataset_id
+        await stream.send_message(AddBinaryDataToDatasetByIDsResponse())
 
     async def RemoveBinaryDataFromDatasetByIDs(
         self, stream: Stream[RemoveBinaryDataFromDatasetByIDsRequest, RemoveBinaryDataFromDatasetByIDsResponse]
     ) -> None:
-        raise NotImplementedError()
+        request = await stream.recv_message()
+        assert request is not None
+        self.removed_data_ids = request.binary_ids
+        self.dataset_id = request.dataset_id
+        await stream.send_message(RemoveBinaryDataFromDatasetByIDsResponse())
 
     async def TabularDataBySQL(self, stream: Stream[TabularDataBySQLRequest, TabularDataBySQLResponse]) -> None:
         raise NotImplementedError()

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -6,6 +6,7 @@ from numpy.typing import NDArray
 from PIL import Image
 
 from viam.app.data_client import DataClient
+from viam.gen import app
 from viam.media.video import RawImage
 from viam.proto.app import (
     AddRoleRequest,
@@ -216,6 +217,20 @@ from viam.proto.app.data import (
     TabularDataBySQLResponse,
     TagsByFilterRequest,
     TagsByFilterResponse,
+)
+from viam.proto.app.dataset import (
+    CreateDatasetRequest,
+    CreateDatasetResponse,
+    Dataset,
+    DatasetServiceBase,
+    DeleteDatasetRequest,
+    DeleteDatasetResponse,
+    ListDatasetsByIDsRequest,
+    ListDatasetsByIDsResponse,
+    ListDatasetsByOrganizationIDRequest,
+    ListDatasetsByOrganizationIDResponse,
+    RenameDatasetRequest,
+    RenameDatasetResponse,
 )
 from viam.proto.app.datasync import (
     DataCaptureUploadRequest,
@@ -843,6 +858,17 @@ class MockData(DataServiceBase):
         raise NotImplementedError()
 
 
+class MockDataset(DatasetServiceBase):
+    def __init__(self, create_response: str, datasets_response: List[DataClient.Dataset]):
+        self.create_response = create_response
+        self.datasets_response = datasets_response
+
+    async def CreateDataset(self, stream: Stream[CreateDatasetRequest, CreateDatasetResponse]) -> None:
+        request = await stream.recv_message()
+        assert request is not None
+        self.name = request.name
+        self.org_id = request.organization_id
+        await stream.send_message(CreateDatasetResponse(id=self.create_response))
 class MockDataSync(DataSyncServiceBase):
     def __init__(self, file_upload_response: str):
         self.file_upload_response = file_upload_response

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 from grpclib.server import Stream
@@ -858,7 +858,7 @@ class MockData(DataServiceBase):
 
 
 class MockDataset(DatasetServiceBase):
-    def __init__(self, create_response: str, datasets_response: List[Dataset]):
+    def __init__(self, create_response: str, datasets_response: Sequence[Dataset]):
         self.create_response = create_response
         self.datasets_response = datasets_response
 

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 
 import numpy as np
+from google.protobuf.internal.containers import RepeatedCompositeFieldContainer
 from grpclib.server import Stream
 from numpy.typing import NDArray
 from PIL import Image
@@ -858,7 +859,7 @@ class MockData(DataServiceBase):
 
 
 class MockDataset(DatasetServiceBase):
-    def __init__(self, create_response: str, datasets_response: List[DataClient.Dataset]):
+    def __init__(self, create_response: str, datasets_response: RepeatedCompositeFieldContainer[Dataset]):
         self.create_response = create_response
         self.datasets_response = datasets_response
 
@@ -879,19 +880,7 @@ class MockDataset(DatasetServiceBase):
         request = await stream.recv_message()
         assert request is not None
         self.ids = request.ids
-        await stream.send_message(
-            ListDatasetsByIDsResponse(
-                datasets=[
-                    Dataset(
-                        id=dataset.id,
-                        name=dataset.name,
-                        organization_id=dataset.organization_id,
-                        time_created=datetime_to_timestamp(dataset.time_created),
-                    )
-                    for dataset in self.datasets_response
-                ]
-            )
-        )
+        await stream.send_message(ListDatasetsByIDsResponse(datasets=self.datasets_response))
 
     async def ListDatasetsByOrganizationID(
         self, stream: Stream[ListDatasetsByOrganizationIDRequest, ListDatasetsByOrganizationIDResponse]
@@ -899,19 +888,7 @@ class MockDataset(DatasetServiceBase):
         request = await stream.recv_message()
         assert request is not None
         self.org_id = request.organization_id
-        await stream.send_message(
-            ListDatasetsByOrganizationIDResponse(
-                datasets=[
-                    Dataset(
-                        id=dataset.id,
-                        name=dataset.name,
-                        organization_id=dataset.organization_id,
-                        time_created=datetime_to_timestamp(dataset.time_created),
-                    )
-                    for dataset in self.datasets_response
-                ]
-            )
-        )
+        await stream.send_message(ListDatasetsByOrganizationIDResponse(datasets=self.datasets_response))
 
     async def RenameDataset(self, stream: Stream[RenameDatasetRequest, RenameDatasetResponse]) -> None:
         request = await stream.recv_message()

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 
 import numpy as np
-from google.protobuf.internal.containers import RepeatedCompositeFieldContainer
 from grpclib.server import Stream
 from numpy.typing import NDArray
 from PIL import Image
@@ -859,7 +858,7 @@ class MockData(DataServiceBase):
 
 
 class MockDataset(DatasetServiceBase):
-    def __init__(self, create_response: str, datasets_response: RepeatedCompositeFieldContainer[Dataset]):
+    def __init__(self, create_response: str, datasets_response: List[Dataset]):
         self.create_response = create_response
         self.datasets_response = datasets_response
 

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -875,6 +875,53 @@ class MockDataset(DatasetServiceBase):
         assert request is not None
         self.deleted_id = request.id
         await stream.send_message(DeleteDatasetResponse())
+
+    async def ListDatasetsByIDs(self, stream: Stream[ListDatasetsByIDsRequest, ListDatasetsByIDsResponse]) -> None:
+        request = await stream.recv_message()
+        assert request is not None
+        self.ids = request.ids
+        await stream.send_message(
+            ListDatasetsByIDsResponse(
+                datasets=[
+                    Dataset(
+                        id=dataset.id,
+                        name=dataset.name,
+                        organization_id=dataset.organization_id,
+                        time_created=datetime_to_timestamp(dataset.time_created),
+                    )
+                    for dataset in self.datasets_response
+                ]
+            )
+        )
+
+    async def ListDatasetsByOrganizationID(
+        self, stream: Stream[ListDatasetsByOrganizationIDRequest, ListDatasetsByOrganizationIDResponse]
+    ) -> None:
+        request = await stream.recv_message()
+        assert request is not None
+        self.org_id = request.organization_id
+        await stream.send_message(
+            ListDatasetsByOrganizationIDResponse(
+                datasets=[
+                    Dataset(
+                        id=dataset.id,
+                        name=dataset.name,
+                        organization_id=dataset.organization_id,
+                        time_created=datetime_to_timestamp(dataset.time_created),
+                    )
+                    for dataset in self.datasets_response
+                ]
+            )
+        )
+
+    async def RenameDataset(self, stream: Stream[RenameDatasetRequest, RenameDatasetResponse]) -> None:
+        request = await stream.recv_message()
+        assert request is not None
+        self.id = request.id
+        self.name = request.name
+        await stream.send_message((RenameDatasetResponse()))
+
+
 class MockDataSync(DataSyncServiceBase):
     def __init__(self, file_upload_response: str):
         self.file_upload_response = file_upload_response

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -869,6 +869,12 @@ class MockDataset(DatasetServiceBase):
         self.name = request.name
         self.org_id = request.organization_id
         await stream.send_message(CreateDatasetResponse(id=self.create_response))
+
+    async def DeleteDataset(self, stream: Stream[DeleteDatasetRequest, DeleteDatasetResponse]) -> None:
+        request = await stream.recv_message()
+        assert request is not None
+        self.deleted_id = request.id
+        await stream.send_message(DeleteDatasetResponse())
 class MockDataSync(DataSyncServiceBase):
     def __init__(self, file_upload_response: str):
         self.file_upload_response = file_upload_response

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -6,7 +6,6 @@ from numpy.typing import NDArray
 from PIL import Image
 
 from viam.app.data_client import DataClient
-from viam.gen import app
 from viam.media.video import RawImage
 from viam.proto.app import (
     AddRoleRequest,

--- a/tests/test_data_client.py
+++ b/tests/test_data_client.py
@@ -36,6 +36,7 @@ END_DATETIME = END_TS.ToDatetime()
 TAGS = ["tag"]
 BBOX_LABEL = "bbox_label"
 BBOX_LABELS = [BBOX_LABEL]
+DATASET_ID = "VIAM_DATASET_1"
 FILTER = create_filter(
     component_name=COMPONENT_NAME,
     component_type=COMPONENT_TYPE,
@@ -51,6 +52,7 @@ FILTER = create_filter(
     end_time=END_DATETIME,
     tags=TAGS,
     bbox_labels=BBOX_LABELS,
+    dataset_id=DATASET_ID,
 )
 
 FILE_ID = "file_id"
@@ -247,6 +249,22 @@ class TestClient:
     @pytest.mark.asyncio
     async def test_configure_database_user(self, service: MockData):
         assert True
+
+    @pytest.mark.asyncio
+    async def test_add_binary_data_to_dataset_by_ids(self, service: MockData):
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            await client.add_binary_data_to_dataset_by_ids(binary_ids=BINARY_IDS, dataset_id=DATASET_ID)
+            assert service.added_data_ids == BINARY_IDS
+            assert service.dataset_id == DATASET_ID
+
+    @pytest.mark.asyncio
+    async def test_remove_binary_data_to_dataset_by_ids(self, service: MockData):
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            await client.remove_binary_data_from_dataset_by_ids(binary_ids=BINARY_IDS, dataset_id=DATASET_ID)
+            assert service.removed_data_ids == BINARY_IDS
+            assert service.dataset_id == DATASET_ID
 
     def assert_filter(self, filter: Filter) -> None:
         assert filter.component_name == COMPONENT_NAME

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,9 +1,9 @@
-from datetime import datetime
-
 import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
 from grpclib.testing import ChannelFor
 
 from viam.app.data_client import DataClient
+from viam.proto.app.dataset import Dataset
 
 from .mocks.services import MockDataset
 
@@ -11,8 +11,10 @@ CREATED_ID = "VIAM_DATASET_0"
 ID = "VIAM_DATASET_1"
 NAME = "dataset"
 ORG_ID = "org_id"
-DATETIME = datetime.now()
-DATASET = DataClient.Dataset(id=ID, name=NAME, organization_id=ORG_ID, time_created=DATETIME)
+SECONDS = 978310861
+NANOS = 0
+TIME = Timestamp(seconds=SECONDS, nanos=NANOS)
+DATASET = Dataset(id=ID, name=NAME, organization_id=ORG_ID, time_created=TIME)
 DATASETS = [DATASET]
 AUTH_TOKEN = "auth_token"
 DATA_SERVICE_METADATA = {"authorization": f"Bearer {AUTH_TOKEN}"}
@@ -46,10 +48,7 @@ class TestClient:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             datasets = await client.list_dataset_by_ids([ID])
             assert service.ids == [ID]
-            assert datasets[0].id == DATASETS[0].id
-            assert datasets[0].name == DATASETS[0].name
-            assert datasets[0].organization_id == DATASETS[0].organization_id
-            assert datasets[0].time_created == DATASETS[0].time_created
+            assert datasets == DATASETS
 
     @pytest.mark.asyncio
     async def test_list_datasets_by_organization_id(self, service: MockDataset):
@@ -57,7 +56,4 @@ class TestClient:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             datasets = await client.list_datasets_by_organization_id(ORG_ID)
             assert service.org_id == ORG_ID
-            assert datasets[0].id == DATASETS[0].id
-            assert datasets[0].name == DATASETS[0].name
-            assert datasets[0].organization_id == DATASETS[0].organization_id
-            assert datasets[0].time_created == DATASETS[0].time_created
+            assert datasets == DATASETS

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -39,3 +39,25 @@ class TestClient:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             await client.delete_dataset(ID)
             assert service.deleted_id == ID
+
+    @pytest.mark.asyncio
+    async def test_list_datasets_by_ids(self, service: MockDataset):
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            datasets = await client.list_dataset_by_ids([ID])
+            assert service.ids == [ID]
+            assert datasets[0].id == DATASETS[0].id
+            assert datasets[0].name == DATASETS[0].name
+            assert datasets[0].organization_id == DATASETS[0].organization_id
+            assert datasets[0].time_created == DATASETS[0].time_created
+
+    @pytest.mark.asyncio
+    async def test_list_datasets_by_organization_id(self, service: MockDataset):
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            datasets = await client.list_datasets_by_organization_id(ORG_ID)
+            assert service.org_id == ORG_ID
+            assert datasets[0].id == DATASETS[0].id
+            assert datasets[0].name == DATASETS[0].name
+            assert datasets[0].organization_id == DATASETS[0].organization_id
+            assert datasets[0].time_created == DATASETS[0].time_created

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+
+import pytest
+from grpclib.testing import ChannelFor
+
+from viam.app.data_client import DataClient
+
+from .mocks.services import MockDataset
+
+CREATED_ID = "VIAM_DATASET_0"
+ID = "VIAM_DATASET_1"
+NAME = "dataset"
+ORG_ID = "org_id"
+DATETIME = datetime.now()
+DATASET = DataClient.Dataset(id=ID, name=NAME, organization_id=ORG_ID, time_created=DATETIME)
+DATASETS = [DATASET]
+AUTH_TOKEN = "auth_token"
+DATA_SERVICE_METADATA = {"authorization": f"Bearer {AUTH_TOKEN}"}
+
+
+@pytest.fixture(scope="function")
+def service() -> MockDataset:
+    return MockDataset(CREATED_ID, DATASETS)
+
+
+class TestClient:
+    @pytest.mark.asyncio
+    async def test_create_dataset(self, service: MockDataset):
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            id = await client.create_dataset(NAME, ORG_ID)
+            assert service.name == NAME
+            assert service.org_id == ORG_ID
+            assert id == CREATED_ID

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -32,3 +32,10 @@ class TestClient:
             assert service.name == NAME
             assert service.org_id == ORG_ID
             assert id == CREATED_ID
+
+    @pytest.mark.asyncio
+    async def test_delete_dataset(self, service: MockDataset):
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            await client.delete_dataset(ID)
+            assert service.deleted_id == ID


### PR DESCRIPTION
[Jira Ticket](https://viam.atlassian.net/browse/RSDK-5731)

Changes:
- Added dataset APIs to /data client (`CreateDataset`, `ListDatasetsByIDs`, `ListDatasetsByOrganizationID`, `RenameDataset`, `DeleteDataset`, `AddBinaryDataToDatasetByIDs`, and `RemoveBinaryDataFromDatasetByIDs`).
- Made a new `Dataset` class in `DataClient` class.
- Made a new `MockDataset` in `mocks/services.py`.
- Created a new `test_dataset.py`.
- Added tests for new DataClient functions.