### PR TITLE
docs(board): stream_ticks method should be awaited to return TickStream iterator

### DIFF
--- a/src/viam/components/board/board.py
+++ b/src/viam/components/board/board.py
@@ -437,7 +437,7 @@ class Board(ComponentBase):
             di11 = await my_board.digital_interrupt_by_name(name="11"))
 
             # Iterate over stream of ticks from pins 8 and 11.
-            async for tick in my_board.stream_ticks([di8, di11]):
+            async for tick in await my_board.stream_ticks([di8, di11]):
                 print(f"Pin {tick.pin_name} changed to {'high' if tick.high else 'low'} at {tick.time}")
 
 


### PR DESCRIPTION
The current example usage doc comment for the `stream_ticks` method demonstrates using an `async for` loop to process the stream of digital interrupt ticks without awaiting the method call, which is required to fulfill the coroutine and access the `TickStream` response. 