### PR TITLE
DOCS-2313: Make fixups to app client, data client, and motion service package docs

### DIFF
--- a/src/viam/app/app_client.py
+++ b/src/viam/app/app_client.py
@@ -646,6 +646,7 @@ class AppClient:
 
         Args:
             org_id (str): The ID of the organization.
+                You can obtain your organization ID from the Viam app's organization settings page.
         """
         request = DeleteOrganizationRequest(organization_id=org_id)
         await self._app_client.DeleteOrganization(request, metadata=self._metadata)
@@ -659,6 +660,7 @@ class AppClient:
 
         Args:
             org_id (str): The ID of the organization to list members of.
+                You can obtain your organization ID from the Viam app's organization settings page.
 
         Returns:
             Tuple[List[viam.proto.app.OrganizationMember], List[viam.proto.app.OrganizationInvite]]: A tuple containing two lists; the first
@@ -679,6 +681,7 @@ class AppClient:
 
         Args:
             org_id (str): The ID of the organization to create an invite for.
+                You can obtain your organization ID from the Viam app's organization settings page.
             email (str): The email address to send the invite to.
             authorizations (Optional[List[viam.proto.app.Authorization]]): Specifications of the
                 authorizations to include in the invite. If not provided, full owner permissions will
@@ -730,6 +733,7 @@ class AppClient:
 
         Args:
             org_id (str): The ID of the organization that the invite is for.
+                You can obtain your organization ID from the Viam app's organization settings page.
             email (str): Email of the user the invite was sent to.
             add_authorizations (Optional[List[viam.proto.app.Authorization]]): Optional list of authorizations to add to the invite.
             remove_authorizations (Optional[List[viam.proto.app.Authorization]]): Optional list of authorizations to remove from the invite.
@@ -761,6 +765,7 @@ class AppClient:
 
         Args:
             org_id (str): The ID of the org to remove the user from.
+                You can obtain your organization ID from the Viam app's organization settings page.
             user_id (str): The ID of the user to remove.
         """
         request = DeleteOrganizationMemberRequest(organization_id=org_id, user_id=user_id)
@@ -775,6 +780,7 @@ class AppClient:
 
         Args:
             org_id (str): The ID of the organization that the invite to delete was for.
+                You can obtain your organization ID from the Viam app's organization settings page.
             email (str): The email address the pending invite was sent to.
 
         Raises:
@@ -788,14 +794,18 @@ class AppClient:
 
         ::
 
-            await cloud.resend_organization_invite("org-id", "youremail@email.com")
+            org_invite = await cloud.resend_organization_invite("org-id", "youremail@email.com")
 
         Args:
             org_id (str): The ID of the organization that the invite to resend was for.
+                You can obtain your organization ID from the Viam app's organization settings page.
             email (str): The email address associated with the invite.
 
         Raises:
             GRPCError: If no pending invite is associated with the provided email address.
+
+        Returns:
+            viam.proto.app.OrganizationInvite: The organization invite sent.
         """
         request = ResendOrganizationInviteRequest(organization_id=org_id, email=email)
         response: ResendOrganizationInviteResponse = await self._app_client.ResendOrganizationInvite(request, metadata=self._metadata)
@@ -810,6 +820,7 @@ class AppClient:
 
         Args:
             org_id (str): The ID of the organization to create the location under.
+                You can obtain your organization ID from the Viam app's organization settings page.
             name (str): Name of the location.
             parent_location_id (Optional[str]): Optional parent location to put the location under. Defaults to a root-level location if no
                 location ID is provided.
@@ -913,6 +924,7 @@ class AppClient:
 
         Args:
             org_id (str): The ID of the org to list locations for.
+                You can obtain your organization ID from the Viam app's organization settings page.
 
         Returns:
             List[viam.proto.app.Location]: The list of locations.
@@ -1043,6 +1055,7 @@ class AppClient:
 
         Args:
             org_id (str): The ID of the organization to list rover rental robots for.
+                You can obtain your organization ID from the Viam app's organization settings page.
 
         Returns:
             List[viam.proto.app.RoverRentalRobot]: The list of rover rental robots.
@@ -1482,6 +1495,7 @@ class AppClient:
 
         Args:
             org_id (str): The ID of the organization to list fragments for.
+                You can obtain your organization ID from the Viam app's organization settings page.
             show_public: Optional boolean specifying whether or not to only show public fragments. If True, only public fragments will
                 return. If False, only private fragments will return. Defaults to True.
 
@@ -1523,7 +1537,8 @@ class AppClient:
             new_fragment = await cloud.create_fragment(org_id="org-id", name="cool_smart_machine_to_configure_several_of")
 
         Args:
-            org_id (str): The ID of the organization to create the ragment within.
+            org_id (str): The ID of the organization to create the fragment within.
+                You can obtain your organization ID from the Viam app's organization settings page.
             name (str): Name of the fragment.
             config (Optional[Mapping[str, Any]]): Optional Dictionary representation of new config to assign to specified fragment. Can be
                 assigned by updating the fragment.
@@ -1605,6 +1620,7 @@ class AppClient:
 
         Args:
             org_id (str): The ID of the organization to create the role in.
+                You can obtain your organization ID from the Viam app's organization settings page.
             identity_id (str): ID of the entity the role belongs to (e.g., a user ID).
             role (Union[Literal["owner"], Literal["operator"]]): The role to add.
             resource_type (Union[Literal["organization"], Literal["location"], Literal["robot"]]): Type of the resource to add role to.
@@ -1646,6 +1662,7 @@ class AppClient:
 
         Args:
             org_id (str): The ID of the organization the role exists in.
+                You can obtain your organization ID from the Viam app's organization settings page.
             identity_id (str): ID of the entity the role belongs to (e.g., a user ID).
             role (Union[Literal["owner"], Literal["operator"]]): The role to remove.
             resource_type (Union[Literal["organization"], Literal["location"], Literal["robot"]]): Type of the resource the role is being
@@ -1891,6 +1908,7 @@ class AppClient:
 
         Args:
             org_id (str): The ID of the organization to create the module under.
+                You can obtain your organization ID from the Viam app's organization settings page.
             name (str): The name of the module. Must be unique within your organization.
 
         Raises:
@@ -2002,6 +2020,7 @@ class AppClient:
 
         Args:
             org_id (str): The ID of the organization to list modules for.
+                You can obtain your organization ID from the Viam app's organization settings page.
 
         Returns:
             List[viam.proto.app.Module]: The list of modules.
@@ -2029,6 +2048,7 @@ class AppClient:
 
         Args:
             org_id (str): The ID of the organization to create the key for.
+                You can obtain your organization ID from the Viam app's organization settings page.
             authorizations (List[viam.proto.app.Authorization]): A list of authorizations to associate
                 with the key.
             name (Optional[str]): A name for the key. If None, defaults to the current timestamp.
@@ -2088,6 +2108,7 @@ class AppClient:
 
         Args:
             org_id (str): The ID of the organization to list API keys for.
+                You can obtain your organization ID from the Viam app's organization settings page.
 
         Returns:
             List[viam.proto.app.APIKeyWithAuthorizations]: The existing API keys and authorizations."""

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -200,8 +200,9 @@ class DataClient:
             dest (str): Optional filepath for writing retrieved data.
 
         Returns:
-            List[TabularData]: The tabular data.
-            int: The count (number of entries)
+            Tuple[List[TabularData], int, str]: A tuple containing the following:
+            List[TabularData]: The tabular data,
+            int: The count (number of entries),
             str: The last-returned page ID.
         """
         filter = filter if filter else Filter()
@@ -244,6 +245,7 @@ class DataClient:
 
         Args:
             organization_id (str): The ID of the organization that owns the data.
+                You can obtain your organization ID from the Viam app's organization settings page.
             sql_query (str): The SQL query to run.
 
         Returns:
@@ -257,6 +259,7 @@ class DataClient:
         """Obtain unified tabular data and metadata, queried with MQL.
 
         ::
+
             # using bson
             import bson
             tabular_data = await data_client.tabular_data_by_mql(org_id="<your-org-id>", mql_binary=[
@@ -274,6 +277,7 @@ class DataClient:
 
         Args:
             organization_id (str): The ID of the organization that owns the data.
+                You can obtain your organization ID from the Viam app's organization settings page.
             mql_binary (List[bytes]): The MQL query to run as a list of BSON queries. You can encode your bson queries using a library like
                 `pymongo` or `bson`.
 
@@ -328,8 +332,9 @@ class DataClient:
             dest (str): Optional filepath for writing retrieved data.
 
         Returns:
-            List[viam.proto.app.data.BinaryData]: The binary data.
-            int: The count (number of entries)
+            Tuple[List[viam.proto.app.data.BinaryData], int, str]: A tuple containing the following:
+            List[viam.proto.app.data.BinaryData]: The binary data,
+            int: The count (number of entries),
             str: The last-returned page ID.
         """
 
@@ -421,6 +426,7 @@ class DataClient:
 
         Args:
             organization_id (str): ID of organization to delete data from.
+                You can obtain your organization ID from the Viam app's organization settings page.
             delete_older_than_days (int): Delete data that was captured up to this many days ago. For example if `delete_older_than_days`
                 is 10, this deletes any data that was captured up to 10 days ago. If it is 0, all existing data is deleted.
 
@@ -554,7 +560,7 @@ class DataClient:
         await self._data_client.AddTagsToBinaryDataByFilter(request, metadata=self._metadata)
 
     async def remove_tags_from_binary_data_by_ids(self, tags: List[str], binary_ids: List[BinaryID]) -> int:
-        """Remove tags from binary.
+        """Remove tags from binary data by IDs.
 
         ::
 
@@ -691,7 +697,7 @@ class DataClient:
             GRPCError: If the X or Y values are outside of the [0, 1] range.
 
         Returns:
-            str: The bounding box ID
+            str: The bounding box ID.
         """
         request = AddBoundingBoxToImageByIDRequest(
             label=label,
@@ -724,7 +730,7 @@ class DataClient:
 
         Args:
             bbox_id (str): The ID of the bounding box to remove.
-            Binary_id (viam.proto.arr.data.BinaryID): Binary ID of the image to to remove the bounding box from
+            binary_id (viam.proto.arr.data.BinaryID): Binary ID of the image to to remove the bounding box from.
         """
         request = RemoveBoundingBoxFromImageByIDRequest(bbox_id=bbox_id, binary_id=binary_id)
         await self._data_client.RemoveBoundingBoxFromImageByID(request, metadata=self._metadata)
@@ -761,6 +767,7 @@ class DataClient:
 
         Args:
             organization_id (str): Organization to retrieve the connection for.
+                You can obtain your organization ID from the Viam app's organization settings page.
 
         Returns:
             str: The hostname of the federated database.
@@ -773,8 +780,16 @@ class DataClient:
         """Configure a database user for the Viam organization's MongoDB Atlas Data Federation instance. It can also be used to reset the
         password of the existing database user.
 
+        ::
+
+            await data_client.configure_database_user(
+                organization_id="<your-org-id>",
+                password="your_password"
+            )
+
         Args:
             organization_id (str): The ID of the organization.
+                You can obtain your organization ID from the Viam app's organization settings page.
             password (str): The password of the user.
         """
         request = ConfigureDatabaseUserRequest(organization_id=organization_id, password=password)
@@ -794,6 +809,7 @@ class DataClient:
         Args:
             name (str): The name of the dataset being created.
             organization_id (str): The ID of the organization where the dataset is being created.
+                You can obtain your organization ID from the Viam app's organization settings page.
 
         Returns:
             str: The dataset ID of the created dataset.
@@ -813,7 +829,9 @@ class DataClient:
             print(datasets)
 
         Args:
-            ids (List[str]): The IDs of the datasets being called for.
+            ids (List[str]): The IDs of the datasets being called for. To retrieve these IDs,
+                navigate to your dataset's page in the Viam app,
+                click **...** in the left-hand menu, and click **Copy dataset ID**.
 
         Returns:
             Sequence[Dataset]: The list of datasets.
@@ -828,13 +846,14 @@ class DataClient:
 
         ::
 
-            datasets = await data_client.list_dataset_by_ids(
-                ids=["abcd-1234xyz-8765z-123abc"]
+            datasets = await data_client.list_dataset_by_organization_id(
+                organization_id=[""a12b3c4e-1234-1abc-ab1c-ab1c2d345abc""]
             )
             print(datasets)
 
         Args:
             organization_id (str): The ID of the organization.
+                You can obtain your organization ID from the Viam app's organization settings page.
 
         Returns:
             Sequence[Dataset]: The list of datasets in the organization.
@@ -908,7 +927,9 @@ class DataClient:
             )
 
         Args:
-            binary_ids (List[BinaryID]): The IDs of binary data to add to dataset.
+            binary_ids (List[BinaryID]): The IDs of binary data to add to dataset. To retrieve these IDs,
+                navigate to your dataset's page in the Viam app,
+                click **...** in the left-hand menu, and click **Copy dataset ID**.
             dataset_id (str): The ID of the dataset to be added to.
         """
         request = AddBinaryDataToDatasetByIDsRequest(binary_ids=binary_ids, dataset_id=dataset_id)
@@ -944,7 +965,9 @@ class DataClient:
             )
 
         Args:
-            binary_ids (List[BinaryID]): The IDs of binary data to remove from dataset.
+            binary_ids (List[BinaryID]): The IDs of binary data to remove from dataset. To retrieve these IDs,
+                navigate to your dataset's page in the Viam app,
+                click **...** in the left-hand menu, and click **Copy dataset ID**.
             dataset_id (str): The ID of the dataset to be removed from.
         """
         request = RemoveBinaryDataFromDatasetByIDsRequest(binary_ids=binary_ids, dataset_id=dataset_id)
@@ -964,7 +987,7 @@ class DataClient:
     ) -> str:
         """Upload binary sensor data.
 
-        Upload binary data collected on a robot through a specific component (e.g., a motor) along with the relevant metadata to
+        Upload binary data collected on a robot through a specific component (for example, a motor) along with the relevant metadata to
         app.viam.com. Binary data can be found under the "Files" subtab of the Data tab on app.viam.com.
 
         ::
@@ -987,10 +1010,10 @@ class DataClient:
         Args:
             binary_data (bytes): The data to be uploaded, represented in bytes.
             part_id (str): Part ID of the component used to capture the data.
-            component_type (str): Type of the component used to capture the data (e.g., "movement_sensor").
+            component_type (str): Type of the component used to capture the data (for example, "movement_sensor").
             component_name (str): Name of the component used to capture the data.
             method_name (str): Name of the method used to capture the data.
-            file_extension (str): The file extension of binary data including the period, e.g. .jpg, .png, .pcd.
+            file_extension (str): The file extension of binary data including the period, for example .jpg, .png, .pcd.
                 The backend will route the binary to its corresponding mime type based on this extension. Files with a .jpeg, .jpg,
                 or .png extension will be saved to the images tab.
             method_parameters (Optional[Mapping[str, Any]]): Optional dictionary of method parameters. No longer in active use.
@@ -1002,7 +1025,7 @@ class DataClient:
             GRPCError: If an invalid part ID is passed.
 
         Returns:
-            str: the file_id of the uploaded data.
+            str: The file_id of the uploaded data.
         """
         sensor_contents = SensorData(
             metadata=(
@@ -1043,7 +1066,7 @@ class DataClient:
     ) -> str:
         """Upload tabular sensor data.
 
-        Upload tabular data collected on a robot through a specific component (e.g., a motor) along with the relevant metadata to
+        Upload tabular data collected on a robot through a specific component (for example, a motor) along with the relevant metadata to
         app.viam.com. Tabular data can be found under the "Sensors" subtab of the Data tab on app.viam.com.
 
         ::
@@ -1064,7 +1087,7 @@ class DataClient:
         Args:
             tabular_data (List[Mapping[str, Any]]): List of the data to be uploaded, represented tabularly as a collection of dictionaries.
             part_id (str): Part ID of the component used to capture the data.
-            component_type (str): Type of the component used to capture the data (e.g., "movement_sensor").
+            component_type (str): Type of the component used to capture the data (for example, "movement_sensor").
             component_name (str): Name of the component used to capture the data.
             method_name (str): Name of the method used to capture the data.
             method_parameters (Optional[Mapping[str, Any]]): Optional dictionary of method parameters. No longer in active use.
@@ -1080,7 +1103,7 @@ class DataClient:
                 data.
 
         Returns:
-            str: the file_id of the uploaded data.
+            str: The file_id of the uploaded data.
         """
         sensor_contents = []
         if data_request_times:
@@ -1157,7 +1180,7 @@ class DataClient:
             data (bytes): the data to be uploaded.
             part_id (str): Part ID of the resource associated with the file.
             file_ext (str): file extension type for the data. required for determining MIME type.
-            component_type (Optional[str]): Optional type of the component associated with the file (e.g., "movement_sensor").
+            component_type (Optional[str]): Optional type of the component associated with the file (for example, "movement_sensor").
             component_name (Optional[str]): Optional name of the component associated with the file.
             method_name (Optional[str]): Optional name of the method associated with the file.
             method_parameters (Optional[str]): Optional dictionary of the method parameters. No longer in active use.
@@ -1169,7 +1192,7 @@ class DataClient:
             GRPCError: If an invalid part ID is passed.
 
         Returns:
-            str: the file_id of the uploaded data.
+            str: The file_id of the uploaded data.
         """
 
         upload_metadata = UploadMetadata(
@@ -1228,7 +1251,7 @@ class DataClient:
         Args:
             part_id (str): Part ID of the resource associated with the file.
             data (bytes): Bytes representing file data to upload.
-            component_type (Optional[str]): Optional type of the component associated with the file (e.g., "movement_sensor").
+            component_type (Optional[str]): Optional type of the component associated with the file (for example, "movement_sensor").
             component_name (Optional[str]): Optional name of the component associated with the file.
             method_name (Optional[str]): Optional name of the method associated with the file.
             file_name (Optional[str]): Optional name of the file. The empty string "" will be assigned as the file name if one isn't
@@ -1284,7 +1307,7 @@ class DataClient:
         Args:
             filepath (str): Absolute filepath of file to be uploaded.
             part_id (str): Part ID of the component associated with the file.
-            component_type (Optional[str]): Optional type of the component associated with the file (e.g., "movement_sensor").
+            component_type (Optional[str]): Optional type of the component associated with the file (for example, "movement_sensor").
             component_name (Optional[str]): Optional name of the component associated with the file.
             method_name (Optional[str]): Optional name of the method associated with the file.
             method_parameters (Optional[str]): Optional dictionary of the method parameters. No longer in active use.

--- a/src/viam/services/motion/client.py
+++ b/src/viam/services/motion/client.py
@@ -99,10 +99,10 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
             world_state (viam.proto.common.WorldState): When supplied, the motion service will create a plan that obeys any constraints
                 expressed in the WorldState message.
             constraints (viam.proto.service.motion.Constraints): When supplied, the motion service will create a plan that obeys any
-                specified constraints
+                specified constraints.
 
         Returns:
-            bool: Whether the move was successful
+            bool: Whether the move was successful.
         """
         if extra is None:
             extra = {}
@@ -169,10 +169,12 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
                 at the destination point. Range: [0-360) 0: North, 90: East, 180: South, 270: West. Default: None
             configuration (Optional[MotionConfiguration]): The configuration you want to set across this machine for this
                 motion service. This parameter and each of its fields are optional.
+
                 - obstacle_detectors (Iterable[ObstacleDetector]): The names of each vision service and camera resource pair
-                    you want to use for transient obstacle avoidance.
-                - position_polling_frequency_hz (float): The frequency in hz to poll the position of the machine.
-                - obstacle_polling_frequency_hz (float): The frequency in hz to poll the vision service for new obstacles.
+                you want to use for transient obstacle avoidance.
+
+                - position_polling_frequency_hz (float): The frequency in Hz to poll the position of the machine.
+                - obstacle_polling_frequency_hz (float): The frequency in Hz to poll the vision service for new obstacles.
                 - plan_deviation_m (float): The distance in meters that the machine can deviate from the motion plan.
                 - linear_m_per_sec (float): Linear velocity this machine should target when moving.
                 - angular_degs_per_sec (float): Angular velocity this machine should target when turning.
@@ -246,8 +248,10 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
             slam_service_name (ResourceName): The ResourceName of the SLAM service from which the SLAM map is requested.
             configuration (Optional[MotionConfiguration]): The configuration you want to set across this machine for this motion service.
                 This parameter and each of its fields are optional.
+
                 - obstacle_detectors (Iterable[ObstacleDetector]): The names of each vision service and camera resource pair you want to use
-                    for transient obstacle avoidance.
+                for transient obstacle avoidance.
+
                 - position_polling_frequency_hz (float): The frequency in hz to poll the position of the machine.
                 - obstacle_polling_frequency_hz (float): The frequency in hz to poll the vision service for new obstacles.
                 - plan_deviation_m (float): The distance in meters that the machine can deviate from the motion plan.
@@ -341,8 +345,8 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
 
         Args:
             component_name (ResourceName): The component to stop
-            last_plan_only (Optional[bool]): If supplied, the response will only return the last plan for the component / execution
-            execution_id (Optional[str]): If supplied, the response will only return plans with the provided execution_id
+            last_plan_only (Optional[bool]): If supplied, the response will only return the last plan for the component / execution.
+            execution_id (Optional[str]): If supplied, the response will only return plans with the provided execution_id.
 
         Returns:
             ``GetPlanResponse`` (GetPlanResponse): The current PlanWithStatus & replan history which matches the request
@@ -382,11 +386,11 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
             resp = await motion.list_plan_statuses()
 
         Args:
-            only_active_plans (Optional[bool]):  If supplied, the response will filter out any plans that are not executing
+            only_active_plans (Optional[bool]):  If supplied, the response will filter out any plans that are not executing.
 
         Returns:
             ``ListPlanStatusesResponse`` (ListPlanStatusesResponse): List of last known statuses with the
-            associated IDs of all plans within the TTL ordered by timestamp in ascending order
+            associated IDs of all plans within the TTL ordered by timestamp in ascending order.
         """
         if extra is None:
             extra = {}
@@ -466,10 +470,10 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
             await motion.do_command(my_command)
 
         Args:
-            command (Dict[str, ValueTypes]): The command to execute
+            command (Dict[str, ValueTypes]): The command to execute.
 
         Returns:
-            Dict[str, ValueTypes]: Result of the executed command
+            Dict[str, ValueTypes]: Result of the executed command.
         """
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
         response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)


### PR DESCRIPTION
* Fix code samples, parameter and return descriptions and formatting
* Update descriptions for more info on grabbing organization and dataset ids 
* Add periods and remove "e.g". bc it causes linting error in docs.viam (we aren't supposed to use it)

Note: Motion move_on_globe and move_on_map configuration object formatting: sub-bulleted list -- still looks slightly odd with indenting but couldn't figure out how to completely fix 