### PR TITLE
RSDK-8440: fix license finder

### DIFF
--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -39,7 +39,5 @@ jobs:
 
       - name: Run license finder and capture output
         run: |
-          rm -rf ~/.local/share/virtualenvs
-          pipx install pipenv
-          pipenv --version
+          pip
           /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/license_finder-7.2.1/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -40,5 +40,5 @@ jobs:
 
       - name: Run license finder
         run: |
-          license_finder
-          echo "Exit code: $?"
+          /opt/hostedtoolcache/Ruby/*/x64/lib/ruby/gems/*/gems/license_finder-*/bin/license_finder_pip.py requirements.txt
+          poetry run license_finder --python-version=3

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11.5"
+          python-version: "3.11"
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -40,5 +40,4 @@ jobs:
 
       - name: Run license finder
         run: |
-          /opt/hostedtoolcache/Ruby/*/x64/lib/ruby/gems/*/gems/license_finder-*/bin/license_finder_pip.py requirements.txt
           license_finder

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -39,4 +39,4 @@ jobs:
 
       - name: Run license finder and capture output
         run: |
-          ./.gem/ruby/*/gems/license_finder-*/bin/license_finder_pip.py requirements.txt
+          /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/license_finder-7.2.1/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Run license finder
         run: |
           /opt/hostedtoolcache/Ruby/*/x64/lib/ruby/gems/*/gems/license_finder-*/bin/license_finder_pip.py requirements.txt
-          poetry run license_finder
+          license_finder

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -39,7 +39,4 @@ jobs:
 
       - name: Run license finder and capture output
         run: |
-          poetry run license_finder --python-version=3 > license_finder_output.txt 2>&1 || true
-
-      - name: Display output
-        run: cat license_finder_output.txt
+          ~/.gem/ruby/*/gems/license_finder-*/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -40,5 +40,5 @@ jobs:
 
       - name: Run license finder and capture output
         run: |
-          pip install six
+          pip install --upgrade pip==22.0.2
           /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/license_finder-7.2.1/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -39,5 +39,5 @@ jobs:
 
       - name: Run license finder and capture output
         run: |
-          pip --version
+          curl -sS https://bootstrap.pypa.io/get-pip.py | python3
           /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/license_finder-7.2.1/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11.5"
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -39,7 +39,4 @@ jobs:
 
       - name: Run license finder and capture output
         run: |
-          curl -sS https://bootstrap.pypa.io/get-pip.py | python3
-          sudo apt install python-six
-          echo $PATH
           /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/license_finder-7.2.1/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Run license finder
         run: |
           /opt/hostedtoolcache/Ruby/*/x64/lib/ruby/gems/*/gems/license_finder-*/bin/license_finder_pip.py requirements.txt
-          poetry run license_finder --python-version=3
+          license_finder

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11.5"
+          python-version: "3.12"
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.11.5"
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   license_finder:
-    # if: github.repository_owner == 'viamrobotics'
+    if: github.repository_owner == 'viamrobotics'
     name: Audit 3rd-Party Licenses
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -40,4 +40,4 @@ jobs:
 
       - name: Run license finder
         run: |
-          license_finder --python-version=3
+          /opt/hostedtoolcache/Ruby/*/x64/lib/ruby/gems/*/gems/license_finder-*/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -18,7 +18,6 @@ jobs:
 
       - name: Install Poetry
         run: |
-          pip install --upgrade pip==22.0.2
           pipx install poetry
 
       - name: Setup Python
@@ -41,4 +40,5 @@ jobs:
 
       - name: Run license finder and capture output
         run: |
+          pip install six
           /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/license_finder-7.2.1/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -40,5 +40,5 @@ jobs:
 
       - name: Run license finder and capture output
         run: |
-          pip install --upgrade pip==23.0.0
+          pip install --upgrade pip==9.0.3
           /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/license_finder-7.2.1/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -39,4 +39,5 @@ jobs:
 
       - name: Run license finder
         run: |
+          pipx install pipenv
           poetry run license_finder --python-version=3

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -39,5 +39,5 @@ jobs:
 
       - name: Run license finder
         run: |
-          poetry run license_finder --python-version=3
+          poetry run license_finder --python-version=3 --debug
           echo "Exit code: $?"

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -39,4 +39,4 @@ jobs:
 
       - name: Run license finder and capture output
         run: |
-          ~/.gem/ruby/*/gems/license_finder-*/bin/license_finder_pip.py requirements.txt
+          ./.gem/ruby/*/gems/license_finder-*/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -39,6 +39,5 @@ jobs:
 
       - name: Run license finder and capture output
         run: |
-          pip freeze
           pip install -r requirements.txt
-          /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/license_finder-7.2.1/bin/license_finder_pip.py requirements.txt
+          /opt/hostedtoolcache/Ruby/*/x64/lib/ruby/gems/*/gems/license_finder-*/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -39,5 +39,6 @@ jobs:
 
       - name: Run license finder and capture output
         run: |
-          pip install --upgrade pip==20.0.2
+          pyenv global 3.10.0
+          pip install pipenv
           /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/license_finder-7.2.1/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -40,4 +40,4 @@ jobs:
 
       - name: Run license finder
         run: |
-          python3 /opt/hostedtoolcache/Ruby/*/x64/lib/ruby/gems/*/gems/license_finder-*/bin/license_finder_pip.py requirements.txt
+          license_finder requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -40,5 +40,5 @@ jobs:
 
       - name: Run license finder and capture output
         run: |
-          pip install --upgrade pip==22.0.2
+          pip install --upgrade pip==23.0.0
           /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/license_finder-7.2.1/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -17,8 +17,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Poetry
-        run: |
-          pipx install poetry
+        run: pipx install poetry
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -40,5 +39,5 @@ jobs:
 
       - name: Run license finder and capture output
         run: |
-          pip install --upgrade pip==9.0.3
+          pip install --upgrade pip==20.0.2
           /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/license_finder-7.2.1/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11.5"
+          python-version: "3.11"
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -41,3 +41,4 @@ jobs:
       - name: Run license finder
         run: |
           license_finder
+          echo "Exit code: $?"

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -40,4 +40,4 @@ jobs:
 
       - name: Run license finder
         run: |
-          license_finder requirements.txt
+          license_finder

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -40,5 +40,4 @@ jobs:
 
       - name: Run license finder
         run: |
-          /opt/hostedtoolcache/Ruby/*/x64/lib/ruby/gems/*/gems/license_finder-*/bin/license_finder_pip.py requirements.txt
           license_finder

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Run license finder
         run: |
           /opt/hostedtoolcache/Ruby/*/x64/lib/ruby/gems/*/gems/license_finder-*/bin/license_finder_pip.py requirements.txt
-          license_finder
+          poetry run license_finder

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Generate requirements.txt (exclude dev dependencies)
         run: |
           poetry export -f requirements.txt --without-hashes > requirements.txt
-
-      - name: Run license finder and capture output
-        run: |
           pip install -r requirements.txt
+
+      - name: Run license finder
+        run: |
           /opt/hostedtoolcache/Ruby/*/x64/lib/ruby/gems/*/gems/license_finder-*/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -40,4 +40,5 @@ jobs:
       - name: Run license finder and capture output
         run: |
           curl -sS https://bootstrap.pypa.io/get-pip.py | python3
+          apt install python-six
           /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/license_finder-7.2.1/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11.5"
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -39,4 +39,6 @@ jobs:
 
       - name: Run license finder and capture output
         run: |
+          pip freeze
+          pip install -r requirements.txt
           /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/license_finder-7.2.1/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -39,5 +39,5 @@ jobs:
 
       - name: Run license finder
         run: |
-          pipx install pipenv
           poetry run license_finder --python-version=3
+          echo "Exit code: $?"

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -39,6 +39,5 @@ jobs:
 
       - name: Run license finder and capture output
         run: |
-          pyenv global 3.10.0
-          pip install pipenv
+          pipx install pipenv
           /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/license_finder-7.2.1/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.11.5"
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -40,4 +40,5 @@ jobs:
 
       - name: Run license finder
         run: |
+          /opt/hostedtoolcache/Ruby/*/x64/lib/ruby/gems/*/gems/license_finder-*/bin/license_finder_pip.py requirements.txt
           license_finder

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -37,7 +37,9 @@ jobs:
         run: |
           poetry export -f requirements.txt --without-hashes > requirements.txt
 
-      - name: Run license finder
+      - name: Run license finder and capture output
         run: |
-          poetry run license_finder --python-version=3 --debug
-          echo "Exit code: $?"
+          poetry run license_finder --python-version=3 > license_finder_output.txt 2>&1 || true
+
+      - name: Display output
+        run: cat license_finder_output.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -40,5 +40,6 @@ jobs:
       - name: Run license finder and capture output
         run: |
           curl -sS https://bootstrap.pypa.io/get-pip.py | python3
-          apt install python-six
+          sudo apt install python-six
+          echo $PATH
           /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/license_finder-7.2.1/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11.5"
+          python-version: "3.11"
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -17,7 +17,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Poetry
-        run: pipx install poetry
+        run: |
+          pip install --upgrade pip==22.0.2
+          pipx install poetry
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -40,4 +40,4 @@ jobs:
 
       - name: Run license finder
         run: |
-          /opt/hostedtoolcache/Ruby/*/x64/lib/ruby/gems/*/gems/license_finder-*/bin/license_finder_pip.py requirements.txt
+          python3 /opt/hostedtoolcache/Ruby/*/x64/lib/ruby/gems/*/gems/license_finder-*/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -39,5 +39,7 @@ jobs:
 
       - name: Run license finder and capture output
         run: |
+          rm -rf ~/.local/share/virtualenvs
           pipx install pipenv
+          pipenv --version
           /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/license_finder-7.2.1/bin/license_finder_pip.py requirements.txt

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11.5"
+          python-version: "3.11"
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -40,4 +40,4 @@ jobs:
 
       - name: Run license finder
         run: |
-          /opt/hostedtoolcache/Ruby/*/x64/lib/ruby/gems/*/gems/license_finder-*/bin/license_finder_pip.py requirements.txt
+          license_finder --python-version=3

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -39,5 +39,5 @@ jobs:
 
       - name: Run license finder and capture output
         run: |
-          pip
+          pip --version
           /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/license_finder-7.2.1/bin/license_finder_pip.py requirements.txt


### PR DESCRIPTION
Based on the available logs, this workflow has been failing for at least 3 months. Before that, the git logs have been removed, so we're not sure when the failure started.

`license_finder` has some issues with Python version 3.12, so now the workflow is using 3.11.5.
In the workflow, the command to run `license_finder` was changed so that errors fail the workflow instead of letting it succeed.

Things I tried that didn't work, wasn't the best solution, or introduced more errors:
- `pip install six` doesn't change anything
- `pip install pip==22.0` introduces another error
- `pip install pip==23.0` introduces another error
- `pip install pip==20.0.2` introduces another error
- `pip install pip==9.0.0` introduces another error
- `curl -sS https://bootstrap.pypa.io/get-pip.py | python3` doesn't change anything
- `python version 3.11` doesn't change anything
- `pip install pyenv` doesn't change anything
-  `/opt/hostedtoolcache/Ruby/*/x64/lib/ruby/gems/*/gems/license_finder-*/bin/license_finder_pip.py requirements.txt` doesn't actually run license_finder
- `poetry run license_finder --python-version=3` fails even after using python v3.11.5
- `poetry run license_finder` fails even after using python v3.11.5