### PR TITLE
RSDK-7393 - remove references to do_command from mlmodel service

### DIFF
--- a/src/viam/services/mlmodel/client.py
+++ b/src/viam/services/mlmodel/client.py
@@ -27,8 +27,3 @@ class MLModelClient(MLModel, ReconfigurableResourceRPCClientBase):
         request = MetadataRequest(name=self.name)
         response: MetadataResponse = await self.client.Metadata(request)
         return response.metadata
-
-    async def do_command(self, command: Mapping[str, ValueTypes], *, timeout: Optional[float] = None, **kwargs) -> Mapping[str, ValueTypes]:
-        request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
-        return struct_to_dict(response.result)

--- a/src/viam/services/mlmodel/client.py
+++ b/src/viam/services/mlmodel/client.py
@@ -1,13 +1,11 @@
-from typing import Dict, Mapping, Optional
+from typing import Dict, Optional
 
 from grpclib.client import Channel
 from numpy.typing import NDArray
 
-from viam.proto.common import DoCommandRequest, DoCommandResponse
 from viam.proto.service.mlmodel import InferRequest, InferResponse, MetadataRequest, MetadataResponse, MLModelServiceStub
 from viam.resource.rpc_client_base import ReconfigurableResourceRPCClientBase
 from viam.services.mlmodel.utils import flat_tensors_to_ndarrays, ndarrays_to_flat_tensors
-from viam.utils import ValueTypes, dict_to_struct, struct_to_dict
 
 from .mlmodel import Metadata, MLModel
 

--- a/tests/test_mlmodel.py
+++ b/tests/test_mlmodel.py
@@ -23,12 +23,6 @@ class TestMLModel:
         resp = await self.mlmodel.metadata()
         assert resp == MockMLModel.META
 
-    @pytest.mark.asyncio
-    async def do_command(self):
-        command = {"command": "args"}
-        resp = await self.mlmodel.do_command(command)
-        assert resp == {"command": command}
-
 
 class TestService:
     @classmethod


### PR DESCRIPTION
As part of the audit of do_command, it came up that we defined `do_command` for an mlmodel client but not service, and that we were doing tests of `do_command` as part of the mlmodel tests. But, `do_command` is not part of the mlmodel protos so we should get rid of it.