### PR TITLE
RSDK-8341: log on main thread

### DIFF
--- a/src/viam/logging.py
+++ b/src/viam/logging.py
@@ -86,7 +86,7 @@ class _ColorFormatter(logging.Formatter):
 
 
 def getLogger(name: str) -> logging.Logger:
-    # If creating a thread with a logger, this function should be called outside of or in the `__init__()` of the thread.
+    # Warning: unstable if invoked in a different thread than that of the module. We recommend initializing the logger in the main module thread, then passing it as an argument to any child threads.
     logger = LOGGERS.get(name)
     if logger:
         return logger

--- a/src/viam/logging.py
+++ b/src/viam/logging.py
@@ -87,7 +87,8 @@ class _ColorFormatter(logging.Formatter):
 
 
 def getLogger(name: str) -> logging.Logger:
-    # Warning: unstable if invoked in a different thread than that of the module. We recommend initializing the logger in the main module thread, then passing it as an argument to any child threads.
+    # Warning: unstable if invoked in a different thread than that of the module. We recommend initializing the logger in the main module
+    # thread, then passing it as an argument to any child threads.
     logger = LOGGERS.get(name)
     if logger:
         return logger

--- a/src/viam/logging.py
+++ b/src/viam/logging.py
@@ -86,6 +86,7 @@ class _ColorFormatter(logging.Formatter):
 
 
 def getLogger(name: str) -> logging.Logger:
+    # If creating a thread with a logger, this function should be called outside of or in the `__init__()` of the thread.
     logger = LOGGERS.get(name)
     if logger:
         return logger

--- a/src/viam/logging.py
+++ b/src/viam/logging.py
@@ -32,6 +32,7 @@ class _ModuleHandler(logging.Handler):
         try:
             self.loop = asyncio.get_event_loop()
         except RuntimeError:
+            self._logger.warn("Created an event loop from a new thread. We recommend initializing loggers in the main module thread.")
             # If the log is coming from a thread that doesn't have an event loop, create and set a new one.
             self.loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self.loop)

--- a/src/viam/logging.py
+++ b/src/viam/logging.py
@@ -4,6 +4,7 @@ import sys
 from copy import copy
 from datetime import datetime
 from logging import DEBUG, ERROR, FATAL, INFO, WARN, WARNING  # noqa: F401
+from threading import Thread, Lock
 from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Union
 
 from grpclib.exceptions import StreamTerminatedError
@@ -19,16 +20,54 @@ LOGGERS: Dict[str, logging.Logger] = {}
 _MODULE_PARENT: Optional["RobotClient"] = None
 
 
+class SingletonEventLoopThread:
+    _instance = None
+    _lock = Lock()
+    _ready_event = asyncio.Event()
+    _thread = None
+
+    def __new__(cls):
+        # Ensure singleton precondition
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super(SingletonEventLoopThread, cls).__new__(cls)
+                    cls._instance._loop = None
+                    cls._instance._thread = Thread(target=cls._instance._run)
+                    cls._instance._thread.start()
+        return cls._instance
+
+    def _run(self):
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        self._ready_event.set()
+        self._loop.run_forever()
+
+    def stop(self):
+        if self._loop is not None:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            self._loop.close()
+
+    def get_loop(self):
+        if self._loop is None:
+            raise RuntimeError("Event loop is None. Did you call .start() and .wait_until_ready?")
+        return self._loop
+
+    async def wait_until_ready(self):
+        await self._ready_event.wait()
+
+
 class _ModuleHandler(logging.Handler):
     _parent: "RobotClient"
     _logger: logging.Logger
 
     def __init__(self, parent: "RobotClient"):
+        super().__init__()
         self._parent = parent
         self._logger = logging.getLogger("ModuleLogger")
         addHandlers(self._logger, True)
-        super().__init__()
         self._logger.setLevel(self.level)
+        self._worker = SingletonEventLoopThread()
         try:
             self.loop = asyncio.get_event_loop()
         except RuntimeError:
@@ -41,7 +80,7 @@ class _ModuleHandler(logging.Handler):
         self._logger.setLevel(level)
         return super().setLevel(level)
 
-    def handle_task_result(self, task: asyncio.Task):
+    async def handle_task_result(self, task: asyncio.Task):
         try:
             _ = task.result()
         except (asyncio.CancelledError, asyncio.InvalidStateError, StreamTerminatedError):
@@ -55,14 +94,27 @@ class _ModuleHandler(logging.Handler):
         time = datetime.fromtimestamp(record.created)
 
         try:
-            assert self._parent is not None
-            self.loop.create_task(
-                self._parent.log(name, record.levelname, time, message, stack), name=f"{viam._TASK_PREFIX}-LOG-{record.created}"
-            ).add_done_callback(self.handle_task_result)
+            loop = self._worker.get_loop()
+            asyncio.run_coroutine_threadsafe(
+                self._asynchronously_emit(record, name, message, stack, time),
+                loop,
+            )
         except Exception as err:
             # If the module log fails, log using stdout/stderr handlers
             self._logger.error(f"ModuleLogger failed for {record.name} - {err}")
             self._logger.log(record.levelno, message)
+
+    async def _asynchronously_emit(self, record: logging.LogRecord, name: str, message: str, stack: str, time: datetime):
+        await self._worker.wait_until_ready()
+        task = self._worker.get_loop().create_task(
+            self._parent.log(name, record.levelname, time, message, stack),
+            name=f"{viam._TASK_PREFIX}-LOG-{record.created}",
+        )
+        task.add_done_callback(lambda t: asyncio.run_coroutine_threadsafe(self.handle_task_result(t), self._worker.get_loop()))
+
+    def close(self):
+        self._worker.stop()
+        super().close()
 
 
 class _ColorFormatter(logging.Formatter):
@@ -74,8 +126,8 @@ class _ColorFormatter(logging.Formatter):
         "CRITICAL": 41,  # white on red bg
     }
 
-    def __init__(self, patern):
-        logging.Formatter.__init__(self, patern)
+    def __init__(self, pattern):
+        logging.Formatter.__init__(self, pattern)
 
     def format(self, record):
         colored_record = copy(record)
@@ -87,8 +139,6 @@ class _ColorFormatter(logging.Formatter):
 
 
 def getLogger(name: str) -> logging.Logger:
-    # Warning: unstable if invoked in a different thread than that of the module. We recommend initializing the logger in the main module
-    # thread, then passing it as an argument to any child threads.
     logger = LOGGERS.get(name)
     if logger:
         return logger

--- a/src/viam/logging.py
+++ b/src/viam/logging.py
@@ -32,7 +32,7 @@ class _ModuleHandler(logging.Handler):
         try:
             self.loop = asyncio.get_event_loop()
         except RuntimeError:
-            self._logger.warn("Created an event loop from a new thread. We recommend initializing loggers in the main module thread.")
+            self._logger.warn("Creating an event loop from a new thread. We recommend initializing loggers in the main module thread.")
             # If the log is coming from a thread that doesn't have an event loop, create and set a new one.
             self.loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self.loop)

--- a/src/viam/logging.py
+++ b/src/viam/logging.py
@@ -4,7 +4,7 @@ import sys
 from copy import copy
 from datetime import datetime
 from logging import DEBUG, ERROR, FATAL, INFO, WARN, WARNING  # noqa: F401
-from threading import Thread, Lock
+from threading import Lock, Thread
 from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Union
 
 from grpclib.exceptions import StreamTerminatedError


### PR DESCRIPTION
[Jira ticket](https://viam.atlassian.net/browse/RSDK-8341)

If a user doesn't give their thread the time to log (i.e. the user is using a while loop), the logs will never show since the logs are never being awaited. This fix changes logs so that they are being printed in a separate thread, which means that logs aren't dependent on the users.

Tested using both our SDK's `complex_module` as well as @hexbabe 's [module](https://github.com/hexbabe/logs-in-thread-bug-repro).