### PR TITLE
RSDK-6684 - remove binarydata shadow type

### DIFF
--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -754,7 +754,7 @@ class MockData(DataServiceBase):
         self,
         tabular_response: List[DataClient.TabularData],
         tabular_query_response: List[Dict[str, ValueTypes]],
-        binary_response: List[DataClient.BinaryData],
+        binary_response: List[BinaryData],
         delete_remove_response: int,
         tags_response: List[str],
         bbox_labels_response: List[str],
@@ -817,7 +817,7 @@ class MockData(DataServiceBase):
         self.last = request.data_request.last
         await stream.send_message(
             BinaryDataByFilterResponse(
-                data=[BinaryData(binary=data.data, metadata=data.metadata) for data in self.binary_response],
+                data=self.binary_response,
                 count=len(self.binary_response),
                 last="LAST_BINARY_DATA_PAGE_ID",
             )
@@ -829,7 +829,7 @@ class MockData(DataServiceBase):
         assert request is not None
         self.binary_ids = request.binary_ids
         await stream.send_message(
-            BinaryDataByIDsResponse(data=[BinaryData(binary=data.data, metadata=data.metadata) for data in self.binary_response])
+            BinaryDataByIDsResponse(data=self.binary_response)
         )
 
     async def DeleteTabularData(self, stream: Stream[DeleteTabularDataRequest, DeleteTabularDataResponse]) -> None:

--- a/tests/test_data_client.py
+++ b/tests/test_data_client.py
@@ -103,7 +103,7 @@ TABULAR_RESPONSE = [DataClient.TabularData(TABULAR_DATA, TABULAR_METADATA, START
 TABULAR_QUERY_RESPONSE = [
     {"key1": 1, "key2": "2", "key3": [1, 2, 3], "key4": {"key4sub1": 1}},
 ]
-BINARY_RESPONSE = [BinaryData(data=BINARY_DATA, metadata=BINARY_METADATA)]
+BINARY_RESPONSE = [BinaryData(binary=BINARY_DATA, metadata=BINARY_METADATA)]
 DELETE_REMOVE_RESPONSE = 1
 TAGS_RESPONSE = ["tag"]
 HOSTNAME_RESPONSE = "host"

--- a/tests/test_data_client.py
+++ b/tests/test_data_client.py
@@ -5,7 +5,7 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from grpclib.testing import ChannelFor
 
 from viam.app.data_client import DataClient
-from viam.proto.app.data import Annotations, BinaryID, BinaryMetadata, BoundingBox, CaptureMetadata, Filter, Order
+from viam.proto.app.data import Annotations, BinaryData, BinaryID, BinaryMetadata, BoundingBox, CaptureMetadata, Filter, Order
 from viam.utils import create_filter
 
 from .mocks.services import MockData
@@ -103,7 +103,7 @@ TABULAR_RESPONSE = [DataClient.TabularData(TABULAR_DATA, TABULAR_METADATA, START
 TABULAR_QUERY_RESPONSE = [
     {"key1": 1, "key2": "2", "key3": [1, 2, 3], "key4": {"key4sub1": 1}},
 ]
-BINARY_RESPONSE = [DataClient.BinaryData(BINARY_DATA, BINARY_METADATA)]
+BINARY_RESPONSE = [BinaryData(data=BINARY_DATA, metadata=BINARY_METADATA)]
 DELETE_REMOVE_RESPONSE = 1
 TAGS_RESPONSE = ["tag"]
 HOSTNAME_RESPONSE = "host"


### PR DESCRIPTION
Removes the `BinaryData` shadow type, instead returning the raw proto type.