### PR TITLE
Add missing param to set_power_mode()

### DIFF
--- a/src/viam/components/board/board.py
+++ b/src/viam/components/board/board.py
@@ -356,6 +356,7 @@ class Board(ComponentBase):
 
         Args:
             mode (PowerMode): The desired power mode.
+            duration (Optional[timedelta]): Requested duration to stay in power mode.
         """
         ...
 


### PR DESCRIPTION
Just updates the code comment to fix Py SDK docs and downstream consumers (like Docs!). Description pulled from Proto.

Thanks much!