### PR TITLE
Build process

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,65 @@
+name: Build Wheels
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: macosx_x86_64
+            ext: dylib
+            whl: macosx_10_16_x86_64
+          - arch: macosx_arm64
+            ext: dylib
+            whl: macosx_11_0_arm64
+          - arch: linux_aarch64
+            ext: so
+            whl: manylinux2014_aarch64
+          - arch: linux_x86_64
+            ext: so
+            whl: manylinux2014_x86_64
+          - arch: musllinux_x86_64
+            ext: so
+            whl: musllinux_1_2_x86_64
+          - arch: linux_armv6l
+            ext: so
+            whl: linux_armv6l
+          - arch: linux_armv6l
+            ext: so
+            whl: linux_armv7l
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+
+      - name: Install package
+        run: poetry install --all-extras
+
+      - name: Download binary
+        run: curl -sL -o src/viam/rpc/libviam_rust_utils.${{ matrix.ext }} https://github.com/viamrobotics/rust-utils/releases/latest/download/libviam_rust_utils-${{ matrix.arch }}.${{ matrix.ext }}
+
+      - name: HACK for arm7l
+        if: ${{ matrix.whl == 'linux_armv7l' }}
+        run: echo "This file enables arm7l support. PyPI doesn't allow for packages with the same hash, so this file must be added to differentiate this arm7l package from the arm6l package." > src/viam/arm7l.txt
+
+      - name: Build
+        run: poetry build -f wheel
+
+      - name: Rename
+        run: mv dist/viam_sdk-$(poetry run python -c "import viam; print(viam.__version__)")-py3-none-any.whl dist/viam_sdk-$(poetry run python -c "import viam; print(viam.__version__)")-py3-none-${{ matrix.whl }}.whl
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,6 +1,11 @@
 name: Build Wheels
 
 on:
+  workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
   workflow_dispatch:
 
 jobs:
@@ -31,8 +36,14 @@ jobs:
             ext: so
             whl: linux_armv7l
     steps:
-      - name: Checkout Code
+      - name: Checkout Code - Call
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+        if: ${{ inputs.branch }}
+      - name: Checkout Code - Dispatch
+        uses: actions/checkout@v4
+        if: ${{ !inputs.branch }}
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -56,10 +67,12 @@ jobs:
         run: poetry build -f wheel
 
       - name: Rename
-        run: mv dist/viam_sdk-$(poetry run python -c "import viam; print(viam.__version__)")-py3-none-any.whl dist/viam_sdk-$(poetry run python -c "import viam; print(viam.__version__)")-py3-none-${{ matrix.whl }}.whl
+        run: |
+          echo "WHL_NAME=viam_sdk-$(poetry run python -c 'import viam; print(viam.__version__)')-py3-none-${{ matrix.whl }}.whl" >> $GITHUB_ENV
+          mv dist/viam_sdk-$(poetry run python -c "import viam; print(viam.__version__)")-py3-none-any.whl dist/viam_sdk-$(poetry run python -c 'import viam; print(viam.__version__)')-py3-none-${{ matrix.whl }}.whl
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dist
-          path: dist
+          name: ${{ env.WHL_NAME }}
+          path: dist/${{ env.WHL_NAME }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   prepare:
-    if: github.repository_owner == 'viamrobotics'
+    # if: github.repository_owner == 'viamrobotics'
     runs-on: ubuntu-latest
     outputs:
       rc_version: ${{ steps.bump_version.outputs.rc_version }}
@@ -37,13 +37,13 @@ jobs:
         run: poetry install --all-extras
 
       - name: Clean Format Test
-        run: make clean better_imports format test
+        run: make clean format typecheck test
 
       - name: Current version
         id: current_version
         shell: bash
         run: |
-          echo "current_version=$(poetry version)" >> $GITHUB_OUTPUT
+          echo "current_version=$(poetry version -s)" >> $GITHUB_OUTPUT
 
       - name: Bump Version
         id: bump_version
@@ -86,82 +86,27 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build:
+    uses: ./.github/workflows/build-wheels.yml
+    with:
+      branch: rc-${{ needs.prepare.outputs.version }}
     needs: prepare
-    if: github.repository_owner == 'viamrobotics'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - arch: macosx_x86_64
-            ext: dylib
-            whl: macosx_10_16_x86_64
-          - arch: macosx_arm64
-            ext: dylib
-            whl: macosx_11_0_arm64
-          - arch: linux_aarch64
-            ext: so
-            whl: manylinux2014_aarch64
-          - arch: linux_x86_64
-            ext: so
-            whl: manylinux2014_x86_64
-          - arch: musllinux_x86_64
-            ext: so
-            whl: musllinux_1_2_x86_64
-          - arch: linux_armv6l
-            ext: so
-            whl: linux_armv6l
-          - arch: linux_armv6l
-            ext: so
-            whl: linux_armv7l
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-        with:
-          ref: rc-${{ needs.prepare.outputs.version }}
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-
-      - name: Install package
-        run: poetry install --all-extras
-
-      - name: Download binary
-        run: curl -sL -o src/viam/rpc/libviam_rust_utils.${{ matrix.ext }} https://github.com/viamrobotics/rust-utils/releases/latest/download/libviam_rust_utils-${{ matrix.arch }}.${{ matrix.ext }}
-
-      - name: HACK for arm7l
-        if: ${{ matrix.whl == 'linux_armv7l' }}
-        run: echo "This file enables arm7l support. PyPI doesn't allow for packages with the same hash, so this file must be added to differentiate this arm7l package from the arm6l package." > src/viam/arm7l.txt
-
-      - name: Build
-        run: poetry build -f wheel
-
-      - name: Rename
-        run: mv dist/viam_sdk-$(poetry run python -c "import viam; print(viam.__version__)")-py3-none-any.whl dist/viam_sdk-$(poetry run python -c "import viam; print(viam.__version__)")-py3-none-${{ matrix.whl }}.whl
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: dist
-          path: dist
+    # if: github.repository_owner == 'viamrobotics'
 
   release:
     needs: [prepare, build]
-    if: github.repository_owner == 'viamrobotics'
+    # if: github.repository_owner == 'viamrobotics'
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ needs.prepare.outputs.rc_version }}
-          files: dist/*
+          files: dist/**
           draft: true
           prerelease: true
           fail_on_unmatched_files: true

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   prepare:
-    # if: github.repository_owner == 'viamrobotics'
+    if: github.repository_owner == 'viamrobotics'
     runs-on: ubuntu-latest
     outputs:
       rc_version: ${{ steps.bump_version.outputs.rc_version }}
@@ -90,11 +90,11 @@ jobs:
     with:
       branch: rc-${{ needs.prepare.outputs.version }}
     needs: prepare
-    # if: github.repository_owner == 'viamrobotics'
+    if: github.repository_owner == 'viamrobotics'
 
   release:
     needs: [prepare, build]
-    # if: github.repository_owner == 'viamrobotics'
+    if: github.repository_owner == 'viamrobotics'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         run: poetry install --all-extras
 
       - name: Clean Format Test
-        run: make clean better_imports format test
+        run: make clean format typecheck test
 
       - name: Bump Version
         id: bump_version
@@ -63,68 +63,11 @@ jobs:
           pr_body: This is an auto-generated PR to merge the rc branch back into main upon successful release.
 
   build:
+    uses: ./.github/workflows/build-wheels.yml
+    with:
+      branch: rc-${{ needs.prepare.outputs.version }}
     needs: prepare
     if: github.repository_owner == 'viamrobotics' && startsWith(github.ref_name, 'rc-')
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - arch: macosx_x86_64
-            ext: dylib
-            whl: macosx_10_16_x86_64
-          - arch: macosx_arm64
-            ext: dylib
-            whl: macosx_11_0_arm64
-          - arch: linux_aarch64
-            ext: so
-            whl: manylinux2014_aarch64
-          - arch: linux_x86_64
-            ext: so
-            whl: manylinux2014_x86_64
-          - arch: musllinux_x86_64
-            ext: so
-            whl: musllinux_1_2_x86_64
-          - arch: linux_armv6l
-            ext: so
-            whl: linux_armv6l
-          - arch: linux_armv6l
-            ext: so
-            whl: linux_armv7l
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-        with:
-          ref: rc-${{ needs.prepare.outputs.version }}
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-
-      - name: Install package
-        run: poetry install --all-extras
-
-      - name: Download binary
-        run: curl -sL -o src/viam/rpc/libviam_rust_utils.${{ matrix.ext }} https://github.com/viamrobotics/rust-utils/releases/latest/download/libviam_rust_utils-${{ matrix.arch }}.${{ matrix.ext }}
-
-      - name: HACK for arm7l
-        if: ${{ matrix.whl == 'linux_armv7l' }}
-        run: echo "This file enables arm7l support. PyPI doesn't allow for packages with the same hash, so this file must be added to differentiate this arm7l package from the arm6l package." > src/viam/arm7l.txt
-
-      - name: Build
-        run: poetry build -f wheel
-
-      - name: Rename
-        run: mv dist/viam_sdk-$(poetry run python -c "import viam; print(viam.__version__)")-py3-none-any.whl dist/viam_sdk-$(poetry run python -c "import viam; print(viam.__version__)")-py3-none-${{ matrix.whl }}.whl
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: dist
-          path: dist
 
   release:
     needs: [prepare, build]
@@ -132,13 +75,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
 
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ needs.prepare.outputs.version }}
-          files: dist/*
+          files: dist/**
           draft: true
           prerelease: false
           fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
           path: dist
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ needs.prepare.outputs.version }}
           files: dist/**

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -30,9 +30,6 @@ jobs:
         env:
           BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
 
-      - name: Generate better imports
-        run: make better_imports
-
       - name: Format
         run: make format
 


### PR DESCRIPTION
Update the build process so that we aren't duplicating a lot of code. This also enables us to build wheels outside of the process of a release, which is useful for the instance where we're manually testing releases (like for `v0.21.0`)