### PR TITLE
RSDK-5569 - require users to pass org-id

### DIFF
--- a/docs/examples/example.ipynb
+++ b/docs/examples/example.ipynb
@@ -1356,7 +1356,7 @@
    "source": [
     "my_organizations = await app_client.list_organizations()\n",
     "MY_ORG_ID = my_organizations[0].id\n",
-    "my_locations = await app_client.list_locations()\n",
+    "my_locations = await app_client.list_locations(org_id=MY_ORG_ID)\n",
     "robots = []\n",
     "\n",
     "for location in my_locations:\n",

--- a/src/viam/app/app_client.py
+++ b/src/viam/app/app_client.py
@@ -479,7 +479,7 @@ class AppClient:
         """Return details about the requested organization.
 
         Args:
-            org_id (str): ID of the organization to query.
+            org_id (str): The ID of the organization to query.
 
         Raises:
             GRPCError: If the provided org_id is invalid, or not currently authed to.
@@ -571,7 +571,7 @@ class AppClient:
         return list(response.members), list(response.invites)
 
     async def create_organization_invite(
-            self, org_id: str, email: str, authorizations: Optional[List[Authorization]] = None, send_email_invite=True
+        self, org_id: str, email: str, authorizations: Optional[List[Authorization]] = None, send_email_invite=True
     ) -> OrganizationInvite:
         """Creates an organization invite and sends it via email.
 

--- a/src/viam/app/app_client.py
+++ b/src/viam/app/app_client.py
@@ -423,27 +423,15 @@ class AppClient:
     _channel: Channel
     _organization_id: Optional[str] = None
 
-    # TODO(RSDK-5569): this method will no longer be reliable when we're not authing as an org.
-    # consider what assumptions we _can_ make (e.g., if `list_orgs` only returns a single org
-    # then we can probably still rely on it for org id?), and also update other APIs to ask for
-    # an org id (optionally?) instead of just assuming we'll get it from this method.
-    async def _get_organization_id(self) -> str:
-        return self._organization_id if self._organization_id is not None else await self._request_organization_id()
-
-    async def _request_organization_id(self) -> str:
-        organizations = await self.list_organizations()
-        self._organization_id = organizations[0].id
-        return self._organization_id
-
     async def _create_authorization(
         self,
+        organization_id: str,
         identity_id: str,
         identity_type: str,
         role: Union[Literal["owner"], Literal["operator"]],
         resource_type: Union[Literal["organization"], Literal["location"], Literal["robot"]],
         resource_id: str,
     ) -> Authorization:
-        organization_id = await self._get_organization_id()
         return Authorization(
             authorization_type="role",
             identity_id=identity_id,
@@ -486,12 +474,11 @@ class AppClient:
     async def list_organizations_by_user(self, user_id: str) -> List[OrgDetails]:
         raise NotImplementedError()
 
-    async def get_organization(self, org_id: Optional[str] = None) -> Organization:
+    async def get_organization(self, org_id: str) -> Organization:
         """Return details about the requested organization.
 
         Args:
-            org_id (Optional[str]): ID of the organization to query. If None, defaults to the
-                currently-authed org.
+            org_id (str): ID of the organization to query.
 
         Raises:
             GRPCError: If the provided org_id is invalid, or not currently authed to.
@@ -499,7 +486,6 @@ class AppClient:
         Returns:
             viam.proto.app.Organization: The requested organization.
         """
-        org_id = org_id if org_id is not None else await self._get_organization_id()
         request = GetOrganizationRequest(organization_id=org_id)
         response: GetOrganizationResponse = await self._app_client.GetOrganization(request, metadata=self._metadata)
         return response.organization
@@ -530,6 +516,7 @@ class AppClient:
 
     async def update_organization(
         self,
+        org_id: str,
         name: Optional[str] = None,
         public_namespace: Optional[str] = None,
         region: Optional[str] = None,
@@ -538,6 +525,7 @@ class AppClient:
         """Updates organization details.
 
         Args:
+            org_id (str): The ID of the organization to update.
             name (Optional[str]): If provided, updates the org's name.
             public_namespace (Optional[str]): If provided, sets the org's namespace if it hasn't already been set.
             region (Optional[str]): If provided, updates the org's region.
@@ -549,9 +537,8 @@ class AppClient:
         Returns:
             viam.proto.app.Organization: The updated organization.
         """
-        organization_id = await self._get_organization_id()
         request = UpdateOrganizationRequest(
-            organization_id=organization_id,
+            organization_id=org_id,
             public_namespace=public_namespace,
             region=region,
             cid=cid,
@@ -561,27 +548,29 @@ class AppClient:
         return response.organization
 
     # TODO(RSDK-5569): implement
-    async def delete_organization(self, org_id: Optional[str] = None) -> None:
+    async def delete_organization(self, org_id: str) -> None:
         raise NotImplementedError()
 
-    async def list_organization_members(self) -> Tuple[List[OrganizationMember], List[OrganizationInvite]]:
+    async def list_organization_members(self, org_id: str) -> Tuple[List[OrganizationMember], List[OrganizationInvite]]:
         """List the members and invites of the currently authed-to organization.
 
         ::
 
             member_list, invite_list = await cloud.list_organization_members()
 
+        Args:
+            org_id (str): The ID of the organization to list members of.
+
         Returns:
             Tuple[List[viam.proto.app.OrganizationMember], List[viam.proto.app.OrganizationInvite]]: A tuple containing two lists; the first
                 [0] of organization members, and the second [1] of organization invites.
         """
-        organization_id = await self._get_organization_id()
-        request = ListOrganizationMembersRequest(organization_id=organization_id)
+        request = ListOrganizationMembersRequest(organization_id=org_id)
         response: ListOrganizationMembersResponse = await self._app_client.ListOrganizationMembers(request, metadata=self._metadata)
         return list(response.members), list(response.invites)
 
     async def create_organization_invite(
-        self, email: str, authorizations: Optional[List[Authorization]] = None, send_email_invite=True
+            self, org_id: str, email: str, authorizations: Optional[List[Authorization]] = None, send_email_invite=True
     ) -> OrganizationInvite:
         """Creates an organization invite and sends it via email.
 
@@ -590,6 +579,7 @@ class AppClient:
             await cloud.create_organization_invite("youremail@email.com")
 
         Args:
+            org_id (str): The ID of the organization to create an invite for.
             email (str): The email address to send the invite to.
             authorizations (Optional[List[viam.proto.app.Authorization]]): Specifications of the
                 authorizations to include in the invite. If not provided, full owner permissions will
@@ -602,15 +592,15 @@ class AppClient:
         Raises:
             GRPCError: if an invalid email is provided, or if the user is already a member of the org.
         """
-        organization_id = await self._get_organization_id()
         request = CreateOrganizationInviteRequest(
-            organization_id=organization_id, email=email, authorizations=authorizations, send_email_invite=send_email_invite
+            organization_id=org_id, email=email, authorizations=authorizations, send_email_invite=send_email_invite
         )
         response: CreateOrganizationInviteResponse = await self._app_client.CreateOrganizationInvite(request, metadata=self._metadata)
         return response.invite
 
     async def update_organization_invite_authorizations(
         self,
+        org_id: str,
         email: str,
         add_authorizations: Optional[List[Authorization]] = None,
         remove_authorizations: Optional[List[Authorization]] = None,
@@ -639,6 +629,7 @@ class AppClient:
             )
 
         Args:
+            org_id (str): The ID of the organization that the invite is for.
             email (str): Email of the user the invite was sent to.
             add_authorizations (Optional[List[viam.proto.app.Authorization]]): Optional list of authorizations to add to the invite.
             remove_authorizations (Optional[List[viam.proto.app.Authorization]]): Optional list of authorizations to remove from the invite.
@@ -650,16 +641,15 @@ class AppClient:
         Returns:
             viam.proto.app.OrganizationInvite: The updated invite.
         """
-        organization_id = await self._get_organization_id()
         request = UpdateOrganizationInviteAuthorizationsRequest(
-            organization_id=organization_id, email=email, add_authorizations=add_authorizations, remove_authorizations=remove_authorizations
+            organization_id=org_id, email=email, add_authorizations=add_authorizations, remove_authorizations=remove_authorizations
         )
         response: UpdateOrganizationInviteAuthorizationsResponse = await self._app_client.UpdateOrganizationInviteAuthorizations(
             request, metadata=self._metadata
         )
         return response.invite
 
-    async def delete_organization_member(self, user_id: str) -> None:
+    async def delete_organization_member(self, org_id: str, user_id: str) -> None:
         """Remove a member from the organization.
 
         ::
@@ -670,13 +660,13 @@ class AppClient:
             await cloud.delete_organization_member(first_user_id)
 
         Args:
+            org_id (str): The ID of the org to remove the user from.
             user_id (str): The ID of the user to remove.
         """
-        organization_id = await self._get_organization_id()
-        request = DeleteOrganizationMemberRequest(organization_id=organization_id, user_id=user_id)
+        request = DeleteOrganizationMemberRequest(organization_id=org_id, user_id=user_id)
         await self._app_client.DeleteOrganizationMember(request, metadata=self._metadata)
 
-    async def delete_organization_invite(self, email: str) -> None:
+    async def delete_organization_invite(self, org_id: str, email: str) -> None:
         """Deletes a pending organization invite.
 
         ::
@@ -684,16 +674,16 @@ class AppClient:
             await cloud.delete_organization_invite("youremail@email.com")
 
         Args:
+            org_id (str): The ID of the organization that the invite to delete was for.
             email (str): The email address the pending invite was sent to.
 
         Raises:
             GRPCError: If no pending invite is associated with the provided email address.
         """
-        organization_id = await self._get_organization_id()
-        request = DeleteOrganizationInviteRequest(organization_id=organization_id, email=email)
+        request = DeleteOrganizationInviteRequest(organization_id=org_id, email=email)
         await self._app_client.DeleteOrganizationInvite(request, metadata=self._metadata)
 
-    async def resend_organization_invite(self, email: str) -> OrganizationInvite:
+    async def resend_organization_invite(self, org_id: str, email: str) -> OrganizationInvite:
         """Re-sends a pending organization invite email.
 
         ::
@@ -701,17 +691,17 @@ class AppClient:
             await cloud.resend_organization_invite("youremail@email.com")
 
         Args:
+            org_id (str): The ID of the organization that the invite to resend was for.
             email (str): The email address associated with the invite.
 
         Raises:
             GRPCError: If no pending invite is associated with the provided email address.
         """
-        organization_id = await self._get_organization_id()
-        request = ResendOrganizationInviteRequest(organization_id=organization_id, email=email)
+        request = ResendOrganizationInviteRequest(organization_id=org_id, email=email)
         response: ResendOrganizationInviteResponse = await self._app_client.ResendOrganizationInvite(request, metadata=self._metadata)
         return response.invite
 
-    async def create_location(self, name: str, parent_location_id: Optional[str] = None) -> Location:
+    async def create_location(self, org_id: str, name: str, parent_location_id: Optional[str] = None) -> Location:
         """Create and name a location under the currently authed-to organization and the specified parent location.
 
         ::
@@ -720,6 +710,7 @@ class AppClient:
                                                           parent_location_id="111ab12345")
 
         Args:
+            org_id (str): The ID of the organization to create the location under.
             name (str): Name of the location.
             parent_location_id (Optional[str]): Optional parent location to put the location under. Defaults to a root-level location if no
                 location ID is provided.
@@ -730,8 +721,7 @@ class AppClient:
         Returns:
             viam.proto.app.Location: The newly created location.
         """
-        organization_id = await self._get_organization_id()
-        request = CreateLocationRequest(organization_id=organization_id, name=name, parent_location_id=parent_location_id)
+        request = CreateLocationRequest(organization_id=org_id, name=name, parent_location_id=parent_location_id)
         response: CreateLocationResponse = await self._app_client.CreateLocation(request, metadata=self._metadata)
         return response.location
 
@@ -815,18 +805,20 @@ class AppClient:
         request = DeleteLocationRequest(location_id=location_id)
         await self._app_client.DeleteLocation(request, metadata=self._metadata)
 
-    async def list_locations(self) -> List[Location]:
+    async def list_locations(self, org_id: str) -> List[Location]:
         """Get a list of all locations under the currently authed-to organization.
 
         ::
 
             locations = await cloud.list_locations()
 
+        Args:
+            org_id (str): The ID of the org to list locations for.
+
         Returns:
             List[viam.proto.app.Location]: The list of locations.
         """
-        organization_id = await self._get_organization_id()
-        request = ListLocationsRequest(organization_id=organization_id)
+        request = ListLocationsRequest(organization_id=org_id)
         response: ListLocationsResponse = await self._app_client.ListLocations(request, metadata=self._metadata)
         return list(response.locations)
 
@@ -923,18 +915,20 @@ class AppClient:
         response: GetRobotResponse = await self._app_client.GetRobot(request, metadata=self._metadata)
         return response.robot
 
-    async def get_rover_rental_robots(self) -> List[RoverRentalRobot]:
+    async def get_rover_rental_robots(self, org_id: str) -> List[RoverRentalRobot]:
         """Returns a list of rover rental robots within an org.
 
         ::
 
             rental_robots = await cloud.get_rover_rental_robots()
 
+        Args:
+            org_id (str): The ID of the organization to list rover rental robots for.
+
         Returns:
             List[viam.proto.app.RoverRentalRobot]: The list of rover rental robots.
         """
-        organization_id = await self._get_organization_id()
-        request = GetRoverRentalRobotsRequest(org_id=organization_id)
+        request = GetRoverRentalRobotsRequest(org_id=org_id)
         response: GetRoverRentalRobotsResponse = await self._app_client.GetRoverRentalRobots(request, metadata=self._metadata)
         return list(response.robots)
 
@@ -1343,7 +1337,7 @@ class AppClient:
         request = DeleteRobotRequest(id=robot_id)
         await self._app_client.DeleteRobot(request, metadata=self._metadata)
 
-    async def list_fragments(self, show_public: bool = True) -> List[Fragment]:
+    async def list_fragments(self, org_id: str, show_public: bool = True) -> List[Fragment]:
         """Get a list of fragments under the currently authed-to organization.
 
         ::
@@ -1351,14 +1345,14 @@ class AppClient:
             fragments_list = await cloud.list_fragments(show_public=False)
 
         Args:
+            org_id (str): The ID of the organization to list fragments for.
             show_public: Optional boolean specifying whether or not to only show public fragments. If True, only public fragments will
                 return. If False, only private fragments will return. Defaults to True.
 
         Returns:
             List[viam.app.app_client.Fragment]: The list of fragments.
         """
-        organization_id = await self._get_organization_id()
-        request = ListFragmentsRequest(organization_id=organization_id, show_public=show_public)
+        request = ListFragmentsRequest(organization_id=org_id, show_public=show_public)
         response: ListFragmentsResponse = await self._app_client.ListFragments(request, metadata=self._metadata)
         return [Fragment.from_proto(fragment=fragment) for fragment in response.fragments]
 
@@ -1385,7 +1379,7 @@ class AppClient:
         response: GetFragmentResponse = await self._app_client.GetFragment(request, metadata=self._metadata)
         return Fragment.from_proto(fragment=response.fragment)
 
-    async def create_fragment(self, name: str, config: Optional[Mapping[str, Any]] = None) -> Fragment:
+    async def create_fragment(self, org_id: str, name: str, config: Optional[Mapping[str, Any]] = None) -> Fragment:
         """Create a new private fragment.
 
         ::
@@ -1394,6 +1388,7 @@ class AppClient:
                 name="cool_smart_machine_to_configure_several_of")
 
         Args:
+            org_id (str): The ID of the organization to create the ragment within.
             name (str): Name of the fragment.
             config (Optional[Mapping[str, Any]]): Optional Dictionary representation of new config to assign to specified fragment. Can be
                 assigned by updating the fragment.
@@ -1404,8 +1399,7 @@ class AppClient:
         Returns:
             viam.app.app_client.Fragment: The newly created fragment.
         """
-        organization_id = await self._get_organization_id()
-        request = CreateFragmentRequest(name=name, config=dict_to_struct(config) if config else None, organization_id=organization_id)
+        request = CreateFragmentRequest(name=name, config=dict_to_struct(config) if config else None, organization_id=org_id)
         response: CreateFragmentResponse = await self._app_client.CreateFragment(request, metadata=self._metadata)
         return Fragment.from_proto(response.fragment)
 
@@ -1529,7 +1523,7 @@ class AppClient:
         request = RemoveRoleRequest(authorization=authorization)
         await self._app_client.RemoveRole(request, metadata=self._metadata)
 
-    async def list_authorizations(self, resource_ids: Optional[List[str]] = None) -> List[Authorization]:
+    async def list_authorizations(self, org_id: str, resource_ids: Optional[List[str]] = None) -> List[Authorization]:
         """List all authorizations under a specific resource (or resources) within the currently authed-to organization. If no resource IDs
         are provided, all resource authorizations within the organizations are returned.
 
@@ -1539,6 +1533,7 @@ class AppClient:
                 resource_ids=["1a123456-x1yz-0ab0-a12xyzabc"])
 
         Args:
+            org_id: The ID of the organization to list authorizations for.
             resource_ids (Optional[List[str]]): IDs of the resources to retrieve authorizations from.
                 If None, defaults to all resources.
 
@@ -1548,8 +1543,7 @@ class AppClient:
         Returns:
             List[viam.proto.app.Authorization]: The list of authorizations.
         """
-        organization_id = await self._get_organization_id()
-        request = ListAuthorizationsRequest(organization_id=organization_id, resource_ids=resource_ids)
+        request = ListAuthorizationsRequest(organization_id=org_id, resource_ids=resource_ids)
         response: ListAuthorizationsResponse = await self._app_client.ListAuthorizations(request, metadata=self._metadata)
         return list(response.authorizations)
 
@@ -1583,7 +1577,7 @@ class AppClient:
         response: CheckPermissionsResponse = await self._app_client.CheckPermissions(request, metadata=self._metadata)
         return list(response.authorized_permissions)
 
-    async def create_module(self, name: str) -> Tuple[str, str]:
+    async def create_module(self, org_id: str, name: str) -> Tuple[str, str]:
         """Create a module under the currently authed-to organization.
 
         ::
@@ -1592,6 +1586,7 @@ class AppClient:
             print("Module ID:", new_module[0])
 
         Args:
+            org_id (str): The ID of the organization to create the module under.
             name (str): The name of the module. Must be unique within your organization.
 
         Raises:
@@ -1600,8 +1595,7 @@ class AppClient:
         Returns:
             Tuple[str, str]: A tuple containing the ID [0] of the new module and its URL [1].
         """
-        organization_id = await self._get_organization_id()
-        request = CreateModuleRequest(organization_id=organization_id, name=name)
+        request = CreateModuleRequest(organization_id=org_id, name=name)
         response: CreateModuleResponse = await self._app_client.CreateModule(request, metadata=self._metadata)
         return response.module_id, response.url
 
@@ -1696,18 +1690,20 @@ class AppClient:
         response: GetModuleResponse = await self._app_client.GetModule(request, metadata=self._metadata)
         return response.module
 
-    async def list_modules(self) -> List[Module]:
+    async def list_modules(self, org_id: str) -> List[Module]:
         """List the modules under the currently authed-to organization.
 
         ::
 
             modules_list = await cloud.list_modules()
 
+        Args:
+            org_id (str): The ID of the organization to list modules for.
+
         Returns:
             List[viam.proto.app.Module]: The list of modules.
         """
-        organization_id = await self._get_organization_id()
-        request = ListModulesRequest(organization_id=organization_id)
+        request = ListModulesRequest(organization_id=org_id)
         response: ListModulesResponse = await self._app_client.ListModules(request, metadata=self._metadata)
         return list(response.modules)
 
@@ -1766,16 +1762,18 @@ class AppClient:
         )
         return (response.key, response.id)
 
-    async def list_keys(self) -> List[APIKeyWithAuthorizations]:
+    async def list_keys(self, org_id: str) -> List[APIKeyWithAuthorizations]:
         """Lists all keys for the currently-authed-to org.
 
         ::
 
             keys = cloud.list_keys()
 
+        Args:
+            org_id (str): The ID of the organization to list API keys for.
+
         Returns:
             List[viam.proto.app.APIKeyWithAuthorizations]: The existing API keys and authorizations."""
-        org_id = await self._get_organization_id()
         request = ListKeysRequest(org_id=org_id)
         response: ListKeysResponse = await self._app_client.ListKeys(request, metadata=self._metadata)
         return list(response.api_keys)

--- a/src/viam/app/app_client.py
+++ b/src/viam/app/app_client.py
@@ -1451,6 +1451,7 @@ class AppClient:
 
     async def add_role(
         self,
+        org_id: str,
         identity_id: str,
         role: Union[Literal["owner"], Literal["operator"]],
         resource_type: Union[Literal["organization"], Literal["location"], Literal["robot"]],
@@ -1467,6 +1468,7 @@ class AppClient:
                 resource_id="111ab12345")
 
         Args:
+            org_id (str): The ID of the organization to create the role in.
             identity_id (str): ID of the entity the role belongs to (e.g., a user ID).
             role (Union[Literal["owner"], Literal["operator"]]): The role to add.
             resource_type (Union[Literal["organization"], Literal["location"], Literal["robot"]]): Type of the resource to add role to.
@@ -1477,6 +1479,7 @@ class AppClient:
             GRPCError: If either an invalid identity ID, role ID, resource type, or resource ID is passed.
         """
         authorization = await self._create_authorization(
+            organization_id=org_id,
             identity_id=identity_id,
             identity_type="",
             role=role,
@@ -1488,6 +1491,7 @@ class AppClient:
 
     async def remove_role(
         self,
+        org_id: str,
         identity_id: str,
         role: Union[Literal["owner"], Literal["operator"]],
         resource_type: Union[Literal["organization"], Literal["location"], Literal["robot"]],
@@ -1504,6 +1508,7 @@ class AppClient:
                 resource_id="111ab12345")
 
         Args:
+            org_id (str): The ID of the organization the role exists in.
             identity_id (str): ID of the entity the role belongs to (e.g., a user ID).
             role (Union[Literal["owner"], Literal["operator"]]): The role to add.
             resource_type (Union[Literal["organization"], Literal["location"], Literal["robot"]]): Type of the resource to add role to.
@@ -1514,6 +1519,7 @@ class AppClient:
             GRPCError: If either an invalid identity ID, role ID, resource type, or resource ID or is passed.
         """
         authorization = await self._create_authorization(
+            organization_id=org_id,
             identity_id=identity_id,
             identity_type="",
             role=role,

--- a/tests/test_app_client.py
+++ b/tests/test_app_client.py
@@ -276,7 +276,7 @@ class TestClient:
             assert invite == INVITE
             assert service.send_email_invite is True
 
-            await client.create_organization_invite(org_id=ID, email=EMAIL, authorizations=AUTHORIZATIONS, send_email_invites=False)
+            await client.create_organization_invite(org_id=ID, email=EMAIL, authorizations=AUTHORIZATIONS, send_email_invite=False)
             assert service.send_email_invite is False
 
     @pytest.mark.asyncio
@@ -324,7 +324,7 @@ class TestClient:
     async def test_delete_location(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            await client.delete_location(org_id=ID, location_id=ID)
+            await client.delete_location(location_id=ID)
             assert service.location_id == ID
 
     @pytest.mark.asyncio
@@ -648,7 +648,7 @@ class TestClient:
     async def test_create_key(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            api_key = await client.create_key(authorizations=API_KEY_AUTHORIZATIONS, name=NAME)
+            api_key = await client.create_key(org_id=ID, authorizations=API_KEY_AUTHORIZATIONS, name=NAME)
             assert (API_KEY, ID) == api_key
 
     @pytest.mark.asyncio

--- a/tests/test_app_client.py
+++ b/tests/test_app_client.py
@@ -204,7 +204,7 @@ class TestClient:
     async def test_get_organization(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            org = await client.get_organization()
+            org = await client.get_organization(org_id=ID)
             assert org == ORGANIZATION
             available = await client.get_organization_namespace_availability(public_namespace=NAMESPACE)
             assert available == AVAILABLE
@@ -222,7 +222,7 @@ class TestClient:
     async def test_list_organization_members(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            members, invites = await client.list_organization_members()
+            members, invites = await client.list_organization_members(org_id=ID)
             assert members == MEMBERS
             assert invites == INVITES
 
@@ -237,7 +237,7 @@ class TestClient:
     async def test_update_organization(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            org = await client.update_organization(name=NAME, public_namespace=PUBLIC_NAMESPACE, region=DEFAULT_REGION, cid=CID)
+            org = await client.update_organization(org_id=ID, name=NAME, public_namespace=PUBLIC_NAMESPACE, region=DEFAULT_REGION, cid=CID)
             assert org == ORGANIZATION
             assert service.update_region == DEFAULT_REGION
             assert service.update_cid == CID
@@ -249,7 +249,7 @@ class TestClient:
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
             invite = await client.update_organization_invite_authorizations(
-                email=EMAIL, add_authorizations=AUTHORIZATIONS, remove_authorizations=AUTHORIZATIONS
+                org_id=ID, email=EMAIL, add_authorizations=AUTHORIZATIONS, remove_authorizations=AUTHORIZATIONS
             )
             assert invite == INVITE
             assert service.email == EMAIL
@@ -265,39 +265,39 @@ class TestClient:
     async def test_delete_organization_member(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            await client.delete_organization_member(user_id=ID)
+            await client.delete_organization_member(org_id=ID, user_id=ID)
             assert service.deleted_member_id == ID
 
     @pytest.mark.asyncio
     async def test_create_organization_invite(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            invite = await client.create_organization_invite(EMAIL, AUTHORIZATIONS)
+            invite = await client.create_organization_invite(org_id=ID, email=EMAIL, authorizations=AUTHORIZATIONS)
             assert invite == INVITE
             assert service.send_email_invite is True
 
-            await client.create_organization_invite(EMAIL, AUTHORIZATIONS, False)
+            await client.create_organization_invite(org_id=ID, email=EMAIL, authorizations=AUTHORIZATIONS, send_email_invites=False)
             assert service.send_email_invite is False
 
     @pytest.mark.asyncio
     async def test_delete_organization_invite(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            await client.delete_organization_invite(email=EMAIL)
+            await client.delete_organization_invite(org_id=ID, email=EMAIL)
             assert service.deleted_invite_email == EMAIL
 
     @pytest.mark.asyncio
     async def test_resend_organization_invite(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            await client.resend_organization_invite(email=EMAIL)
+            await client.resend_organization_invite(org_id=ID, email=EMAIL)
             assert service.resent_invite_email == EMAIL
 
     @pytest.mark.asyncio
     async def test_create_location(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            new_location = await client.create_location(name=NAME, parent_location_id=ID)
+            new_location = await client.create_location(org_id=ID, name=NAME, parent_location_id=ID)
             assert service.name == NAME
             assert service.parent_location_id == ID
             assert new_location == LOCATION
@@ -324,14 +324,14 @@ class TestClient:
     async def test_delete_location(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            await client.delete_location(location_id=ID)
+            await client.delete_location(org_id=ID, location_id=ID)
             assert service.location_id == ID
 
     @pytest.mark.asyncio
     async def test_list_locations(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            locations = await client.list_locations()
+            locations = await client.list_locations(org_id=ID)
             assert locations == locations
 
     @pytest.mark.asyncio
@@ -370,7 +370,7 @@ class TestClient:
     async def test_get_rover_rental_robots(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            robots = await client.get_rover_rental_robots()
+            robots = await client.get_rover_rental_robots(org_id=ID)
             assert robots == ROVER_RENTAL_ROBOTS
 
     @pytest.mark.asyncio
@@ -513,7 +513,7 @@ class TestClient:
     async def test_list_fragments(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            fragments = await client.list_fragments(show_public=SHOW_PUBLIC)
+            fragments = await client.list_fragments(org_id=ID, show_public=SHOW_PUBLIC)
             assert service.show_public == SHOW_PUBLIC
             assert [fragment.proto for fragment in fragments] == [FRAGMENT]
 
@@ -529,7 +529,7 @@ class TestClient:
     async def test_create_fragment(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            fragment = await client.create_fragment(name=NAME)
+            fragment = await client.create_fragment(org_id=ID, name=NAME)
             assert service.name == NAME
             assert fragment.proto == FRAGMENT
 
@@ -581,7 +581,7 @@ class TestClient:
     async def test_list_authorizations(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            authorizations = await client.list_authorizations(resource_ids=IDS)
+            authorizations = await client.list_authorizations(org_id=ID, resource_ids=IDS)
             assert service.resource_ids == IDS
             assert authorizations == AUTHORIZATIONS
 
@@ -589,7 +589,7 @@ class TestClient:
     async def test_create_module(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            id, url = await client.create_module(name=NAME)
+            id, url = await client.create_module(org_id=ID, name=NAME)
             assert service.name == NAME
             assert id == ID
             assert url == URL
@@ -641,7 +641,7 @@ class TestClient:
     async def test_list_modules(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            modules = await client.list_modules()
+            modules = await client.list_modules(org_id=ID)
             assert modules == MODULES
 
     @pytest.mark.asyncio
@@ -662,5 +662,5 @@ class TestClient:
     async def list_keys(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            api_keys = await client.list_keys()
+            api_keys = await client.list_keys(org_id=ID)
             assert api_keys == API_KEYS_WITH_AUTHORIZATIONS

--- a/tests/test_app_client.py
+++ b/tests/test_app_client.py
@@ -554,7 +554,7 @@ class TestClient:
     async def test_add_role(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            await client.add_role(identity_id=ID, role=ROLE, resource_type=TYPE, resource_id=ID)
+            await client.add_role(org_id=ID, identity_id=ID, role=ROLE, resource_type=TYPE, resource_id=ID)
             assert service.identity_id == ID
             assert service.role == ROLE
             assert service.resource_type == TYPE
@@ -564,7 +564,7 @@ class TestClient:
     async def test_remove_role(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            await client.remove_role(identity_id=ID, role=ROLE, resource_type=TYPE, resource_id=ID)
+            await client.remove_role(org_id=ID, identity_id=ID, role=ROLE, resource_type=TYPE, resource_id=ID)
             assert service.identity_id == ID
             assert service.role == ROLE
             assert service.resource_type == TYPE


### PR DESCRIPTION
Removes the `_get_organization_id` helper function (which assumed org-level authorization), instead require users to pass org ID to relevant APIs.

Note that, because this is a breaking change, it will be merged into `rc-0.21.0` rather than `main` in order to give users plenty of time to prepare.