### PR TITLE
RSDK-7933 fix logging bugs

### DIFF
--- a/src/viam/logging.py
+++ b/src/viam/logging.py
@@ -43,7 +43,7 @@ class _ModuleHandler(logging.Handler):
     def emit(self, record: logging.LogRecord):
         assert isinstance(record, logging.LogRecord)
         name = record.name.split(".")[-1]
-        message = f"{record.filename}:{record.lineno}\t{record.msg}"
+        message = f"{record.filename}:{record.lineno}\t{record.getMessage()}"
         stack = f"exc_info: {record.exc_info}, exc_text: {record.exc_text}, stack_info: {record.stack_info}"
         time = datetime.fromtimestamp(record.created)
 

--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -793,7 +793,7 @@ class RobotClient:
     # LOG #
     #######
 
-    async def log(self, name: str, level: str, time: datetime, log: str, stack: str):
+    async def log(self, name: str, level: str, time: datetime, message: str, stack: str):
         """Send log from Python module over gRPC.
 
         Create a LogEntry object from the log to send to RDK.
@@ -802,12 +802,12 @@ class RobotClient:
             name (str): The logger's name.
             level (str): The level of the log.
             time (datetime): The log creation time.
-            log (str): The log message.
+            message (str): The log message.
             stack (str): The stack information of the log.
 
         For more information, see `Machine Management API <https://docs.viam.com/appendix/apis/robot/>`_.
         """
-        entry = LogEntry(level=level, time=datetime_to_timestamp(time), logger_name=name, message=log, stack=stack)
+        entry = LogEntry(level=level, time=datetime_to_timestamp(time), logger_name=name, message=message, stack=stack)
         request = LogRequest(logs=[entry])
         await self._client.Log(request)
 


### PR DESCRIPTION
[Jira Ticket](https://viam.atlassian.net/browse/RSDK-7933)

fixed a bug where formatting logs with arguments did not work.

FLYBY: renamed the `log` method parameter `log` to `message` to keep it consistent with the RDK and the `ModuleHandler`.