### PR TITLE
[RSDK-8126]: Update fragment methods to use fragment visibility

### DIFF
--- a/src/viam/app/app_client.py
+++ b/src/viam/app/app_client.py
@@ -1642,7 +1642,7 @@ class AppClient:
         Args:
             org_id (str): The ID of the organization to list fragments for.
                 You can obtain your organization ID from the Viam app's organization settings page.
-            show_public (bool): **Deprecated**: Use visibilities instead. Optional boolean specifying whether or not to only show public
+            show_public (bool): **Deprecated**: Use ``visibilities`` instead. Optional boolean specifying whether or not to only show public
                 fragments. If True, only public fragments will return. If False, only private fragments will return. Defaults to True.
                 .. deprecated:: 0.25.0
                     Use ``visiblities`` instead.
@@ -1734,7 +1734,7 @@ class AppClient:
             name (str): New name to associate with the fragment.
             config (Optional[Mapping[str, Any]]): Optional Dictionary representation of new config to assign to specified fragment. Not
                 passing this parameter will leave the fragment's config unchanged.
-            public (bool): **Deprecated**: Use visibility instead. Boolean specifying whether the fragment is public. Not passing this parameter
+            public (bool): **Deprecated**: Use ``visibility`` instead. Boolean specifying whether the fragment is public. Not passing this parameter
                 will leave the fragment's visibility unchanged. A fragment is private by default when created.
                 .. deprecated:: 0.25.0
                 Use ``visibility`` instead.

--- a/src/viam/app/app_client.py
+++ b/src/viam/app/app_client.py
@@ -1642,10 +1642,12 @@ class AppClient:
         Args:
             org_id (str): The ID of the organization to list fragments for.
                 You can obtain your organization ID from the Viam app's organization settings page.
-            visibilities: List of FragmentVisibilities specifying which types of fragments to include in the results.
-                If empty, by default only public fragments will be returned.
-            show_public: Deprecated: use visibilities instead. Optional boolean specifying whether or not to only show public
+            show_public (bool): **Deprecated**: Use visibilities instead. Optional boolean specifying whether or not to only show public
                 fragments. If True, only public fragments will return. If False, only private fragments will return. Defaults to True.
+                .. deprecated:: 0.25.0
+                    Use ``visiblities`` instead.
+            visibilities (Optional[List[Fragment.Visibility]]): List of FragmentVisibilities specifying which types of fragments to include in the results.
+                If empty, by default only public fragments will be returned.
 
         Returns:
             List[viam.app.app_client.Fragment]: The list of fragments.
@@ -1732,11 +1734,13 @@ class AppClient:
             name (str): New name to associate with the fragment.
             config (Optional[Mapping[str, Any]]): Optional Dictionary representation of new config to assign to specified fragment. Not
                 passing this parameter will leave the fragment's config unchanged.
+            public (bool): **Deprecated**: Use visibility instead. Boolean specifying whether the fragment is public. Not passing this parameter
+                will leave the fragment's visibility unchanged. A fragment is private by default when created.
+                .. deprecated:: 0.25.0
+                Use ``visibility`` instead.
             visibility (Optional[FragmentVisibility]): Optional FragmentVisibility list specifying who should be allowed
                 to view the fragment. Not passing this parameter will leave the fragment's visibility unchanged.
                 A fragment is private by default when created.
-            public (bool): Deprecated: use visibility instead. Boolean specifying whether the fragment is public. Not passing this parameter
-                will leave the fragment's visibility unchanged. A fragment is private by default when created.
 
         Raises:
             GRPCError: if an invalid ID, name, or config is passed.

--- a/src/viam/app/app_client.py
+++ b/src/viam/app/app_client.py
@@ -1644,6 +1644,7 @@ class AppClient:
                 You can obtain your organization ID from the Viam app's organization settings page.
             show_public (bool): **Deprecated**: Use ``visibilities`` instead. Optional boolean specifying whether or not to only show public
                 fragments. If True, only public fragments will return. If False, only private fragments will return. Defaults to True.
+
                 .. deprecated:: 0.25.0
                     Use ``visiblities`` instead.
             visibilities (Optional[List[Fragment.Visibility]]): List of FragmentVisibilities specifying which types of fragments to include
@@ -1736,8 +1737,9 @@ class AppClient:
                 passing this parameter will leave the fragment's config unchanged.
             public (bool): **Deprecated**: Use ``visibility`` instead. Boolean specifying whether the fragment is public. Not passing this
                 parameter will leave the fragment's visibility unchanged. A fragment is private by default when created.
+
                 .. deprecated:: 0.25.0
-                Use ``visibility`` instead.
+                    Use ``visibility`` instead.
             visibility (Optional[FragmentVisibility]): Optional FragmentVisibility list specifying who should be allowed
                 to view the fragment. Not passing this parameter will leave the fragment's visibility unchanged.
                 A fragment is private by default when created.

--- a/src/viam/app/app_client.py
+++ b/src/viam/app/app_client.py
@@ -1646,8 +1646,8 @@ class AppClient:
                 fragments. If True, only public fragments will return. If False, only private fragments will return. Defaults to True.
                 .. deprecated:: 0.25.0
                     Use ``visiblities`` instead.
-            visibilities (Optional[List[Fragment.Visibility]]): List of FragmentVisibilities specifying which types of fragments to include in the results.
-                If empty, by default only public fragments will be returned.
+            visibilities (Optional[List[Fragment.Visibility]]): List of FragmentVisibilities specifying which types of fragments to include
+                in the results. If empty, by default only public fragments will be returned.
 
         Returns:
             List[viam.app.app_client.Fragment]: The list of fragments.
@@ -1734,8 +1734,8 @@ class AppClient:
             name (str): New name to associate with the fragment.
             config (Optional[Mapping[str, Any]]): Optional Dictionary representation of new config to assign to specified fragment. Not
                 passing this parameter will leave the fragment's config unchanged.
-            public (bool): **Deprecated**: Use ``visibility`` instead. Boolean specifying whether the fragment is public. Not passing this parameter
-                will leave the fragment's visibility unchanged. A fragment is private by default when created.
+            public (bool): **Deprecated**: Use ``visibility`` instead. Boolean specifying whether the fragment is public. Not passing this
+                parameter will leave the fragment's visibility unchanged. A fragment is private by default when created.
                 .. deprecated:: 0.25.0
                 Use ``visibility`` instead.
             visibility (Optional[FragmentVisibility]): Optional FragmentVisibility list specifying who should be allowed

--- a/src/viam/app/app_client.py
+++ b/src/viam/app/app_client.py
@@ -1646,7 +1646,7 @@ class AppClient:
                 fragments. If True, only public fragments will return. If False, only private fragments will return. Defaults to True.
 
                 .. deprecated:: 0.25.0
-                    Use ``visiblities`` instead.
+                    Use ``visibilities`` instead.
             visibilities (Optional[List[Fragment.Visibility]]): List of FragmentVisibilities specifying which types of fragments to include
                 in the results. If empty, by default only public fragments will be returned.
 

--- a/src/viam/app/app_client.py
+++ b/src/viam/app/app_client.py
@@ -1726,8 +1726,9 @@ class AppClient:
             name (str): New name to associate with the fragment.
             config (Optional[Mapping[str, Any]]): Optional Dictionary representation of new config to assign to specified fragment. Not
                 passing this parameter will leave the fragment's config unchanged.
-            visibility (Optional[FragmentVisibility]): Optional FragmentVisibility list specifying who should be allowed to view the fragment.
-                Not passing this parameter will leave the fragment's visibility unchanged. A fragment is private by default when created.
+            visibility (Optional[FragmentVisibility]): Optional FragmentVisibility list specifying who should be allowed
+                to view the fragment. Not passing this parameter will leave the fragment's visibility unchanged.
+                A fragment is private by default when created.
 
         Raises:
             GRPCError: if an invalid ID, name, or config is passed.

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -1481,7 +1481,7 @@ class MockApp(UnimplementedAppServiceBase):
     async def ListFragments(self, stream: Stream[ListFragmentsRequest, ListFragmentsResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        self.show_public = request.show_public
+        self.fragment_visibility = request.fragment_visibility
         await stream.send_message(ListFragmentsResponse(fragments=[self.fragment]))
 
     async def GetFragment(self, stream: Stream[GetFragmentRequest, GetFragmentResponse]) -> None:

--- a/tests/test_app_client.py
+++ b/tests/test_app_client.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import pytest
 from grpclib.testing import ChannelFor
 
-from viam.app.app_client import APIKeyAuthorization, AppClient
+from viam.app.app_client import APIKeyAuthorization, AppClient, FragmentVisibility, FragmentVisibilityPB
 from viam.proto.app import (
     APIKey,
     APIKeyWithAuthorizations,
@@ -103,7 +103,8 @@ STACK = "stack"
 LOG_ENTRY = LogEntry(host=HOST, level=LEVEL, time=TIME, logger_name=LOGGER_NAME, message=MESSAGE, caller=None, stack=STACK, fields=None)
 LOG_ENTRIES = [LOG_ENTRY]
 ROBOT_CONFIG = {"key": "value"}
-SHOW_PUBLIC = True
+FRAGMENT_VISIBILITY = [FragmentVisibility.PUBLIC]
+FRAGMENT_VISIBILITY_PB = [FragmentVisibilityPB.FRAGMENT_VISIBILITY_PUBLIC]
 ORGANIZATION_OWNER = "organization_owner"
 PUBLIC = True
 ORGANIZATION_NAME = "organization_name"
@@ -596,8 +597,8 @@ class TestClient:
     async def test_list_fragments(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            fragments = await client.list_fragments(org_id=ID, show_public=SHOW_PUBLIC)
-            assert service.show_public == SHOW_PUBLIC
+            fragments = await client.list_fragments(org_id=ID, visibilities=FRAGMENT_VISIBILITY)
+            assert service.fragment_visibility == FRAGMENT_VISIBILITY_PB
             assert [fragment.proto for fragment in fragments] == [FRAGMENT]
 
     @pytest.mark.asyncio

--- a/tests/test_app_client.py
+++ b/tests/test_app_client.py
@@ -3,14 +3,14 @@ from datetime import datetime
 import pytest
 from grpclib.testing import ChannelFor
 
-from viam.app.app_client import APIKeyAuthorization, AppClient, FragmentVisibility, FragmentVisibilityPB
+from viam.app.app_client import APIKeyAuthorization, AppClient, Fragment, FragmentVisibilityPB
 from viam.proto.app import (
     APIKey,
     APIKeyWithAuthorizations,
     Authorization,
     AuthorizationDetails,
     AuthorizedPermissions,
-    Fragment,
+    Fragment as FragmentPB,
     Location,
     LocationAuth,
     Model,
@@ -103,13 +103,13 @@ STACK = "stack"
 LOG_ENTRY = LogEntry(host=HOST, level=LEVEL, time=TIME, logger_name=LOGGER_NAME, message=MESSAGE, caller=None, stack=STACK, fields=None)
 LOG_ENTRIES = [LOG_ENTRY]
 ROBOT_CONFIG = {"key": "value"}
-FRAGMENT_VISIBILITY = [FragmentVisibility.PUBLIC]
+FRAGMENT_VISIBILITY = [Fragment.Visibility.PUBLIC]
 FRAGMENT_VISIBILITY_PB = [FragmentVisibilityPB.FRAGMENT_VISIBILITY_PUBLIC]
 ORGANIZATION_OWNER = "organization_owner"
 PUBLIC = True
 ORGANIZATION_NAME = "organization_name"
 ONLY_USED_BY_OWNER = True
-FRAGMENT = Fragment(
+FRAGMENT = FragmentPB(
     id=ID,
     name=NAME,
     fragment=None,


### PR DESCRIPTION
Context: https://viaminc.slack.com/archives/C02KFSY4H89/p1720458747424109

This addresses the above issue a customer is facing. (In the meantime, Shawn has figured out a workaround) 

With unlisted fragment changes already present in app, we should be making use of `FragmentVisibility` rather than `Public`/`ShowPublic`, and in a future PR, any references to `Public`/`ShowPublic` will be removed entirely. 