### PR TITLE
[RSDK-7267] Board cleanup part 1: analogs can be written to

### DIFF
--- a/examples/server/v1/components.py
+++ b/examples/server/v1/components.py
@@ -287,7 +287,7 @@ class ExampleBoard(Board):
         self.gpios = gpio_pins
         super().__init__(name)
 
-    async def analog_reader_by_name(self, name: str) -> Board.Analog:
+    async def analog_by_name(self, name: str) -> Board.Analog:
         try:
             return self.analogs[name]
         except KeyError:
@@ -305,16 +305,13 @@ class ExampleBoard(Board):
         except KeyError:
             raise ResourceNotFoundError("Board.GPIOPin", name)
 
-    async def analog_reader_names(self) -> List[str]:
+    async def analog_names(self) -> List[str]:
         return [key for key in self.analogs.keys()]
 
     async def digital_interrupt_names(self) -> List[str]:
         return [key for key in self.digital_interrupts.keys()]
 
     async def set_power_mode(self, **kwargs):
-        raise NotImplementedError()
-
-    async def write_analog(self, pin: str, value: int, *, timeout: Optional[float] = None, **kwargs):
         raise NotImplementedError()
 
     async def stream_ticks(self, interrupts: List[Board.DigitalInterrupt], *, timeout: Optional[float] = None, **kwargs) -> TickStream:

--- a/examples/server/v1/components.py
+++ b/examples/server/v1/components.py
@@ -227,13 +227,16 @@ class ExampleBase(Base):
         return GEOMETRIES
 
 
-class ExampleAnalogReader(Board.AnalogReader):
+class ExampleAnalog(Board.Analog):
     def __init__(self, name: str, value: int):
         self.value = value
         super().__init__(name)
 
     async def read(self, extra: Optional[Dict[str, Any]] = None, **kwargs) -> int:
         return self.value
+
+    async def write(self, value: int, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float], **kwargs):
+        self.value = value
 
 
 class ExampleDigitalInterrupt(Board.DigitalInterrupt):
@@ -275,20 +278,20 @@ class ExampleBoard(Board):
     def __init__(
         self,
         name: str,
-        analog_readers: Dict[str, Board.AnalogReader],
+        analogs: Dict[str, Board.Analog],
         digital_interrupts: Dict[str, Board.DigitalInterrupt],
         gpio_pins: Dict[str, Board.GPIOPin],
     ):
-        self.analog_readers = analog_readers
+        self.analogs = analogs
         self.digital_interrupts = digital_interrupts
         self.gpios = gpio_pins
         super().__init__(name)
 
-    async def analog_reader_by_name(self, name: str) -> Board.AnalogReader:
+    async def analog_reader_by_name(self, name: str) -> Board.Analog:
         try:
-            return self.analog_readers[name]
+            return self.analogs[name]
         except KeyError:
-            raise ResourceNotFoundError("Board.AnalogReader", name)
+            raise ResourceNotFoundError("Board.Analog", name)
 
     async def digital_interrupt_by_name(self, name: str) -> Board.DigitalInterrupt:
         try:
@@ -303,7 +306,7 @@ class ExampleBoard(Board):
             raise ResourceNotFoundError("Board.GPIOPin", name)
 
     async def analog_reader_names(self) -> List[str]:
-        return [key for key in self.analog_readers.keys()]
+        return [key for key in self.analogs.keys()]
 
     async def digital_interrupt_names(self) -> List[str]:
         return [key for key in self.digital_interrupts.keys()]

--- a/examples/server/v1/server.py
+++ b/examples/server/v1/server.py
@@ -6,7 +6,7 @@ from viam.proto.common import GeoPoint, Orientation, Vector3
 from viam.rpc.server import Server
 
 from .components import (
-    ExampleAnalogReader,
+    ExampleAnalog,
     ExampleArm,
     ExampleAudioInput,
     ExampleBase,
@@ -33,8 +33,8 @@ async def run(host: str, port: int, log_level: int):
     my_base = ExampleBase("base0")
     my_board = ExampleBoard(
         name="board",
-        analog_readers={
-            "reader1": ExampleAnalogReader("reader1", 3),
+        analogs={
+            "reader1": ExampleAnalog("reader1", 3),
         },
         digital_interrupts={
             "interrupt1": ExampleDigitalInterrupt("interrupt1"),

--- a/src/viam/components/board/__init__.py
+++ b/src/viam/components/board/__init__.py
@@ -13,10 +13,10 @@ __all__ = ["Board"]
 
 
 async def create_status(component: Board) -> Status:
-    (analog_names, digital_interrupt_names) = await asyncio.gather(component.analog_reader_names(), component.digital_interrupt_names())
+    (analog_names, digital_interrupt_names) = await asyncio.gather(component.analog_names(), component.digital_interrupt_names())
     analogs, digital_interrupts = {}, {}
     for x in analog_names:
-        analog = await component.analog_reader_by_name(x)
+        analog = await component.analog_by_name(x)
         read = await analog.read()
         analogs[x] = read
 

--- a/src/viam/components/board/board.py
+++ b/src/viam/components/board/board.py
@@ -71,7 +71,7 @@ class Board(ComponentBase):
             ::
                 my_board = Board.from_robot(robot=robot, name="my_board")
 
-                # Get the AnalogWriter "my_example_analog_reader".
+                # Get the AnalogWriter "my_example_analog_writer".
                 writer = await my_board.analog_by_name(
                     name="my_example_analog_writer")
 

--- a/src/viam/components/board/board.py
+++ b/src/viam/components/board/board.py
@@ -44,7 +44,7 @@ class Board(ComponentBase):
         @abc.abstractmethod
         async def read(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> int:
             """
-            Read the current value from a reader.
+            Read the current value from the reader.
 
             ::
 

--- a/src/viam/components/board/client.py
+++ b/src/viam/components/board/client.py
@@ -51,7 +51,7 @@ class AnalogClient(Board.Analog):
     ) -> int:
         if extra is None:
             extra = {}
-        request = ReadAnalogReaderRequest(board_name=self.board.name, analog_reader_name=self.name, extra=dict_to_struct(extra))
+        request = ReadAnalogReaderRequest(board_name=self.board.name, analog_name=self.name, extra=dict_to_struct(extra))
         response: ReadAnalogReaderResponse = await self.board.client.ReadAnalogReader(request, timeout=timeout)
         return response.value
 
@@ -175,19 +175,19 @@ class BoardClient(Board, ReconfigurableResourceRPCClientBase):
     gRPC client for the Board component.
     """
 
-    _analog_reader_names: List[str]
+    _analog_names: List[str]
     _digital_interrupt_names: List[str]
 
     def __init__(self, name: str, channel: Channel):
         self.channel = channel
         self.client = BoardServiceStub(channel)
-        self._analog_reader_names = []
+        self._analog_names = []
         self._digital_interrupt_names = []
         super().__init__(name)
 
-    async def analog_reader_by_name(self, name: str) -> Board.AnalogReader:
-        self._analog_reader_names.append(name)
-        return AnalogReaderClient(name, self)
+    async def analog_by_name(self, name: str) -> Board.Analog:
+        self._analog_names.append(name)
+        return AnalogClient(name, self)
 
     async def digital_interrupt_by_name(self, name: str) -> Board.DigitalInterrupt:
         self._digital_interrupt_names.append(name)
@@ -196,10 +196,10 @@ class BoardClient(Board, ReconfigurableResourceRPCClientBase):
     async def gpio_pin_by_name(self, name: str) -> Board.GPIOPin:
         return GPIOPinClient(name, self)
 
-    async def analog_reader_names(self) -> List[str]:
-        if self._analog_reader_names is None:
+    async def analog_names(self) -> List[str]:
+        if self._analog_names is None:
             return []
-        return self._analog_reader_names
+        return self._analog_names
 
     async def digital_interrupt_names(self) -> List[str]:
         if self._digital_interrupt_names is None:

--- a/src/viam/components/board/client.py
+++ b/src/viam/components/board/client.py
@@ -37,7 +37,7 @@ from .board import Board, TickStream
 LOGGER = getLogger(__name__)
 
 
-class AnalogReaderClient(Board.AnalogReader):
+class AnalogClient(Board.Analog):
     def __init__(self, name: str, board: "BoardClient"):
         self.board = board
         super().__init__(name)
@@ -54,6 +54,17 @@ class AnalogReaderClient(Board.AnalogReader):
         request = ReadAnalogReaderRequest(board_name=self.board.name, analog_reader_name=self.name, extra=dict_to_struct(extra))
         response: ReadAnalogReaderResponse = await self.board.client.ReadAnalogReader(request, timeout=timeout)
         return response.value
+
+    async def write(
+        self,
+        value: int,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
+        request = WriteAnalogRequest(name=self.board.name, pin=self.name, value=value, extra=dict_to_struct(kwargs))
+        await self.board.client.WriteAnalog(request, timeout=timeout)
 
 
 class DigitalInterruptClient(Board.DigitalInterrupt):

--- a/src/viam/components/board/client.py
+++ b/src/viam/components/board/client.py
@@ -63,6 +63,8 @@ class AnalogClient(Board.Analog):
         timeout: Optional[float] = None,
         **kwargs,
     ):
+        if extra is None:
+            extra = {}
         request = WriteAnalogRequest(name=self.board.name, pin=self.name, value=value, extra=dict_to_struct(extra))
         await self.board.client.WriteAnalog(request, timeout=timeout)
 

--- a/src/viam/components/board/client.py
+++ b/src/viam/components/board/client.py
@@ -63,7 +63,7 @@ class AnalogClient(Board.Analog):
         timeout: Optional[float] = None,
         **kwargs,
     ):
-        request = WriteAnalogRequest(name=self.board.name, pin=self.name, value=value, extra=dict_to_struct(kwargs))
+        request = WriteAnalogRequest(name=self.board.name, pin=self.name, value=value, extra=dict_to_struct(extra))
         await self.board.client.WriteAnalog(request, timeout=timeout)
 
 

--- a/src/viam/components/board/client.py
+++ b/src/viam/components/board/client.py
@@ -51,7 +51,7 @@ class AnalogClient(Board.Analog):
     ) -> int:
         if extra is None:
             extra = {}
-        request = ReadAnalogReaderRequest(board_name=self.board.name, analog_name=self.name, extra=dict_to_struct(extra))
+        request = ReadAnalogReaderRequest(board_name=self.board.name, analog_reader_name=self.name, extra=dict_to_struct(extra))
         response: ReadAnalogReaderResponse = await self.board.client.ReadAnalogReader(request, timeout=timeout)
         return response.value
 

--- a/src/viam/components/board/service.py
+++ b/src/viam/components/board/service.py
@@ -181,7 +181,7 @@ class BoardRPCService(BoardServiceBase, ResourceRPCServiceBase[Board]):
         except ResourceNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await analog_writer.write(value=request.value, timeout=timeout, metadata=stream.metadata, extra=request.extra)
+        await analog_writer.write(value=request.value, timeout=timeout, metadata=stream.metadata, extra=struct_to_dict(request.extra))
         response = WriteAnalogResponse()
         await stream.send_message(response)
 

--- a/src/viam/components/board/service.py
+++ b/src/viam/components/board/service.py
@@ -181,7 +181,7 @@ class BoardRPCService(BoardServiceBase, ResourceRPCServiceBase[Board]):
         except ResourceNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await analog_writer.write(value=request.value, timeout=timeout, metadata=stream.metadata)
+        await analog_writer.write(value=request.value, timeout=timeout, metadata=stream.metadata, extra=request.extra)
         response = WriteAnalogResponse()
         await stream.send_message(response)
 

--- a/src/viam/components/board/service.py
+++ b/src/viam/components/board/service.py
@@ -134,7 +134,7 @@ class BoardRPCService(BoardServiceBase, ResourceRPCServiceBase[Board]):
         name = request.board_name
         board = self.get_resource(name)
         try:
-            analog_reader = await board.analog_reader_by_name(request.analog_reader_name)
+            analog_reader = await board.analog_by_name(request.analog_reader_name)
         except ResourceNotFoundError as e:
             raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
@@ -176,8 +176,12 @@ class BoardRPCService(BoardServiceBase, ResourceRPCServiceBase[Board]):
         assert request is not None
         name = request.name
         board = self.get_resource(name)
+        try:
+            analog_writer = await board.analog_by_name(request.pin)
+        except ResourceNotFoundError as e:
+            raise e.grpc_error
         timeout = stream.deadline.time_remaining() if stream.deadline else None
-        await board.write_analog(pin=request.pin, value=request.value, timeout=timeout, metadata=stream.metadata)
+        await analog_writer.write(value=request.value, timeout=timeout, metadata=stream.metadata)
         response = WriteAnalogResponse()
         await stream.send_message(response)
 

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -241,7 +241,7 @@ class MockAnalog(Board.Analog):
         return self.value
 
     async def write(self, value: int, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs):
-        self.extra = kwargs
+        self.extra = extra
         self.timeout = timeout
         self.value = value
 

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -517,7 +517,7 @@ class TestGPIOPinClient:
             mock_analog = cast(MockAnalog, board.analogs["writer1"])
             assert mock_analog.name == "writer1"
             assert mock_analog.value == 42
-            assert mock_analog.extra == extra
+            assert mock_analog.extra == dict_to_struct(extra)
 
     @pytest.mark.asyncio
     async def test_stream_ticks(self, board: MockBoard, service: BoardRPCService):

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -138,7 +138,7 @@ class TestBoard:
     async def test_write_analog(self, board: MockBoard):
         value = 10
         pin = "pin1"
-        writer = await board.analog_by_name(pin=pin, timeout=1.11)
+        writer = await board.analog_by_name(name=pin)
         await writer.write(value=value, timeout=1.11)
         assert board.timeout == loose_approx(1.11)
         assert board.analog_write_value == value

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -119,8 +119,7 @@ class TestBoard:
         assert status.name == MockBoard.get_resource_name(board.name)
         assert status.status == message_to_struct(
             BoardStatus(
-                analogs={"reader1": int(read1),
-                         "writer1": int(read2)},
+                analogs={"reader1": int(read1), "writer1": int(read2)},
                 digital_interrupts={"interrupt1": val},
             )
         )

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -138,7 +138,8 @@ class TestBoard:
     async def test_write_analog(self, board: MockBoard):
         value = 10
         pin = "pin1"
-        await board.write_analog(pin=pin, value=value, timeout=1.11)
+        writer = await board.analog_by_name(pin=pin, timeout=1.11)
+        await writer.write(value=value, timeout=1.11)
         assert board.timeout == loose_approx(1.11)
         assert board.analog_write_value == value
         assert board.analog_write_pin == pin

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -319,9 +319,10 @@ class TestService:
             request = WriteAnalogRequest(name=board.name, pin=pin, value=value)
             response: WriteAnalogResponse = await client.WriteAnalog(request, timeout=6.66)
             assert response == WriteAnalogResponse()
-            assert board.timeout == loose_approx(6.66)
-            assert board.analog_write_value == value
-            assert board.analog_write_pin == pin
+            mock_analog = cast(MockAnalog, board.analogs["writer1"])
+            assert mock_analog.timeout == loose_approx(6.66)
+            assert mock_analog.value == value
+            assert mock_analog.name == pin
 
     # @pytest.mark.asyncio
     async def test_stream_ticks(self, board: MockBoard, service: BoardRPCService):

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -516,7 +516,7 @@ class TestGPIOPinClient:
             mock_analog = cast(MockAnalog, board.analogs["writer1"])
             assert mock_analog.name == "writer1"
             assert mock_analog.value == 42
-            assert mock_analog.extra == dict_to_struct(extra)
+            assert mock_analog.extra == extra
 
     @pytest.mark.asyncio
     async def test_stream_ticks(self, board: MockBoard, service: BoardRPCService):

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -504,12 +504,14 @@ class TestGPIOPinClient:
     async def test_write_analog(self, board: MockBoard, service: BoardRPCService):
         async with ChannelFor([service]) as channel:
             client = BoardClient(name=board.name, channel=channel)
-            pin = "pin1"
+            pin = await client.analog_by_name("pin1")
             value = 42
             extra = {"foo": "bar", "baz": [1, 2, 3]}
-            await client.write_analog(pin, value, extra=extra)
-            assert board.analog_write_pin == "pin1"
-            assert board.analog_write_value == 42
+            await pin.write(value, extra=extra)
+            mock_pin = cast(MockAnalog, board.gpios["pin1"])
+            assert mock_pin.name == "pin1"
+            assert mock_pin.value == 42
+            assert mock_pin.extra == extra
 
     @pytest.mark.asyncio
     async def test_stream_ticks(self, board: MockBoard, service: BoardRPCService):

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -145,9 +145,9 @@ class TestBoard:
         pin = "writer1"
         writer = await board.analog_by_name(name=pin)
         await writer.write(value=value, timeout=1.11)
-        assert board.timeout == loose_approx(1.11)
-        assert board.analog_write_value == value
-        assert board.analog_write_pin == pin
+        assert writer.timeout == loose_approx(1.11)
+        assert writer.value == value
+        assert writer.name == pin
 
     @pytest.mark.asyncio
     async def test_stream_ticks(self, board: MockBoard):
@@ -509,14 +509,14 @@ class TestGPIOPinClient:
     async def test_write_analog(self, board: MockBoard, service: BoardRPCService):
         async with ChannelFor([service]) as channel:
             client = BoardClient(name=board.name, channel=channel)
-            pin = await client.analog_by_name("writer1")
+            writer = await client.analog_by_name("writer1")
             value = 42
             extra = {"foo": "bar", "baz": [1, 2, 3]}
-            await pin.write(value, extra=extra)
-            mock_pin = cast(MockAnalog, board.analogs["writer1"])
-            assert mock_pin.name == "writer1"
-            assert mock_pin.value == 42
-            assert mock_pin.extra == extra
+            await writer.write(value, extra=extra)
+            mock_analog = cast(MockAnalog, board.analogs["writer1"])
+            assert mock_analog.name == "writer1"
+            assert mock_analog.value == 42
+            assert mock_analog.extra == extra
 
     @pytest.mark.asyncio
     async def test_stream_ticks(self, board: MockBoard, service: BoardRPCService):


### PR DESCRIPTION
- `AnalogReader` is now just `Analog`. Similarly, `analog_reader_by_name` is just `analog_by_name`, etc.
- The `Analog` abstract class can now `.write()` in addition to `.read()`.
- (The underlying RPCs are unchanged: it's still a `WriteAnalog` RPC on the board. but SDK users don't interact directly with the RPCs.)

In an upcoming PR, I'll have more board cleanup to stream digital interrupts. but that's separate enough to warrant a separate PR.