### PR TITLE
RSDK-7698: Add Shutdown command to Python SDK

### DIFF
--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -796,10 +796,13 @@ class RobotClient:
 
     async def shutdown(self):
         """
-        Shutdown shuts down the robot. May return DeadlineExceeded error if shutdown request times out,
-        or if robot server shuts down before having a chance to send a response. May return Unavailable error
-        if server is unavailable, or if robot server is in the process of shutting down when response is ready.
+        Shutdown shuts down the robot.
 
+        Raises:
+            GRPCError: Raised with DeadlineExceeded status if shutdown request times out, or if
+              robot server shuts down before having a chance to send a response. Raised with
+              status Unavailable if server is unavailable, or if robot server is in the process of
+              shutting down when response is ready.
         """
         request = ShutdownRequest()
         try:

--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from threading import RLock
 from typing import Any, Dict, List, Optional, Union
 
+from grpclib import GRPCError, Status
 from grpclib.client import Channel
 from typing_extensions import Self
 
@@ -33,6 +34,7 @@ from viam.proto.robot import (
     ResourceNamesRequest,
     ResourceNamesResponse,
     RobotServiceStub,
+    ShutdownRequest,
     StopAllRequest,
     StopExtraParameters,
     TransformPoseRequest,
@@ -787,3 +789,23 @@ class RobotClient:
 
         request = GetCloudMetadataRequest()
         return await self._client.GetCloudMetadata(request)
+
+    ############
+    # Shutdown #
+    ############
+
+    async def shutdown(self):
+        """
+        Shutdown shuts down the robot. update comment here
+
+        """
+        request = ShutdownRequest()
+        try:
+            await self._client.Shutdown(request)
+        except GRPCError as e:
+            if e.status == Status.INTERNAL or e.status == Status.UNKNOWN:
+                pass
+            elif e.status == Status.DEADLINE_EXCEEDED:
+                raise e
+            # unfinishd logic
+            raise e

--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -808,7 +808,6 @@ class RobotClient:
         except GRPCError as e:
             if e.status == Status.INTERNAL or e.status == Status.UNKNOWN:
                 LOGGER.info("robot shutdown successful")
-                pass
             elif e.status == Status.UNAVAILABLE:
                 LOGGER.warn("server unavailable, likely due to successful robot shutdown")
                 raise e

--- a/tests/mocks/robot.py
+++ b/tests/mocks/robot.py
@@ -31,6 +31,8 @@ from viam.proto.robot import (
     RestartModuleResponse,
     SendSessionHeartbeatRequest,
     SendSessionHeartbeatResponse,
+    ShutdownRequest,
+    ShutdownResponse,
     StartSessionRequest,
     StartSessionResponse,
     StopAllRequest,
@@ -115,3 +117,6 @@ class MockRobot(UnimplementedRobotServiceBase):
 
     async def GetCloudMetadata(self, stream: Stream[GetCloudMetadataRequest, GetCloudMetadataResponse]) -> None:
         raise MethodNotImplementedError("GetCloudMetadata").grpc_error
+
+    async def Shutdown(self, stream: Stream[ShutdownRequest, ShutdownResponse]) -> None:
+        raise MethodNotImplementedError("Shutdown").grpc_error

--- a/tests/test_robot.py
+++ b/tests/test_robot.py
@@ -613,12 +613,7 @@ class TestRobotClient:
     @pytest.mark.asyncio
     async def test_shutdown(self, service: RobotService):
         async with ChannelFor([service]) as channel:
-
-            async def shutdown_client_mock(self):
-                self._client = RobotServiceStub(channel)
-                response = await self._client.Shutdown(ShutdownRequest())
-                return response
-
+            shutdown_client_mock = lambda self: self._client.Shutdown(ShutdownRequest())
             client = await RobotClient.with_channel(channel, RobotClient.Options())
 
             with mock.patch("viam.robot.client.RobotClient.shutdown") as shutdown_mock:
@@ -627,5 +622,5 @@ class TestRobotClient:
 
                 assert shutdown_response == ShutdownResponse()
                 shutdown_mock.assert_called_once()
-                
+
                 await client.close()

--- a/tests/test_robot.py
+++ b/tests/test_robot.py
@@ -613,7 +613,10 @@ class TestRobotClient:
     @pytest.mark.asyncio
     async def test_shutdown(self, service: RobotService):
         async with ChannelFor([service]) as channel:
-            shutdown_client_mock = lambda self: self._client.Shutdown(ShutdownRequest())
+
+            async def shutdown_client_mock(self):  
+                return await self._client.Shutdown(ShutdownRequest())
+            
             client = await RobotClient.with_channel(channel, RobotClient.Options())
 
             with mock.patch("viam.robot.client.RobotClient.shutdown") as shutdown_mock:

--- a/tests/test_robot.py
+++ b/tests/test_robot.py
@@ -153,6 +153,7 @@ GET_CLOUD_METADATA_RESPONSE = GetCloudMetadataResponse(
     machine_part_id="the-machine-part-id",
 )
 
+
 @pytest.fixture(scope="function")
 def service() -> RobotService:
     resources = [
@@ -619,12 +620,12 @@ class TestRobotClient:
                 return response
 
             client = await RobotClient.with_channel(channel, RobotClient.Options())
+
             with mock.patch("viam.robot.client.RobotClient.shutdown") as shutdown_mock:
-                   shutdown_mock.return_value = await shutdown_client_mock(client)
+                shutdown_mock.return_value = await shutdown_client_mock(client)
+                shutdown_response = await client.shutdown()
 
-                   shutdown_response = await client.shutdown()
-
-                   assert shutdown_response == ShutdownResponse()
-                   shutdown_mock.assert_called_once()
-
-                   await client.close()
+                assert shutdown_response == ShutdownResponse()
+                shutdown_mock.assert_called_once()
+                
+                await client.close()

--- a/tests/test_robot.py
+++ b/tests/test_robot.py
@@ -614,9 +614,9 @@ class TestRobotClient:
     async def test_shutdown(self, service: RobotService):
         async with ChannelFor([service]) as channel:
 
-            async def shutdown_client_mock(self):  
+            async def shutdown_client_mock(self):
                 return await self._client.Shutdown(ShutdownRequest())
-            
+
             client = await RobotClient.with_channel(channel, RobotClient.Options())
 
             with mock.patch("viam.robot.client.RobotClient.shutdown") as shutdown_mock:


### PR DESCRIPTION
### Description
[**RSDK-7698**](https://viam.atlassian.net/browse/RSDK-7698): Add Shutdown command to Python SDK
* Implements `RobotClient` `shutdown()` with the same error handling logic as the Go SDK seen in [this PR](https://github.com/viamrobotics/rdk/pull/4042)
### Testing
* Adds a robot client test by creating a mock robot shutdown service which sends a `ShutdownResponse()` and a mock robot client shutdown which makes a `ShutdownRequest()` and returns the `ShutdownResponse()`