### PR TITLE
RSDK-8506-RSDK-8253: fix docs

### DIFF
--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -1143,7 +1143,7 @@ class DataClient:
         Args:
             tabular_data (List[Mapping[str, Any]]): List of the data to be uploaded, represented tabularly as a collection of dictionaries.
             part_id (str): Part ID of the component used to capture the data.
-            component_type (str): Type of the component used to capture the data (for example, "movement_sensor").
+            component_type (str): Type of the component used to capture the data (for example, "rdk:component:movement_sensor").
             component_name (str): Name of the component used to capture the data.
             method_name (str): Name of the method used to capture the data.
             data_request_times [List[Tuple[datetime.datetime, datetime.datetime]]]: List of tuples, each containing `datetime` objects

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -1116,9 +1116,9 @@ class DataClient:
         component_type: str,
         component_name: str,
         method_name: str,
+        data_request_times: List[Tuple[datetime, datetime]],
         method_parameters: Optional[Mapping[str, Any]] = None,
         tags: Optional[List[str]] = None,
-        data_request_times: Optional[List[Tuple[datetime, datetime]]] = None,
     ) -> str:
         """Upload tabular sensor data.
 

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -1146,7 +1146,7 @@ class DataClient:
             component_type (str): Type of the component used to capture the data (for example, "rdk:component:movement_sensor").
             component_name (str): Name of the component used to capture the data.
             method_name (str): Name of the method used to capture the data.
-            data_request_times [List[Tuple[datetime, datetime]]]: List of tuples, each containing `datetime` objects
+            data_request_times (List[Tuple[datetime.datetime, datetime.datetime]]): List of tuples, each containing `datetime` objects
                 denoting the times this data was requested[0] by the robot and received[1] from the appropriate sensor. Passing a list of
                 tabular data and Timestamps with length n > 1 will result in n datapoints being uploaded, all tied to the same metadata.
             method_parameters (Optional[Mapping[str, Any]]): Optional dictionary of method parameters. No longer in active use.

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -1132,7 +1132,7 @@ class DataClient:
 
             file_id = await data_client.tabular_data_capture_upload(
                 part_id="INSERT YOUR PART ID",
-                component_type='motor',
+                component_type='rdk:component:motor',
                 component_name='left_motor',
                 method_name='IsPowered',
                 tags=["tag_1", "tag_2"],
@@ -1164,9 +1164,8 @@ class DataClient:
         For more information, see `Data Client API <https://docs.viam.com/appendix/apis/data-client/>`_.
         """
         sensor_contents = []
-        if data_request_times:
-            if len(data_request_times) != len(tabular_data):
-                raise ValueError("data_request_times and tabular_data lengths must be equal.")
+        if len(data_request_times) != len(tabular_data):
+            raise ValueError("data_request_times and tabular_data lengths must be equal.")
 
         for idx, tab in enumerate(tabular_data):
             s = Struct()

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -1146,12 +1146,11 @@ class DataClient:
             component_type (str): Type of the component used to capture the data (for example, "movement_sensor").
             component_name (str): Name of the component used to capture the data.
             method_name (str): Name of the method used to capture the data.
+            data_request_times [List[Tuple[datetime.datetime, datetime.datetime]]]: List of tuples, each containing `datetime` objects
+                denoting the times this data was requested[0] by the robot and received[1] from the appropriate sensor. Passing a list of
+                tabular data and Timestamps with length n > 1 will result in n datapoints being uploaded, all tied to the same metadata.
             method_parameters (Optional[Mapping[str, Any]]): Optional dictionary of method parameters. No longer in active use.
             tags (Optional[List[str]]): Optional list of tags to allow for tag-based data filtering when retrieving data.
-            data_request_times (Optional[List[Tuple[datetime.datetime, datetime.datetime]]]): Optional list of tuples, each containing
-                `datetime` objects denoting the times this data was requested[0] by the robot and received[1] from the appropriate sensor.
-                Passing a list of tabular data and Timestamps with length n > 1 will result in n datapoints being uploaded, all tied to the
-                same metadata.
 
         Raises:
             GRPCError: If an invalid part ID is passed.

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -1146,7 +1146,7 @@ class DataClient:
             component_type (str): Type of the component used to capture the data (for example, "rdk:component:movement_sensor").
             component_name (str): Name of the component used to capture the data.
             method_name (str): Name of the method used to capture the data.
-            data_request_times [List[Tuple[datetime.datetime, datetime.datetime]]]: List of tuples, each containing `datetime` objects
+            data_request_times [List[Tuple[datetime, datetime]]]: List of tuples, each containing `datetime` objects
                 denoting the times this data was requested[0] by the robot and received[1] from the appropriate sensor. Passing a list of
                 tabular data and Timestamps with length n > 1 will result in n datapoints being uploaded, all tied to the same metadata.
             method_parameters (Optional[Mapping[str, Any]]): Optional dictionary of method parameters. No longer in active use.

--- a/src/viam/services/vision/vision.py
+++ b/src/viam/services/vision/vision.py
@@ -181,7 +181,7 @@ class Vision(ServiceBase):
             detections = await my_detector.get_detections(img)
 
         Args:
-            image (Image | RawImage): The image to get detections from
+            image (ViamImage): The image to get detections from
 
         Raises:
             ViamError: Raised if given an image without a specified width and height
@@ -254,7 +254,7 @@ class Vision(ServiceBase):
             classifications = await my_classifier.get_classifications(img, 2)
 
         Args:
-            image (Image | RawImage): The image to get detections from
+            image (ViamImage): The image to get detections from
             count (int): The number of classifications desired
 
         Returns:


### PR DESCRIPTION
[Data Jira ticket](https://viam.atlassian.net/browse/RSDK-8506)
[Vision Jira ticket](https://viam.atlassian.net/browse/RSDK-8253)

BREAKING CHANGE for anyone using `tabular_data_capture_upload` with positional arguments.
Apparently the function fails without the request times, so presumably there's no one successfully calling it without this argument.

Changes:
- `data_request_times` is no longer optional
- comment changes for `data_request_times` and `component_type`
- comment changes for `get_classifications` and `get_detections`

New docs for `tabular_data_capture_upload`:
<img width="710" alt="image" src="https://github.com/user-attachments/assets/cea79d76-15e1-4323-988b-562445835bbe">
<img width="693" alt="image" src="https://github.com/user-attachments/assets/2a9dd801-0ac0-46c7-9b09-7eea650779b1">
