### PR TITLE
chore: add i686 musllinux wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -29,6 +29,9 @@ jobs:
           - arch: musllinux_x86_64
             ext: so
             whl: musllinux_1_2_x86_64
+          - arch: musllinux_x86
+            ext: so
+            whl: musllinux_1_2_i686
           - arch: musllinux_aarch64
             ext: so
             whl: musllinux_1_2_aarch64


### PR DESCRIPTION
To support Home Assistant's core platforms, x86 (32bit, a.k.a i686/i586/i386) wheels are required. This PR adds that target with the corresponding libviam binary. 