### PR TITLE
fix(components/board): update stream ticks example doc

### DIFF
--- a/src/viam/components/board/board.py
+++ b/src/viam/components/board/board.py
@@ -382,11 +382,13 @@ class Board(ComponentBase):
             di8 = await my_board.digital_interrupt_by_name(name="8"))
             di11 = await my_board.digital_interrupt_by_name(name="11"))
 
-            Stream ticks from pins 8 and 11.
-            ticks = my_board.stream_ticks([di8, di11])
+            # Iterate over stream of ticks from pins 8 and 11.
+            async for tick in my_board.stream_ticks([di8, di11]):
+                print(f"Pin {tick.pin_name} changed to {'high' if tick.high else 'low'} at {tick.time}")
+
 
         Args:
-            interrupts (List[DigitalInterrupt]) : list of digital interrupts to recieve ticks from.
+            interrupts (List[DigitalInterrupt]) : list of digital interrupts to receive ticks from.
 
         Returns:
             TickStream: stream of ticks.


### PR DESCRIPTION
As I was reading through the newly released `StreamTicks` docs, I noticed the example for Python doesn't show how to consume the stream of "ticks" from the method. I added an `async for` loop to show how a developer could access those values and what fields a "tick" contains. 