### PR TITLE
chore: add homepage, repo, docs urls to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ description = "Viam Robotics Python SDK"
 authors = [ "Naveed <naveed@viam.com>" ]
 license = "Apache-2.0"
 readme = "README.md"
+homepage = "https://www.viam.com"
+repository = "https://github.com/viamrobotics/viam-python-sdk"
+documentation = "https://python.viam.dev"
 packages = [
   { include = "viam", from = "src" },
 ]


### PR DESCRIPTION
As a [request from Home Assistant maintainers](https://github.com/home-assistant/core/pull/117477#issuecomment-2129331354) and general package etiquette, I've added `homepage`, `repository`, and `documentation` links to the `pyproject.toml` to show up in the details of the PyPi page. 