### PR TITLE
DOCS-2497: Add backlinks to main docs

### DIFF
--- a/src/viam/components/arm/arm.py
+++ b/src/viam/components/arm/arm.py
@@ -22,6 +22,8 @@ class Arm(ComponentBase):
         from viam.proto.common import Pose
         # To use move_to_joint_positions:
         from viam.proto.component.arm import JointPositions
+
+    For more information, see `Arm component <https://docs.viam.com/components/arm/>`_.
     """
 
     SUBTYPE: Final = Subtype(RESOURCE_NAMESPACE_RDK, RESOURCE_TYPE_COMPONENT, "arm")  # pyright: ignore [reportIncompatibleVariableOverride]
@@ -49,6 +51,8 @@ class Arm(ComponentBase):
             The ``Pose`` is composed of values for location and orientation with respect to the origin.
             Location is expressed as distance, which is represented by x, y, and z coordinate values.
             Orientation is expressed as an orientation vector, which is represented by o_x, o_y, o_z, and theta values.
+
+        For more information, see `Arm component <https://docs.viam.com/components/arm/>`_.
         """
         ...
 
@@ -79,6 +83,8 @@ class Arm(ComponentBase):
                 with respect to the origin.
                 Location is expressed as distance, which is represented by x, y, and z coordinate values.
                 Orientation is expressed as an orientation vector, which is represented by o_x, o_y, o_z, and theta values.
+
+        For more information, see `Arm component <https://docs.viam.com/components/arm/>`_.
         """
         ...
 
@@ -111,6 +117,8 @@ class Arm(ComponentBase):
 
         Args:
             positions (JointPositions): The destination ``JointPositions`` for the arm.
+
+        For more information, see `Arm component <https://docs.viam.com/components/arm/>`_.
         """
         ...
 
@@ -136,6 +144,8 @@ class Arm(ComponentBase):
             JointPositions: The current ``JointPositions`` for the arm.
             ``JointPositions`` can have one attribute, ``values``, a list of joint positions with rotational values (degrees)
             and translational values (mm).
+
+        For more information, see `Arm component <https://docs.viam.com/components/arm/>`_.
         """
         ...
 
@@ -157,6 +167,7 @@ class Arm(ComponentBase):
             # Stop all motion of the arm. It is assumed that the arm stops immediately.
             await my_arm.stop()
 
+        For more information, see `Arm component <https://docs.viam.com/components/arm/>`_.
         """
         ...
 
@@ -177,6 +188,8 @@ class Arm(ComponentBase):
 
         Returns:
             bool: Whether the arm is moving.
+
+        For more information, see `Arm component <https://docs.viam.com/components/arm/>`_.
         """
         ...
 
@@ -204,5 +217,7 @@ class Arm(ComponentBase):
             Tuple[KinematicsFileFormat.ValueType, bytes]: A tuple containing two values; the first [0] value represents the format of the
             file, either in URDF format or Viam's kinematic parameter format (spatial vector algebra), and the second [1] value
             represents the byte contents of the file.
+
+        For more information, see `Arm component <https://docs.viam.com/components/arm/>`_.
         """
         ...

--- a/src/viam/components/base/base.py
+++ b/src/viam/components/base/base.py
@@ -19,6 +19,8 @@ class Base(ComponentBase):
     ::
 
         from viam.components.base import Base
+
+    For more information, see `Base component <https://docs.viam.com/components/base/>`_.
     """
 
     SUBTYPE: Final = Subtype(  # pyright: ignore [reportIncompatibleVariableOverride]
@@ -62,6 +64,8 @@ class Base(ComponentBase):
                 Negative implies backwards.
             velocity (float): The velocity (in millimeters per second) to move.
                 Negative implies backwards.
+
+        For more information, see `Base component <https://docs.viam.com/components/base/>`_.
         """
         ...
 
@@ -93,6 +97,8 @@ class Base(ComponentBase):
             velocity (float): The angular velocity (in degrees per second)
                 to spin.
                 Given a positive angle and a positive velocity, the base will turn to the left.
+
+        For more information, see `Base component <https://docs.viam.com/components/base/>`_.
         """
         ...
 
@@ -146,6 +152,8 @@ class Base(ComponentBase):
                 for wheeled base. Positive implies forwards.
             angular (Vector3): The angular component. Only the Z component is used
                 for wheeled base. Positive turns left; negative turns right.
+
+        For more information, see `Base component <https://docs.viam.com/components/base/>`_.
         """
         ...
 
@@ -174,6 +182,8 @@ class Base(ComponentBase):
         Args:
             linear (Vector3): Velocity in mm/sec
             angular (Vector3): Velocity in deg/sec
+
+        For more information, see `Base component <https://docs.viam.com/components/base/>`_.
         """
 
     @abc.abstractmethod
@@ -196,6 +206,8 @@ class Base(ComponentBase):
 
             # Stop the base.
             await my_base.stop()
+
+        For more information, see `Base component <https://docs.viam.com/components/base/>`_.
         """
         ...
 
@@ -214,6 +226,8 @@ class Base(ComponentBase):
 
         Returns:
             bool: Whether the base is moving.
+
+        For more information, see `Base component <https://docs.viam.com/components/base/>`_.
         """
         ...
 
@@ -240,5 +254,7 @@ class Base(ComponentBase):
 
         Returns:
             Properties: The properties of the base
+
+        For more information, see `Base component <https://docs.viam.com/components/base/>`_.
         """
         ...

--- a/src/viam/components/board/board.py
+++ b/src/viam/components/board/board.py
@@ -30,6 +30,8 @@ class Board(ComponentBase):
     ::
 
         from viam.components.board import Board
+
+    For more information, see `Board component <https://docs.viam.com/components/board/>`_.
     """
 
     SUBTYPE: Final = Subtype(  # pyright: ignore [reportIncompatibleVariableOverride]
@@ -49,6 +51,8 @@ class Board(ComponentBase):
         Value contains the result of reading an analog reader. It contains the raw data read,
         the reader's minimum and maximum possible values, and its step size (the minimum possible
         change between values it can read).
+
+        For more information, see `analogs <https://docs.viam.com/components/board/#analogs>`_.
         """
 
         def __init__(self, name: str):
@@ -73,6 +77,8 @@ class Board(ComponentBase):
 
             Returns:
                 Value: The current value, including the min, max, and step_size of the reader.
+
+            For more information, see `Board component Analog API <https://docs.viam.com/components/board/#analog-api>`_.
             """
             ...
 
@@ -93,6 +99,8 @@ class Board(ComponentBase):
 
             Args:
                 value (int): Value to write to the analog writer.
+
+            For more information, see `Board component Analog API <https://docs.viam.com/components/board/#analog-api>`_.
             """
             ...
 
@@ -101,6 +109,8 @@ class Board(ComponentBase):
         DigitalInterrupt represents a configured interrupt on the Board that
         when interrupted, calls the added callbacks. Post processors can
         be added to modify what Value it ultimately returns.
+
+        For more information, see `digital_interrupts <https://docs.viam.com/components/board/#digital_interrupts>`_.
         """
 
         name: str
@@ -129,6 +139,9 @@ class Board(ComponentBase):
 
             Returns:
                 int: The current value.
+
+            For more information, see
+            `Board component DigitalInterrupt API <https://docs.viam.com/components/board/#digitalinterrupt-api>`_.
             """
             ...
 
@@ -160,6 +173,8 @@ class Board(ComponentBase):
 
             Args:
                 high (bool): When true, sets the pin to high. When false, sets the pin to low.
+
+            For more information, see `GPIOPin API <https://docs.viam.com/components/board/#gpiopin-api>`_.
             """
             ...
 
@@ -180,6 +195,8 @@ class Board(ComponentBase):
 
             Returns:
                 bool: Indicates if the state of the pin is high.
+
+            For more information, see `GPIOPin API <https://docs.viam.com/components/board/#gpiopin-api>`_.
             """
             ...
 
@@ -200,6 +217,8 @@ class Board(ComponentBase):
 
             Returns:
                 float: The duty cycle.
+
+            For more information, see `GPIOPin API <https://docs.viam.com/components/board/#gpiopin-api>`_.
             """
             ...
 
@@ -221,6 +240,8 @@ class Board(ComponentBase):
 
             Args:
                 duty_cycle (float): The duty cycle.
+
+            For more information, see `GPIOPin API <https://docs.viam.com/components/board/#gpiopin-api>`_.
             """
             ...
 
@@ -241,6 +262,8 @@ class Board(ComponentBase):
 
             Returns:
                 int: The PWM frequency.
+
+            For more information, see `GPIOPin API <https://docs.viam.com/components/board/#gpiopin-api>`_.
             """
             ...
 
@@ -269,6 +292,8 @@ class Board(ComponentBase):
 
             Args:
                 frequency (int): The frequency, in Hz.
+
+            For more information, see `GPIOPin API <https://docs.viam.com/components/board/#gpiopin-api>`_.
             """
             ...
 
@@ -289,6 +314,8 @@ class Board(ComponentBase):
 
         Returns:
             Analog: The analog reader or writer.
+
+        For more information, see `Board component <https://docs.viam.com/components/board/>`_.
         """
         ...
 
@@ -310,6 +337,8 @@ class Board(ComponentBase):
 
         Returns:
             DigitalInterrupt: The digital interrupt.
+
+        For more information, see `Board component <https://docs.viam.com/components/board/>`_.
         """
         ...
 
@@ -330,6 +359,8 @@ class Board(ComponentBase):
 
         Returns:
             GPIOPin: The pin.
+
+        For more information, see `Board component <https://docs.viam.com/components/board/>`_.
         """
         ...
 
@@ -347,6 +378,8 @@ class Board(ComponentBase):
 
         Returns:
             List[str]: The list of names of all known analog readers/writers.
+
+        For more information, see `Board component <https://docs.viam.com/components/board/>`_.
         """
         ...
 
@@ -364,6 +397,8 @@ class Board(ComponentBase):
 
         Returns:
             List[str]: The names of the digital interrupts.
+
+        For more information, see `Board component <https://docs.viam.com/components/board/>`_.
         """
         ...
 
@@ -384,6 +419,8 @@ class Board(ComponentBase):
         Args:
             mode (PowerMode): The desired power mode.
             duration (Optional[timedelta]): Requested duration to stay in power mode.
+
+        For more information, see `Board component <https://docs.viam.com/components/board/>`_.
         """
         ...
 
@@ -409,5 +446,7 @@ class Board(ComponentBase):
 
         Returns:
             TickStream: stream of ticks.
+
+        For more information, see `Board component <https://docs.viam.com/components/board/>`_.
         """
         ...

--- a/src/viam/components/camera/camera.py
+++ b/src/viam/components/camera/camera.py
@@ -26,6 +26,8 @@ class Camera(ComponentBase):
     ::
 
         from viam.components.camera import Camera
+
+    For more information, see `Camera component <https://docs.viam.com/components/camera/>`_.
     """
 
     SUBTYPE: Final = Subtype(  # pyright: ignore [reportIncompatibleVariableOverride]
@@ -60,6 +62,8 @@ class Camera(ComponentBase):
 
         Returns:
             ViamImage: The frame.
+
+        For more information, see `Camera component <https://docs.viam.com/components/camera/>`_.
         """
         ...
 
@@ -79,6 +83,8 @@ class Camera(ComponentBase):
         Returns:
             Tuple[List[NamedImage], ResponseMetadata]: A tuple containing two values; the first [0] a list of images
             returned from the camera system, and the second [1] the metadata associated with this response.
+
+        For more information, see `Camera component <https://docs.viam.com/components/camera/>`_.
         """
         ...
 
@@ -110,6 +116,8 @@ class Camera(ComponentBase):
         Returns:
             Tuple[bytes, str]: A tuple containing two values; the first [0] the pointcloud data,
             and the second [1] the mimetype of the pointcloud (for example, PCD).
+
+        For more information, see `Camera component <https://docs.viam.com/components/camera/>`_.
         """
         ...
 
@@ -126,5 +134,7 @@ class Camera(ComponentBase):
 
         Returns:
             Properties: The properties of the camera.
+
+        For more information, see `Camera component <https://docs.viam.com/components/camera/>`_.
         """
         ...

--- a/src/viam/components/encoder/encoder.py
+++ b/src/viam/components/encoder/encoder.py
@@ -24,6 +24,8 @@ class Encoder(ComponentBase):
     ::
 
         from viam.components.encoder import Encoder
+
+    For more information, see `Encoder component <https://docs.viam.com/components/encoder/>`_.
     """
 
     SUBTYPE: Final = Subtype(  # pyright: ignore [reportIncompatibleVariableOverride]
@@ -48,6 +50,8 @@ class Encoder(ComponentBase):
             # Reset the zero position of the encoder.
             await my_encoder.reset_position()
 
+
+        For more information, see `Encoder component <https://docs.viam.com/components/encoder/>`_.
         """
         ...
 
@@ -81,6 +85,8 @@ class Encoder(ComponentBase):
             Tuple[float, PositionType]: A tuple containing two values; the first [0] the Position of the encoder
             which can either be ticks since last zeroing for a relative encoder or degrees for an absolute encoder,
             and the second [1] the type of position the encoder returns (ticks or degrees).
+
+        For more information, see `Encoder component <https://docs.viam.com/components/encoder/>`_.
         """
         ...
 
@@ -104,5 +110,7 @@ class Encoder(ComponentBase):
 
         Returns:
             Encoder.Properties: Map of position types to supported status.
+
+        For more information, see `Encoder component <https://docs.viam.com/components/encoder/>`_.
         """
         ...

--- a/src/viam/components/gantry/gantry.py
+++ b/src/viam/components/gantry/gantry.py
@@ -17,6 +17,8 @@ class Gantry(ComponentBase):
     ::
 
         from viam.components.gantry import Gantry
+
+    For more information, see `Gantry component <https://docs.viam.com/components/gantry/>`_.
     """
 
     SUBTYPE: Final = Subtype(  # pyright: ignore [reportIncompatibleVariableOverride]
@@ -37,6 +39,8 @@ class Gantry(ComponentBase):
 
         Returns:
             List[float]: A list of the position of the axes of the gantry in millimeters.
+
+        For more information, see `Gantry component <https://docs.viam.com/components/gantry/>`_.
         """
         ...
 
@@ -70,6 +74,8 @@ class Gantry(ComponentBase):
         Args:
             positions (List[float]): A list of positions for the axes of the gantry to move to, in millimeters.
             speeds (List[float]): A list of speeds in millimeters per second for the gantry to move at respective to each axis.
+
+        For more information, see `Gantry component <https://docs.viam.com/components/gantry/>`_.
         """
         ...
 
@@ -86,6 +92,8 @@ class Gantry(ComponentBase):
 
         Returns:
             bool: Whether the gantry has run the homing sequence successfully.
+
+        For more information, see `Gantry component <https://docs.viam.com/components/gantry/>`_.
         """
 
     @abc.abstractmethod
@@ -102,6 +110,8 @@ class Gantry(ComponentBase):
 
         Returns:
             List[float]: A list of the lengths of the axes of the gantry in millimeters.
+
+        For more information, see `Gantry component <https://docs.viam.com/components/gantry/>`_.
         """
         ...
 
@@ -118,6 +128,7 @@ class Gantry(ComponentBase):
             # immediately.
             await my_gantry.stop()
 
+        For more information, see `Gantry component <https://docs.viam.com/components/gantry/>`_.
         """
         ...
 
@@ -139,5 +150,7 @@ class Gantry(ComponentBase):
 
         Returns:
             bool: Whether the gantry is moving.
+
+        For more information, see `Gantry component <https://docs.viam.com/components/gantry/>`_.
         """
         ...

--- a/src/viam/components/generic/generic.py
+++ b/src/viam/components/generic/generic.py
@@ -67,6 +67,8 @@ class Generic(ComponentBase):
         component.power  # 1
         await asyncio.sleep(10)
         component.power  # 0
+
+    For more information, see `Gantry component <https://docs.viam.com/components/generic/>`_.
     """
 
     SUBTYPE: Final = Subtype(  # pyright: ignore [reportIncompatibleVariableOverride]

--- a/src/viam/components/gripper/gripper.py
+++ b/src/viam/components/gripper/gripper.py
@@ -16,6 +16,8 @@ class Gripper(ComponentBase):
     ::
 
         from viam.components.gripper import Gripper
+
+    For more information, see `Gripper component <https://docs.viam.com/components/gripper/>`_.
     """
 
     SUBTYPE: Final = Subtype(  # pyright: ignore [reportIncompatibleVariableOverride]
@@ -39,6 +41,8 @@ class Gripper(ComponentBase):
 
             # Open the gripper.
             await my_gripper.open()
+
+        For more information, see `Gripper component <https://docs.viam.com/components/gripper/>`_.
         """
         ...
 
@@ -62,6 +66,8 @@ class Gripper(ComponentBase):
 
         Returns:
             bool: Indicates if the gripper grabbed something.
+
+        For more information, see `Gripper component <https://docs.viam.com/components/gripper/>`_.
         """
         ...
 
@@ -82,6 +88,8 @@ class Gripper(ComponentBase):
 
             # Stop the gripper.
             await my_gripper.stop()
+
+        For more information, see `Gripper component <https://docs.viam.com/components/gripper/>`_.
         """
         ...
 
@@ -100,5 +108,7 @@ class Gripper(ComponentBase):
 
         Returns:
             bool: Whether the gripper is moving.
+
+        For more information, see `Gripper component <https://docs.viam.com/components/gripper/>`_.
         """
         ...

--- a/src/viam/components/input/input.py
+++ b/src/viam/components/input/input.py
@@ -139,6 +139,8 @@ class Controller(ComponentBase):
     ::
 
         from viam.components.input import Control, Controller, EventType
+
+    For more information, see `Input Controller component <https://docs.viam.com/components/input-controller/>`_.
     """
 
     SUBTYPE: Final = Subtype(  # pyright: ignore [reportIncompatibleVariableOverride]
@@ -164,6 +166,8 @@ class Controller(ComponentBase):
 
         Returns:
             List[Control]: List of controls provided by the Controller
+
+        For more information, see `Input Controller component <https://docs.viam.com/components/input-controller/>`_.
         """
         ...
 
@@ -189,6 +193,8 @@ class Controller(ComponentBase):
 
         Returns:
             Dict[Control, Event]: The most recent event for each input
+
+        For more information, see `Input Controller component <https://docs.viam.com/components/input-controller/>`_.
         """
         ...
 
@@ -252,6 +258,8 @@ class Controller(ComponentBase):
                 trigger the function
             function (ControlFunction): The function to run on
                 specific triggers
+
+        For more information, see `Input Controller component <https://docs.viam.com/components/input-controller/>`_.
         """
         ...
 
@@ -277,5 +285,7 @@ class Controller(ComponentBase):
 
         Args:
             event (Event): The event to trigger
+
+        For more information, see `Input Controller component <https://docs.viam.com/components/input-controller/>`_.
         """
         raise NotSupportedError(f"Input controller named {self.name} does not support triggering events")

--- a/src/viam/components/motor/motor.py
+++ b/src/viam/components/motor/motor.py
@@ -17,6 +17,8 @@ class Motor(ComponentBase):
     ::
 
         from viam.components.motor import Motor
+
+    For more information, see `Motor component <https://docs.viam.com/components/motor/>`_.
     """
 
     @dataclass
@@ -50,6 +52,8 @@ class Motor(ComponentBase):
         Args:
             power (float): Power between -1 and 1
                 (negative implies backwards).
+
+        For more information, see `Motor component <https://docs.viam.com/components/motor/>`_.
         """
         ...
 
@@ -80,6 +84,8 @@ class Motor(ComponentBase):
                 (negative implies backwards).
             revolutions (float): Number of revolutions the motor should run for
                 (negative implies backwards).
+
+        For more information, see `Motor component <https://docs.viam.com/components/motor/>`_.
         """
         ...
 
@@ -109,6 +115,8 @@ class Motor(ComponentBase):
         Args:
             rpm (float): Speed at which the motor should rotate (absolute value).
             position_revolutions (float): Target position relative to home/zero, in revolutions.
+
+        For more information, see `Motor component <https://docs.viam.com/components/motor/>`_.
         """
         ...
 
@@ -134,6 +142,8 @@ class Motor(ComponentBase):
 
         Args:
             rpm (float): Speed at which the motor should rotate.
+
+        For more information, see `Motor component <https://docs.viam.com/components/motor/>`_.
         """
         ...
 
@@ -158,6 +168,8 @@ class Motor(ComponentBase):
 
         Args:
             offset (float): The offset from the current position to new home/zero position.
+
+        For more information, see `Motor component <https://docs.viam.com/components/motor/>`_.
         """
         ...
 
@@ -183,6 +195,8 @@ class Motor(ComponentBase):
 
         Returns:
             float: Number of revolutions the motor is away from zero/home.
+
+        For more information, see `Motor component <https://docs.viam.com/components/motor/>`_.
         """
         ...
 
@@ -211,6 +225,8 @@ class Motor(ComponentBase):
 
         Returns:
             Properties: Map of feature names to supported status.
+
+        For more information, see `Motor component <https://docs.viam.com/components/motor/>`_.
         """
         ...
 
@@ -231,6 +247,8 @@ class Motor(ComponentBase):
 
             # Stop the motor.
             await my_motor.stop()
+
+        For more information, see `Motor component <https://docs.viam.com/components/motor/>`_.
         """
         ...
 
@@ -257,6 +275,8 @@ class Motor(ComponentBase):
         Returns:
             Tuple[bool, float]: A tuple containing two values; the first [0] value indicates whether the motor is currently powered, and
                 the second [1] value indicates the current power percentage of the motor.
+
+        For more information, see `Motor component <https://docs.viam.com/components/motor/>`_.
         """
         ...
 
@@ -275,5 +295,7 @@ class Motor(ComponentBase):
 
         Returns:
             bool: Whether the motor is moving.
+
+        For more information, see `Motor component <https://docs.viam.com/components/motor/>`_.
         """
         ...

--- a/src/viam/components/movement_sensor/movement_sensor.py
+++ b/src/viam/components/movement_sensor/movement_sensor.py
@@ -27,6 +27,8 @@ class MovementSensor(ComponentBase):
     ::
 
         from viam.components.movement_sensor import MovementSensor
+
+    For more information, see `Movement Sensor component <https://docs.viam.com/components/movement-sensor/>`_.
     """
 
     SUBTYPE: Final = Subtype(  # pyright: ignore [reportIncompatibleVariableOverride]
@@ -83,6 +85,8 @@ class MovementSensor(ComponentBase):
 
         Returns:
             Tuple[GeoPoint, float]: The current lat/long, along with the altitude in m
+
+        For more information, see `Movement Sensor component <https://docs.viam.com/components/movement-sensor/>`_.
         """
         ...
 
@@ -100,6 +104,8 @@ class MovementSensor(ComponentBase):
 
         Returns:
             Vector3: The linear velocity in m/sec
+
+        For more information, see `Movement Sensor component <https://docs.viam.com/components/movement-sensor/>`_.
         """
         ...
 
@@ -120,6 +126,8 @@ class MovementSensor(ComponentBase):
 
         Returns:
             Vector3: The angular velocity in degrees/sec
+
+        For more information, see `Movement Sensor component <https://docs.viam.com/components/movement-sensor/>`_.
         """
         ...
 
@@ -142,6 +150,8 @@ class MovementSensor(ComponentBase):
 
         Returns:
             Vector3: The linear acceleration in m/sec^2
+
+        For more information, see `Movement Sensor component <https://docs.viam.com/components/movement-sensor/>`_.
         """
         ...
 
@@ -159,6 +169,8 @@ class MovementSensor(ComponentBase):
 
         Returns:
             float: The compass heading in degrees
+
+        For more information, see `Movement Sensor component <https://docs.viam.com/components/movement-sensor/>`_.
         """
         ...
 
@@ -176,6 +188,8 @@ class MovementSensor(ComponentBase):
 
         Returns:
             Orientation: The orientation
+
+        For more information, see `Movement Sensor component <https://docs.viam.com/components/movement-sensor/>`_.
         """
         ...
 
@@ -193,6 +207,8 @@ class MovementSensor(ComponentBase):
 
         Returns:
             MovementSensor.Properties: The properties
+
+        For more information, see `Movement Sensor component <https://docs.viam.com/components/movement-sensor/>`_.
         """
         ...
 
@@ -210,6 +226,8 @@ class MovementSensor(ComponentBase):
 
         Returns:
             MovementSensor.Accuracy: The accuracies of the movement sensor
+
+        For more information, see `Movement Sensor component <https://docs.viam.com/components/movement-sensor/>`_.
         """
         ...
 
@@ -229,5 +247,7 @@ class MovementSensor(ComponentBase):
 
         Returns:
             Mapping[str, Any]: The readings for the MovementSensor. Can be of any type.
+
+        For more information, see `Movement Sensor component <https://docs.viam.com/components/movement-sensor/>`_.
         """
         ...

--- a/src/viam/components/power_sensor/power_sensor.py
+++ b/src/viam/components/power_sensor/power_sensor.py
@@ -15,6 +15,8 @@ class PowerSensor(ComponentBase):
     ::
 
         from viam.components.power_sensor import PowerSensor
+
+    For more information, see `Power Sensor component <https://docs.viam.com/components/power-sensor/>`_.
     """
 
     SUBTYPE: Final = Subtype(  # pyright: ignore [reportIncompatibleVariableOverride]
@@ -36,6 +38,8 @@ class PowerSensor(ComponentBase):
         Returns:
             Tuple[float, bool]: A float representing the voltage reading in V. A bool indicating whether the voltage is AC (`true`) or DC
             (`false`).
+
+        For more information, see `Power Sensor component <https://docs.viam.com/components/power-sensor/>`_.
         """
         ...
 
@@ -54,6 +58,8 @@ class PowerSensor(ComponentBase):
         Returns:
             Tuple[float, bool]: A tuple which includes a float representing the current reading in amps, and a bool indicating whether the
             current is AC (`true`) or DC (`false`).
+
+        For more information, see `Power Sensor component <https://docs.viam.com/components/power-sensor/>`_.
         """
         ...
 
@@ -71,6 +77,8 @@ class PowerSensor(ComponentBase):
 
         Returns:
             float: The power reading in watts.
+
+        For more information, see `Power Sensor component <https://docs.viam.com/components/power-sensor/>`_.
         """
         ...
 
@@ -90,5 +98,7 @@ class PowerSensor(ComponentBase):
         Returns:
             Mapping[str, Any]: The readings for the PowerSensor. Can be of any type. Includes voltage in volts (float), current in
                 amperes (float), is_ac (bool), and power in watts (float).
+
+        For more information, see `Power Sensor component <https://docs.viam.com/components/power-sensor/>`_.
         """
         ...

--- a/src/viam/components/sensor/sensor.py
+++ b/src/viam/components/sensor/sensor.py
@@ -18,6 +18,8 @@ class Sensor(ComponentBase):
     ::
 
         from viam.components.sensor import Sensor
+
+    For more information, see `Sensor component <https://docs.viam.com/components/sensor/>`_.
     """
 
     SUBTYPE: Final = Subtype(  # pyright: ignore [reportIncompatibleVariableOverride]
@@ -40,5 +42,7 @@ class Sensor(ComponentBase):
 
         Returns:
             Mapping[str, Any]: The measurements. Can be of any type.
+
+        For more information, see `Sensor component <https://docs.viam.com/components/sensor/>`_.
         """
         ...

--- a/src/viam/components/servo/servo.py
+++ b/src/viam/components/servo/servo.py
@@ -17,6 +17,8 @@ class Servo(ComponentBase):
     ::
 
         from viam.components.servo import Servo
+
+    For more information, see `Servo component <https://docs.viam.com/components/servo/>`_.
     """
 
     SUBTYPE: Final = Subtype(  # pyright: ignore [reportIncompatibleVariableOverride]
@@ -40,6 +42,8 @@ class Servo(ComponentBase):
 
         Args:
             angle (int): The desired angle of the servo in degrees.
+
+        For more information, see `Servo component <https://docs.viam.com/components/servo/>`_.
         """
         ...
 
@@ -66,6 +70,8 @@ class Servo(ComponentBase):
 
         Returns:
             int: The current angle of the servo in degrees.
+
+        For more information, see `Servo component <https://docs.viam.com/components/servo/>`_.
         """
         ...
 
@@ -83,6 +89,8 @@ class Servo(ComponentBase):
 
             # Stop the servo. It is assumed that the servo stops moving immediately.
             await my_servo.stop()
+
+        For more information, see `Servo component <https://docs.viam.com/components/servo/>`_.
         """
         ...
 
@@ -100,5 +108,7 @@ class Servo(ComponentBase):
 
         Returns:
             bool: Whether the servo is moving.
+
+        For more information, see `Servo component <https://docs.viam.com/components/servo/>`_.
         """
         ...


### PR DESCRIPTION
A while ago Eliot asked us to add links back to the main docs from the SDK docs from each method (making it easy to move back and forth). This PR accomplishes that for components. We'll do services and other APIs separate. Open to changes on wording.

<img width="813" alt="Screenshot 2024-06-18 at 13 40 35" src="https://github.com/viamrobotics/viam-python-sdk/assets/5212232/8fa45675-d186-4c28-98c1-d6a95ad2f15a">
