### PR TITLE
RSDK-7014: Configure python to flush to stdout despite not being connected to a tty.

### DIFF
--- a/src/viam/module/module.py
+++ b/src/viam/module/module.py
@@ -1,4 +1,5 @@
-import io, sys
+import io
+import sys
 from inspect import iscoroutinefunction
 from threading import Lock
 from typing import List, Mapping, Optional, Sequence, Tuple

--- a/src/viam/module/module.py
+++ b/src/viam/module/module.py
@@ -64,6 +64,16 @@ class Module:
         return cls(address, log_level=log_level)
 
     def __init__(self, address: str, *, log_level: int = logging.INFO) -> None:
+        if 'reconfigure' in dir(sys.stdout):
+            """Modules are launched from the viam-server, and a module's stdout is not connected to
+            a tty. Python reacts to that environment by disabling line buffering. Which means
+            `print` statements are not immediately flushed to the viam-server. This is confusing for
+            customers and can interfere with debugging. We reconfigure stdout and stderr here to
+            better align python with other languages/viam SDKs and user expectations.
+
+            Note: `reconfigure` only exists in python3.7+. """
+            sys.stdout.reconfigure(line_buffering=True)
+            sys.stderr.reconfigure(line_buffering=True)
         self._address = address
         self.server = Server(resources=[], module_service=ModuleRPCService(self))
         self._log_level = log_level

--- a/src/viam/module/module.py
+++ b/src/viam/module/module.py
@@ -64,15 +64,14 @@ class Module:
         return cls(address, log_level=log_level)
 
     def __init__(self, address: str, *, log_level: int = logging.INFO) -> None:
-        if 'reconfigure' in dir(sys.stdout):
-            """Modules are launched from the viam-server, and a module's stdout is not connected to
-            a tty. Python reacts to that environment by disabling line buffering. Which means
-            `print` statements are not immediately flushed to the viam-server. This is confusing for
-            customers and can interfere with debugging. We reconfigure stdout and stderr here to
-            better align python with other languages/viam SDKs and user expectations.
-
-            Note: `reconfigure` only exists in python3.7+. """
+        # When a module is launched by viam-server, its stdout is not connected to a tty.  In
+        # response, python disables line buffering, which prevents `print` statements from being
+        # immediately flushed to viam-server. This behavior can be confusing, interfere with
+        # debugging, and is non-standard when compared to other languages.  Here, stdout and stderr
+        # are reconfigured to immediately flush.
+        if isinstance(sys.stdout, io.TextIOWrapper):
             sys.stdout.reconfigure(line_buffering=True)
+        if isinstance(sys.stderr, io.TextIOWrapper):
             sys.stderr.reconfigure(line_buffering=True)
         self._address = address
         self.server = Server(resources=[], module_service=ModuleRPCService(self))

--- a/src/viam/module/module.py
+++ b/src/viam/module/module.py
@@ -1,4 +1,4 @@
-import sys
+import io, sys
 from inspect import iscoroutinefunction
 from threading import Lock
 from typing import List, Mapping, Optional, Sequence, Tuple


### PR DESCRIPTION
I'm not seeing any existing tests that simulate the bringing up a python module as a subprocess. I'm not inclined to be the first person to add that test...but I can if it's necessary.