### PR TITLE
DATA-2827 Removes lazy suffix from input mime type

### DIFF
--- a/src/viam/media/video.py
+++ b/src/viam/media/video.py
@@ -27,8 +27,8 @@ class CameraMimeType(str, Enum):
         Returns:
             Self: The mimetype
         """
-        value = value.removesuffix("+lazy")  # ViamImage does lazy encoding by default
-        return cls(value)
+        value_mime = value[:-5] if value.endswith("+lazy") else value  # ViamImage lazy encodes by default
+        return cls(value_mime)
 
     @classmethod
     def from_proto(cls, format: Format.ValueType) -> "CameraMimeType":

--- a/src/viam/media/video.py
+++ b/src/viam/media/video.py
@@ -27,7 +27,7 @@ class CameraMimeType(str, Enum):
         Returns:
             Self: The mimetype
         """
-        value = value.removesuffix("+lazy") # ViamImage does lazy encoding by default
+        value = value.removesuffix("+lazy")  # ViamImage does lazy encoding by default
         return cls(value)
 
     @classmethod

--- a/src/viam/media/video.py
+++ b/src/viam/media/video.py
@@ -19,6 +19,15 @@ class CameraMimeType(str, Enum):
 
     @classmethod
     def from_string(cls, value: str) -> Self:
+        """Return the mimetype from a string.
+
+        Args:
+            value (str): The mimetype as a string
+
+        Returns:
+            Self: The mimetype
+        """
+        value = value.removesuffix("+lazy") # ViamImage does lazy encoding by default
         return cls(value)
 
     @classmethod


### PR DESCRIPTION
Sometimes RDK will append +lazy to the mime type string to specify it as a lazy encoded image. 
Python SDK doesn't require this, as all images are default lazy encoded, and also +lazy will cause an error of 
```
ValueError - 'image/jpeg+lazy' is not a valid CameraMimeType - file_name='enum.py' func_name='__new__' line_num=702
```
Just checking for the +lazy suffix and removing it is enough to solve this issue

