### PR TITLE
RSDK-8684: modules hang on shutdown

### DIFF
--- a/src/viam/logging.py
+++ b/src/viam/logging.py
@@ -24,7 +24,7 @@ class _SingletonEventLoopThread:
     _instance = None
     _lock = Lock()
     _ready_event = asyncio.Event()
-    _loop: asyncio.AbstractEventLoop
+    _loop: Union[asyncio.AbstractEventLoop, None]
     _thread: Thread
 
     def __new__(cls):
@@ -33,6 +33,7 @@ class _SingletonEventLoopThread:
             with cls._lock:
                 if cls._instance is None:
                     cls._instance = super(_SingletonEventLoopThread, cls).__new__(cls)
+                    cls._instance._loop = None
                     cls._instance._thread = Thread(target=cls._instance._run)
                     cls._instance._thread.start()
         return cls._instance
@@ -47,6 +48,7 @@ class _SingletonEventLoopThread:
         if self._loop is not None and not self._loop.is_closed():
             # Stop the event loop only if it's still running
             self._loop.call_soon_threadsafe(self._loop.stop)
+            self._loop.close()
             self._thread.join()
 
     def get_loop(self):

--- a/src/viam/logging.py
+++ b/src/viam/logging.py
@@ -24,8 +24,8 @@ class _SingletonEventLoopThread:
     _instance = None
     _lock = Lock()
     _ready_event = asyncio.Event()
-    _loop: asyncio.AbstractEventLoop = None
-    _thread: Thread = None
+    _loop: asyncio.AbstractEventLoop
+    _thread: Thread
 
     def __new__(cls):
         # Ensure singleton precondition
@@ -33,7 +33,6 @@ class _SingletonEventLoopThread:
             with cls._lock:
                 if cls._instance is None:
                     cls._instance = super(_SingletonEventLoopThread, cls).__new__(cls)
-                    cls._instance._loop = None
                     cls._instance._thread = Thread(target=cls._instance._run)
                     cls._instance._thread.start()
         return cls._instance

--- a/src/viam/rpc/server.py
+++ b/src/viam/rpc/server.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import TYPE_CHECKING, Callable, List, Optional
 
 from grpclib import GRPCError, Status
@@ -112,7 +113,10 @@ class Server(ResourceManager):
             else:
                 await self._server.start(host, port)
                 LOGGER.info(f"Serving on {host}:{port}")
-            await self._server.wait_closed()
+            task = asyncio.create_task(self._server.wait_closed())
+            await self._server._server_closed_fut
+            logging.shutdown()
+            await task
             await self.close()
             LOGGER.debug("gRPC server closed")
 

--- a/src/viam/rpc/server.py
+++ b/src/viam/rpc/server.py
@@ -113,11 +113,14 @@ class Server(ResourceManager):
             else:
                 await self._server.start(host, port)
                 LOGGER.info(f"Serving on {host}:{port}")
+
+            # This has to be done for a bug in Python 3.12, where logger handlers hang on shutdown
             task = asyncio.create_task(self._server.wait_closed())
             if self._server._server_closed_fut is not None:
                 await self._server._server_closed_fut
             logging.shutdown()
             await task
+
             await self.close()
             LOGGER.debug("gRPC server closed")
 

--- a/src/viam/rpc/server.py
+++ b/src/viam/rpc/server.py
@@ -114,7 +114,8 @@ class Server(ResourceManager):
                 await self._server.start(host, port)
                 LOGGER.info(f"Serving on {host}:{port}")
             task = asyncio.create_task(self._server.wait_closed())
-            await self._server._server_closed_fut
+            if self._server._server_closed_fut is not None:
+                await self._server._server_closed_fut
             logging.shutdown()
             await task
             await self.close()


### PR DESCRIPTION
In Python 3.12.6, there is a bug that happens with the grpclib library, where log handlers are not closed correctly. The logs show that the process is killed instead of cleanly exited.

The bug also doesn't happen if the system is on earlier versions of the Python SDK (v0.23.0) or RDK (v0.27.0). Why this is is still unclear. Maybe it was because I did a `brew upgrade` and it upgraded other things other than the RDK, like the Python version? I doubt that it would change my Python version, but I'm confused as to how a bug introduced by a Python version is affected by the Python SDK and RDK version.

To fix this without changing the grpc library, we have to watch the awaited function `wait_closed()` for when to put in `logging.shutdown` manually.