### PR TITLE
RSDK-7854 - fix local dialing, server_hostname setting

### DIFF
--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -313,12 +313,16 @@ async def _dial_direct(address: str, options: Optional[DialOptions] = None) -> C
     if insecure:
         ctx = None
     else:
-        ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
+        is_local_host = host.startswith("localhost") or host.startswith("0.0.0.0") or host.startswith("127.")
+        if is_local_host:
+            ctx = ssl._create_unverified_context(purpose=ssl.Purpose.SERVER_AUTH)
+        else:
+            ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
         ctx.minimum_version = ssl.TLSVersion.TLSv1_2
         ctx.set_ciphers("ECDHE+AESGCM:ECDHE+CHACHA20:DHE+AESGCM:DHE+CHACHA20")
         ctx.set_alpn_protocols(["h2"])
 
-        if options is not None and options.auth_entity and host != options.auth_entity:
+        if options is not None and options.auth_entity and host != options.auth_entity and options.credentials.type != "api-key":
             server_hostname = options.auth_entity
 
         # Test if downgrade is required.

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -313,7 +313,7 @@ async def _dial_direct(address: str, options: Optional[DialOptions] = None) -> C
     if insecure:
         ctx = None
     else:
-        is_local_host = host.startswith("localhost") or host.startswith("0.0.0.0") or host.startswith("127.")
+        is_local_host = host is not None and (host.startswith("localhost") or host.startswith("0.0.0.0") or host.startswith("127."))
         if is_local_host:
             ctx = ssl._create_unverified_context(purpose=ssl.Purpose.SERVER_AUTH)
         else:
@@ -322,7 +322,13 @@ async def _dial_direct(address: str, options: Optional[DialOptions] = None) -> C
         ctx.set_ciphers("ECDHE+AESGCM:ECDHE+CHACHA20:DHE+AESGCM:DHE+CHACHA20")
         ctx.set_alpn_protocols(["h2"])
 
-        if options is not None and options.auth_entity and host != options.auth_entity and options.credentials.type != "api-key":
+        if (
+            options is not None
+            and options.auth_entity
+            and host != options.auth_entity
+            and options.credentials is not None
+            and options.credentials.type != "api-key"
+        ):
             server_hostname = options.auth_entity
 
         # Test if downgrade is required.


### PR DESCRIPTION
Creates an unverified context to allow for proper connection when dialing to localhost. Additionally, prevents us from improperly setting `server_hostname` to our `api_key_id` when authing with an api-key.

This fix allows us to connect properly to `local.viam.cloud` addresses as well as to `localhost`.