### PR TITLE
Unify get_pose code sample

### DIFF
--- a/src/viam/services/motion/client.py
+++ b/src/viam/services/motion/client.py
@@ -427,14 +427,15 @@ class MotionClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
         timeout: Optional[float] = None,
     ) -> PoseInFrame:
         """
-        Get the Pose and observer frame for any given component on a robot. A ``component_name`` can be created like this::
-
-            component_name = Arm.get_resource_name("arm")
-
-        Note that the example uses the ``Arm`` class, but any component class that inherits from ``ComponentBase`` will work
-        (``Base``, ``Gripper``, etc).
+        Get the Pose and observer frame for any given component on a robot.
 
         ::
+
+            # Note that the example uses the ``Arm`` class, but any component class that inherits from ``ComponentBase`` will work
+            # (``Base``, ``Gripper``, etc).
+
+            # Create a `component_name`:
+            component_name = Arm.get_resource_name("arm")
 
             from viam.components.gripper import Gripper
             from viam.services.motion import MotionClient


### PR DESCRIPTION
Separate method description from code sample, merge code sample into one code block. Required for docs to process this sample: all in one code sample. Thank you. This only changes how this method appears in the rendered documentation. Looks good there. No code changes.

![Screenshot 2024-07-08 at 14 26 50](https://github.com/viamrobotics/viam-python-sdk/assets/132301587/53b6c432-d602-4551-981b-7c854c1ebf28)
