### PR TITLE
RSDK-4857 musllinux binaries for python SDK

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -128,6 +128,9 @@ jobs:
           - arch: linux_x86_64
             ext: so
             whl: manylinux2014_x86_64
+          - arch: musllinux_x86_64
+            ext: so
+            whl: musllinux_1_2_x86_64
           - arch: linux_armv6l
             ext: so
             whl: linux_armv6l

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,9 @@ jobs:
           - arch: linux_x86_64
             ext: so
             whl: manylinux2014_x86_64
+          - arch: musllinux_x86_64
+            ext: so
+            whl: musllinux_1_2_x86_64
           - arch: linux_armv6l
             ext: so
             whl: linux_armv6l


### PR DESCRIPTION
Musl supported in rust-utils as of https://github.com/viamrobotics/rust-utils/pull/102

Unfortunately, github runners does not support aarch64 on Alpine linux in github runners:
https://github.com/actions/runner/issues/1637
https://github.com/actions/runner/issues/801
so this is x64 only for now.

Note that platform compatibility tags are formatted slightly different for musllinux
https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#musllinux