### PR TITLE
Build arm7l whl

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -131,6 +131,9 @@ jobs:
           - arch: linux_armv6l
             ext: so
             whl: linux_armv6l
+          - arch: linux_armv6l
+            ext: so
+            whl: linux_armv7l
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,9 @@ jobs:
           - arch: linux_armv6l
             ext: so
             whl: linux_armv6l
+          - arch: linux_armv6l
+            ext: so
+            whl: linux_armv7l
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3


### PR DESCRIPTION
Thanks to how pip does its version management, pip install viam-sdk does not work on an arm7l board. This means that for example, any python modules which require the viam SDK are uninstallable.
arm6l is forward compatible to arm7l. An arm7l board can use the arm6l SDK just fine, it just isn't installable by pip without manually downloading and renaming.

This PR repackages the arm6l buld as arm7l.

https://viaminc.slack.com/archives/C039G724TKP/p1709829556782589