### PR TITLE
RSDK-7728: Update to use non-deprecated create_filter

### DIFF
--- a/docs/examples/example.ipynb
+++ b/docs/examples/example.ipynb
@@ -1272,8 +1272,9 @@
    ],
    "source": [
     "from datetime import datetime\n",
+    "from viam.utils import create_filter\n",
     "\n",
-    "left_motor_filter = data_client.create_filter(\n",
+    "left_motor_filter = create_filter(\n",
     "    component_name=\"left_motor\", start_time=datetime(2023, 6, 5, 11), end_time=datetime(2023, 6, 5, 13, 30), tags=[\"speed_test_run\"]\n",
     ")\n",
     "\n",


### PR DESCRIPTION
[RSDK-7728](https://viam.atlassian.net/browse/RSDK-7728) Switch to using utils.create_filter in the jupyter example code because the old version was deprecated 

[RSDK-7728]: https://viam.atlassian.net/browse/RSDK-7728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ