### PR TITLE
RSDK-7776 - Add mime_types to GetPropertiesResponse

### DIFF
--- a/src/viam/components/camera/service.py
+++ b/src/viam/components/camera/service.py
@@ -88,6 +88,7 @@ class CameraRPCService(CameraServiceBase, ResourceRPCServiceBase[Camera]):
             supports_pcd=properties.supports_pcd,
             intrinsic_parameters=properties.intrinsic_parameters,
             distortion_parameters=properties.distortion_parameters,
+            mime_types=properties.mime_types,
         )
         await stream.send_message(response)
 

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -371,6 +371,7 @@ class MockCamera(Camera):
             supports_pcd=False,
             intrinsic_parameters=IntrinsicParameters(width_px=1, height_px=2, focal_x_px=3, focal_y_px=4, center_x_px=5, center_y_px=6),
             distortion_parameters=DistortionParameters(model="no_distortion"),
+            mime_types=[CameraMimeType.PNG, CameraMimeType.JPEG],
         )
         self.timeout: Optional[float] = None
         ts = Timestamp()

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -61,6 +61,7 @@ def properties() -> Camera.Properties:
         supports_pcd=False,
         intrinsic_parameters=IntrinsicParameters(width_px=1, height_px=2, focal_x_px=3, focal_y_px=4, center_x_px=5, center_y_px=6),
         distortion_parameters=DistortionParameters(model="no_distortion"),
+        mime_types=[CameraMimeType.PNG, CameraMimeType.JPEG],
     )
 
 
@@ -200,6 +201,7 @@ class TestService:
             response: GetPropertiesResponse = await client.GetProperties(request, timeout=5.43)
             assert response.supports_pcd == properties.supports_pcd
             assert response.intrinsic_parameters == properties.intrinsic_parameters
+            assert response.mime_types == properties.mime_types
             assert camera.timeout == loose_approx(5.43)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Simple PR to add `mime_types` to `GetProperties` response. This field was added to the camera `GetPropertiesResponse ` proto a few months back - see PR [here](https://github.com/viamrobotics/api/pull/408).