### PR TITLE
use poetry cache in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: poetry
 
       - name: Install Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,14 +28,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
       - name: Setup python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: poetry
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
 
       - name: Fix Poetry
         run: poetry config installer.modern-installation false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: poetry
-          cache-dependency-path: |
-            requirements-test.txt
 
       - name: Fix Poetry
         run: poetry config installer.modern-installation false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,12 +33,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-
-      - name: Fix Poetry
-        run: poetry config installer.modern-installation false
-
       - name: Install package
         run: make install
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: poetry
-          cache-dependency-path:
+          cache-dependency-path: |
             requirements-test.txt
 
       - name: Fix Poetry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,12 +29,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        run: pipx install poetry
       - name: Setup python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: poetry
+          cache-dependency-path:
+            requirements-test.txt
 
       - name: Fix Poetry
         run: poetry config installer.modern-installation false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+
+      - name: Fix Poetry
+        run: poetry config installer.modern-installation false
+
       - name: Install package
         run: make install
 


### PR DESCRIPTION
## What changed
- add `cache: poetry` param to setup-python action
## Why
Faster builds
## Comparison
I did a run [here](https://github.com/viamrobotics/viam-python-sdk/actions/runs/9518864325) and then reran again after it succeeded (to get cache).

Speedup is about 40 seconds for the slowest job (2:30 -> 1:50).

Before and after:
![before-after](https://github.com/viamrobotics/viam-python-sdk/assets/7256523/5ba514ad-71b0-427e-91b4-eb1abf6dffef)
