### PR TITLE
Remove is org member check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,20 +12,6 @@ jobs:
       image: ghcr.io/viamrobotics/canon:amd64
 
     steps:
-      - name: Check if organization member
-        id: is_organization_member
-        if: github.event_name == 'workflow_dispatch'
-        uses: jamessingleton/is-organization-member@1.0.1
-        with:
-          organization: viamrobotics
-          username: ${{ github.actor }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: cancelling
-        uses: andymckay/cancel-action@0.2
-        if: |
-          github.event_name == 'workflow_dispatch' && steps.is_organization_member.outputs.result == 'false'
-
       - name: Download Release
         uses: dsaltares/fetch-gh-release-asset@master
         with:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -27,19 +27,6 @@ jobs:
       - name: Output Event
         run: echo "${{ toJSON(github.event) }}"
 
-      - name: Check if organization member
-        id: is_organization_member
-        uses: jamessingleton/is-organization-member@1.0.1
-        with:
-          organization: viamrobotics
-          username: ${{ github.actor }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cancelling - user not part of organization
-        uses: andymckay/cancel-action@0.2
-        if: |
-          steps.is_organization_member.outputs.result == 'false'
-
       - name: Install GH CLI
         run: |
           type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,19 +10,6 @@ jobs:
     outputs:
       version: ${{ steps.bump_version.outputs.version }}
     steps:
-      - name: Check if organization member
-        id: is_organization_member
-        uses: jamessingleton/is-organization-member@1.0.1
-        with:
-          organization: viamrobotics
-          username: ${{ github.actor }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cancelling - user not part of organization
-        uses: andymckay/cancel-action@0.2
-        if: |
-          steps.is_organization_member.outputs.result == 'false'
-
       - name: Checkout Code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Actions are only available to members we give permission to (org members and collaborators with appropriate access level). The `is_org_member` check was redundant