### PR TITLE
RSDK-7229 add machine_id to cloud metadata

### DIFF
--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -53,6 +53,16 @@ from viam.utils import datetime_to_timestamp, dict_to_struct
 LOGGER = logging.getLogger(__name__)
 
 
+@dataclass
+class CloudMetadata:
+    """App-related information about the robot"""
+
+    primary_org_id: str
+    location_id: str
+    machine_id: str
+    machine_part_id: str
+
+
 class RobotClient:
     """gRPC client for a Robot. This class should be used for all interactions with a robot.
 
@@ -779,7 +789,7 @@ class RobotClient:
     # Get Cloud Metadata #
     ######################
 
-    async def get_cloud_metadata(self) -> GetCloudMetadataResponse:
+    async def get_cloud_metadata(self) -> CloudMetadata:
         """
         Get app-related information about the robot.
 
@@ -788,4 +798,11 @@ class RobotClient:
         """
 
         request = GetCloudMetadataRequest()
-        return await self._client.GetCloudMetadata(request)
+        resp: GetCloudMetadataResponse = await self._client.GetCloudMetadata(request)
+
+        return CloudMetadata(
+            primary_org_id=resp.primary_org_id,
+            location_id=resp.location_id,
+            machine_id=resp.machine_id,
+            machine_part_id=resp.machine_part_id,
+        )

--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -53,16 +53,6 @@ from viam.utils import datetime_to_timestamp, dict_to_struct
 LOGGER = logging.getLogger(__name__)
 
 
-@dataclass
-class CloudMetadata:
-    """App-related information about the robot"""
-
-    primary_org_id: str
-    location_id: str
-    machine_id: str
-    machine_part_id: str
-
-
 class RobotClient:
     """gRPC client for a Robot. This class should be used for all interactions with a robot.
 
@@ -789,7 +779,7 @@ class RobotClient:
     # Get Cloud Metadata #
     ######################
 
-    async def get_cloud_metadata(self) -> CloudMetadata:
+    async def get_cloud_metadata(self) -> GetCloudMetadataResponse:
         """
         Get app-related information about the robot.
 
@@ -798,11 +788,4 @@ class RobotClient:
         """
 
         request = GetCloudMetadataRequest()
-        resp: GetCloudMetadataResponse = await self._client.GetCloudMetadata(request)
-
-        return CloudMetadata(
-            primary_org_id=resp.primary_org_id,
-            location_id=resp.location_id,
-            machine_id=resp.machine_id,
-            machine_part_id=resp.machine_part_id,
-        )
+        return await self._client.GetCloudMetadata(request)

--- a/tests/test_robot.py
+++ b/tests/test_robot.py
@@ -49,7 +49,7 @@ from viam.resource.manager import ResourceManager
 from viam.resource.registry import Registry
 from viam.resource.rpc_client_base import ResourceRPCClientBase
 from viam.resource.types import RESOURCE_NAMESPACE_RDK, RESOURCE_TYPE_COMPONENT, RESOURCE_TYPE_SERVICE
-from viam.robot.client import RobotClient, CloudMetadata
+from viam.robot.client import RobotClient
 from viam.robot.service import RobotService
 from viam.services.motion.client import MotionClient
 from viam.utils import dict_to_struct, message_to_struct, struct_to_message
@@ -428,12 +428,7 @@ class TestRobotClient:
         async with ChannelFor([service]) as channel:
             client = await RobotClient.with_channel(channel, RobotClient.Options())
             md = await client.get_cloud_metadata()
-            assert md == CloudMetadata(
-                primary_org_id=GET_CLOUD_METADATA_RESPONSE.primary_org_id,
-                location_id=GET_CLOUD_METADATA_RESPONSE.location_id,
-                machine_id=GET_CLOUD_METADATA_RESPONSE.machine_id,
-                machine_part_id=GET_CLOUD_METADATA_RESPONSE.machine_part_id,
-            )
+            assert md == GET_CLOUD_METADATA_RESPONSE
             await client.close()
 
     @pytest.mark.asyncio

--- a/tests/test_robot.py
+++ b/tests/test_robot.py
@@ -49,7 +49,7 @@ from viam.resource.manager import ResourceManager
 from viam.resource.registry import Registry
 from viam.resource.rpc_client_base import ResourceRPCClientBase
 from viam.resource.types import RESOURCE_NAMESPACE_RDK, RESOURCE_TYPE_COMPONENT, RESOURCE_TYPE_SERVICE
-from viam.robot.client import RobotClient
+from viam.robot.client import RobotClient, CloudMetadata
 from viam.robot.service import RobotService
 from viam.services.motion.client import MotionClient
 from viam.utils import dict_to_struct, message_to_struct, struct_to_message
@@ -143,9 +143,11 @@ OPERATION_ID = "abc"
 OPERATIONS_RESPONSE = [Operation(id=OPERATION_ID)]
 
 GET_CLOUD_METADATA_RESPONSE = GetCloudMetadataResponse(
-    robot_part_id="the-robot-part",
+    robot_part_id="the-machine-id",
     primary_org_id="the-primary-org",
     location_id="the-location",
+    machine_id="the-machine-id",
+    machine_part_id="the-machine-part-id",
 )
 
 
@@ -426,7 +428,12 @@ class TestRobotClient:
         async with ChannelFor([service]) as channel:
             client = await RobotClient.with_channel(channel, RobotClient.Options())
             md = await client.get_cloud_metadata()
-            assert md == GET_CLOUD_METADATA_RESPONSE
+            assert md == CloudMetadata(
+                primary_org_id=GET_CLOUD_METADATA_RESPONSE.primary_org_id,
+                location_id=GET_CLOUD_METADATA_RESPONSE.location_id,
+                machine_id=GET_CLOUD_METADATA_RESPONSE.machine_id,
+                machine_part_id=GET_CLOUD_METADATA_RESPONSE.machine_part_id,
+            )
             await client.close()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
~Breaking change!~ Not anymore!

Add `machine_id` to the `get_cloud_metadata` robot client method. ~Also change the return type and rename `robot_part_id` to `machine_part_id` for clarity.~ [We are just deprecating the duplicate field instead](https://github.com/viamrobotics/viam-python-sdk/pull/585#discussion_r1571261813).

Depends on:
* [x] https://github.com/viamrobotics/api/pull/487