### PR TITLE
Force kwargs in DialOptions

### DIFF
--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -74,6 +74,7 @@ class DialOptions:
 
     def __init__(
         self,
+        *,
         disable_webrtc: bool = False,
         auth_entity: Optional[str] = None,
         credentials: Optional[Credentials] = None,


### PR DESCRIPTION
Removes a small footgun - it's easy to write code like `dial_options=DialOptions({"insecure": True})` and wonder why SSL is still required.