### PR TITLE
[RSDK-4561] Remove unused check

### DIFF
--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -10,8 +10,6 @@ from typing_extensions import Self
 import viam
 from viam import logging
 from viam.components.component_base import ComponentBase
-from viam.components.movement_sensor import MovementSensor
-from viam.components.sensor import Sensor
 from viam.errors import ResourceNotFoundError
 from viam.proto.common import LogEntry, PoseInFrame, ResourceName, Transform
 from viam.proto.robot import (
@@ -303,10 +301,6 @@ class RobotClient:
                 if rname.type not in [RESOURCE_TYPE_COMPONENT, RESOURCE_TYPE_SERVICE]:
                     continue
                 if rname.subtype == "remote":
-                    continue
-
-                # If the resource is a MovementSensor, DO NOT include Sensor as well (it will get added via MovementSensor)
-                if rname.subtype == Sensor.SUBTYPE.resource_subtype and MovementSensor.get_resource_name(rname.name) in resource_names:
                     continue
 
                 await self._create_or_reset_client(rname)

--- a/src/viam/services/vision/__init__.py
+++ b/src/viam/services/vision/__init__.py
@@ -2,7 +2,7 @@ from viam.resource.registry import Registry, ResourceRegistration
 from viam.services.vision.service import VisionRPCService
 
 from .client import Classification, Detection, VisionClient
-from .vision import Vision, CaptureAllResult
+from .vision import CaptureAllResult, Vision
 
 __all__ = [
     "CaptureAllResult",

--- a/src/viam/services/vision/client.py
+++ b/src/viam/services/vision/client.py
@@ -27,7 +27,7 @@ from viam.proto.service.vision import (
 from viam.resource.rpc_client_base import ReconfigurableResourceRPCClientBase
 from viam.utils import ValueTypes, dict_to_struct, struct_to_dict
 
-from .vision import Vision, CaptureAllResult
+from .vision import CaptureAllResult, Vision
 
 
 class VisionClient(Vision, ReconfigurableResourceRPCClientBase):
@@ -57,14 +57,14 @@ class VisionClient(Vision, ReconfigurableResourceRPCClientBase):
         if extra is None:
             extra = {}
         request = CaptureAllFromCameraRequest(
-                name=self.name,
-                camera_name=camera_name,
-                return_image=return_image,
-                return_classifications=return_classifications,
-                return_detections=return_detections,
-                return_object_point_clouds=return_object_point_clouds,
-                extra=dict_to_struct(extra),
-                )
+            name=self.name,
+            camera_name=camera_name,
+            return_image=return_image,
+            return_classifications=return_classifications,
+            return_detections=return_detections,
+            return_object_point_clouds=return_object_point_clouds,
+            extra=dict_to_struct(extra),
+        )
         response: CaptureAllFromCameraResponse = await self.client.CaptureAllFromCamera(request, timeout=timeout)
         result = CaptureAllResult()
         result.extra = struct_to_dict(response.extra)
@@ -188,7 +188,7 @@ class VisionClient(Vision, ReconfigurableResourceRPCClientBase):
             name=self.name,
             extra=dict_to_struct(extra),
         )
-        response : GetPropertiesResponse = await self.client.GetProperties(request, timeout=timeout)
+        response: GetPropertiesResponse = await self.client.GetProperties(request, timeout=timeout)
         return response
 
     async def do_command(

--- a/src/viam/services/vision/vision.py
+++ b/src/viam/services/vision/vision.py
@@ -24,6 +24,7 @@ class CaptureAllResult:
     "there was no request for the classifier/detector to return a result" vs.
     "the classifier/detector was requested, but there were no results".
     """
+
     def __init__(self, image=None, classifications=None, detections=None, objects=None, extra={}):
         """
         Args:
@@ -51,6 +52,7 @@ class Vision(ServiceBase):
     vision implementations. This cannot be used on its own. If the ``__init__()`` function is
     overridden, it must call the ``super().__init__()`` function.
     """
+
     SUBTYPE: Final = Subtype(  # pyright: ignore [reportIncompatibleVariableOverride]
         RESOURCE_NAMESPACE_RDK, RESOURCE_TYPE_SERVICE, "vision"
     )
@@ -283,10 +285,10 @@ class Vision(ServiceBase):
 
     @abc.abstractmethod
     async def get_properties(
-            self,
-            *,
-            extra: Optional[Mapping[str, Any]] = None,
-            timeout: Optional[float] = None,
+        self,
+        *,
+        extra: Optional[Mapping[str, Any]] = None,
+        timeout: Optional[float] = None,
     ) -> Properties:
         """
         Get info about what vision methods the vision service provides. Currently returns boolean values that

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -330,7 +330,7 @@ from viam.services.mlmodel import File, LabelType, Metadata, MLModel, TensorInfo
 from viam.services.mlmodel.utils import flat_tensors_to_ndarrays, ndarrays_to_flat_tensors
 from viam.services.navigation import Navigation
 from viam.services.slam import SLAM
-from viam.services.vision import Vision, CaptureAllResult
+from viam.services.vision import CaptureAllResult, Vision
 from viam.utils import ValueTypes, datetime_to_timestamp, dict_to_struct, struct_to_dict
 
 
@@ -360,7 +360,10 @@ class MockVision(Vision):
         super().__init__(name)
 
     async def get_properties(
-        self, *, extra: Optional[Mapping[str, Any]] = None, timeout: Optional[float] = None,
+        self,
+        *,
+        extra: Optional[Mapping[str, Any]] = None,
+        timeout: Optional[float] = None,
     ) -> Vision.Properties:
         self.extra = extra
         self.timeout = timeout

--- a/tests/test_vision_service.py
+++ b/tests/test_vision_service.py
@@ -34,12 +34,7 @@ from viam.proto.service.vision import (
     VisionServiceStub,
 )
 from viam.resource.manager import ResourceManager
-from viam.services.vision import (
-    Classification,
-    Detection,
-    Vision,
-    VisionClient,
-)
+from viam.services.vision import Classification, Detection, Vision, VisionClient
 from viam.services.vision.service import VisionRPCService
 from viam.utils import dict_to_struct, struct_to_dict
 
@@ -215,11 +210,7 @@ class TestService:
             client = VisionServiceStub(channel)
             extra = {"foo": "capture_all_from_camera"}
             request = CaptureAllFromCameraRequest(
-                    name=vision.name,
-                    camera_name="fake-camera",
-                    return_image=True,
-                    return_classifications=True,
-                    extra=dict_to_struct(extra)
+                name=vision.name, camera_name="fake-camera", return_image=True, return_classifications=True, extra=dict_to_struct(extra)
             )
             response: CaptureAllFromCameraResponse = await client.CaptureAllFromCamera(request)
             assert response.image.image == VISION_IMAGE.data


### PR DESCRIPTION
When `MovementSensor` was still a subclass of `Sensor`, we had to exclude adding registering a `Sensor` subtype with the robot for every `MovementSensor` so as to not duplicate the available resources. 

Now that `MovementSensor` is distinct from `Sensor`, we can remove that check 