### PR TITLE
RSDK-6169 - gRPC debugging client api

### DIFF
--- a/src/viam/components/arm/client.py
+++ b/src/viam/components/arm/client.py
@@ -39,12 +39,11 @@ class ArmClient(Arm, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Pose:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetEndPositionRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetEndPositionResponse = await self.client.GetEndPosition(request, timeout=timeout)
+        response: GetEndPositionResponse = await self.client.GetEndPosition(request, timeout=timeout, metadata=md)
         return response.pose
 
     async def move_to_position(
@@ -53,24 +52,22 @@ class ArmClient(Arm, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = MoveToPositionRequest(name=self.name, to=pose, extra=dict_to_struct(extra))
-        await self.client.MoveToPosition(request, timeout=timeout)
+        await self.client.MoveToPosition(request, timeout=timeout, metadata=md)
 
     async def get_joint_positions(
         self,
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> JointPositions:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetJointPositionsRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetJointPositionsResponse = await self.client.GetJointPositions(request, timeout=timeout)
+        response: GetJointPositionsResponse = await self.client.GetJointPositions(request, timeout=timeout, metadata=md)
         return response.positions
 
     async def move_to_joint_positions(
@@ -79,28 +76,27 @@ class ArmClient(Arm, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = MoveToJointPositionsRequest(name=self.name, positions=positions, extra=dict_to_struct(extra))
-        await self.client.MoveToJointPositions(request, timeout=timeout)
+        await self.client.MoveToJointPositions(request, timeout=timeout, metadata=md)
 
     async def stop(
         self,
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = StopRequest(name=self.name, extra=dict_to_struct(extra))
-        await self.client.Stop(request, timeout=timeout)
+        await self.client.Stop(request, timeout=timeout, metadata=md)
 
-    async def is_moving(self, *, timeout: Optional[float] = None) -> bool:
+    async def is_moving(self, *, timeout: Optional[float] = None, **kwargs) -> bool:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = IsMovingRequest(name=self.name)
-        response: IsMovingResponse = await self.client.IsMoving(request, timeout=timeout)
+        response: IsMovingResponse = await self.client.IsMoving(request, timeout=timeout, metadata=md)
         return response.is_moving
 
     async def do_command(
@@ -108,20 +104,21 @@ class ArmClient(Arm, ReconfigurableResourceRPCClientBase):
         command: Mapping[str, Any],
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Mapping[str, ValueTypes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         return struct_to_dict(response.result)
 
     async def get_kinematics(
-        self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None
+        self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs
     ) -> Tuple[KinematicsFileFormat.ValueType, bytes]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetKinematicsRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetKinematicsResponse = await self.client.GetKinematics(request, timeout=timeout)
+        response: GetKinematicsResponse = await self.client.GetKinematics(request, timeout=timeout, metadata=md)
         return (response.format, response.kinematics_data)
 
-    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[Geometry]:
-        return await get_geometries(self.client, self.name, extra, timeout)
+    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[Geometry]:
+        md = kwargs.get('metadata', self.Metadata())
+        return await get_geometries(self.client, self.name, extra, timeout, md)

--- a/src/viam/components/base/client.py
+++ b/src/viam/components/base/client.py
@@ -38,17 +38,16 @@ class BaseClient(Base, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = MoveStraightRequest(
             name=self.name,
             distance_mm=distance,
             mm_per_sec=velocity,
             extra=dict_to_struct(extra),
         )
-        await self.client.MoveStraight(request, timeout=timeout)
+        await self.client.MoveStraight(request, timeout=timeout, metadata=md)
 
     async def spin(
         self,
@@ -57,17 +56,16 @@ class BaseClient(Base, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = SpinRequest(
             name=self.name,
             angle_deg=angle,
             degs_per_sec=velocity,
             extra=dict_to_struct(extra),
         )
-        await self.client.Spin(request, timeout=timeout)
+        await self.client.Spin(request, timeout=timeout, metadata=md)
 
     async def set_power(
         self,
@@ -76,17 +74,16 @@ class BaseClient(Base, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = SetPowerRequest(
             name=self.name,
             linear=linear,
             angular=angular,
             extra=dict_to_struct(extra),
         )
-        await self.client.SetPower(request, timeout=timeout)
+        await self.client.SetPower(request, timeout=timeout, metadata=md)
 
     async def set_velocity(
         self,
@@ -95,33 +92,32 @@ class BaseClient(Base, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = SetVelocityRequest(name=self.name, linear=linear, angular=angular, extra=dict_to_struct(extra))
-        await self.client.SetVelocity(request, timeout=timeout)
+        await self.client.SetVelocity(request, timeout=timeout, metadata=md)
 
     async def stop(
         self,
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = StopRequest(name=self.name, extra=dict_to_struct(extra))
-        await self.client.Stop(request, timeout=timeout)
+        await self.client.Stop(request, timeout=timeout, metadata=md)
 
     async def is_moving(
         self,
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> bool:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = IsMovingRequest(name=self.name)
-        response: IsMovingResponse = await self.client.IsMoving(request, timeout=timeout)
+        response: IsMovingResponse = await self.client.IsMoving(request, timeout=timeout, metadata=md)
         return response.is_moving
 
     async def get_properties(
@@ -129,12 +125,11 @@ class BaseClient(Base, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Base.Properties:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetPropertiesRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetPropertiesResponse = await self.client.GetProperties(request, timeout=timeout)
+        response: GetPropertiesResponse = await self.client.GetProperties(request, timeout=timeout, metadata=md)
         return Base.Properties(
             width_meters=response.width_meters,
             turning_radius_meters=response.turning_radius_meters,
@@ -146,11 +141,13 @@ class BaseClient(Base, ReconfigurableResourceRPCClientBase):
         command: Mapping[str, ValueTypes],
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Mapping[str, ValueTypes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         return struct_to_dict(response.result)
 
-    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[Geometry]:
-        return await get_geometries(self.client, self.name, extra, timeout)
+    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[Geometry]:
+        md = kwargs.get('metadata', self.Metadata())
+        return await get_geometries(self.client, self.name, extra, timeout, md)

--- a/src/viam/components/board/client.py
+++ b/src/viam/components/board/client.py
@@ -46,12 +46,11 @@ class AnalogClient(Board.Analog):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Board.Analog.Value:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = ReadAnalogReaderRequest(board_name=self.board.name, analog_reader_name=self.name, extra=dict_to_struct(extra))
-        return await self.board.client.ReadAnalogReader(request, timeout=timeout)
+        return await self.board.client.ReadAnalogReader(request, timeout=timeout, metadata=md)
 
     async def write(
         self,
@@ -61,10 +60,9 @@ class AnalogClient(Board.Analog):
         timeout: Optional[float] = None,
         **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = WriteAnalogRequest(name=self.board.name, pin=self.name, value=value, extra=dict_to_struct(extra))
-        await self.board.client.WriteAnalog(request, timeout=timeout)
+        await self.board.client.WriteAnalog(request, timeout=timeout, metadata=md)
 
 
 class DigitalInterruptClient(Board.DigitalInterrupt):
@@ -77,12 +75,11 @@ class DigitalInterruptClient(Board.DigitalInterrupt):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> int:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetDigitalInterruptValueRequest(board_name=self.board.name, digital_interrupt_name=self.name, extra=dict_to_struct(extra))
-        response: GetDigitalInterruptValueResponse = await self.board.client.GetDigitalInterruptValue(request, timeout=timeout)
+        response: GetDigitalInterruptValueResponse = await self.board.client.GetDigitalInterruptValue(request, timeout=timeout, metadata=md)
         return response.value
 
 
@@ -96,12 +93,11 @@ class GPIOPinClient(Board.GPIOPin):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> bool:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetGPIORequest(name=self.board.name, pin=self.name, extra=dict_to_struct(extra))
-        response: GetGPIOResponse = await self.board.client.GetGPIO(request, timeout=timeout)
+        response: GetGPIOResponse = await self.board.client.GetGPIO(request, timeout=timeout, metadata=md)
         return response.high
 
     async def set(
@@ -110,24 +106,22 @@ class GPIOPinClient(Board.GPIOPin):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = SetGPIORequest(name=self.board.name, pin=self.name, high=high, extra=dict_to_struct(extra))
-        await self.board.client.SetGPIO(request, timeout=timeout)
+        await self.board.client.SetGPIO(request, timeout=timeout, metadata=md)
 
     async def get_pwm(
         self,
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> float:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = PWMRequest(name=self.board.name, pin=self.name, extra=dict_to_struct(extra))
-        response: PWMResponse = await self.board.client.PWM(request, timeout=timeout)
+        response: PWMResponse = await self.board.client.PWM(request, timeout=timeout, metadata=md)
         return response.duty_cycle_pct
 
     async def set_pwm(
@@ -136,24 +130,22 @@ class GPIOPinClient(Board.GPIOPin):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = SetPWMRequest(name=self.board.name, pin=self.name, duty_cycle_pct=duty_cycle, extra=dict_to_struct(extra))
-        await self.board.client.SetPWM(request, timeout=timeout)
+        await self.board.client.SetPWM(request, timeout=timeout, metadata=md)
 
     async def get_pwm_frequency(
         self,
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> int:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = PWMFrequencyRequest(name=self.board.name, pin=self.name, extra=dict_to_struct(extra))
-        response: PWMFrequencyResponse = await self.board.client.PWMFrequency(request, timeout=timeout)
+        response: PWMFrequencyResponse = await self.board.client.PWMFrequency(request, timeout=timeout, metadata=md)
         return response.frequency_hz
 
     async def set_pwm_frequency(
@@ -162,12 +154,11 @@ class GPIOPinClient(Board.GPIOPin):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = SetPWMFrequencyRequest(name=self.board.name, pin=self.name, frequency_hz=frequency, extra=dict_to_struct(extra))
-        await self.board.client.SetPWMFrequency(request, timeout=timeout)
+        await self.board.client.SetPWMFrequency(request, timeout=timeout, metadata=md)
 
 
 class BoardClient(Board, ReconfigurableResourceRPCClientBase):
@@ -211,10 +202,11 @@ class BoardClient(Board, ReconfigurableResourceRPCClientBase):
         command: Mapping[str, ValueTypes],
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Mapping[str, ValueTypes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         return struct_to_dict(response.result)
 
     async def set_power_mode(
@@ -223,15 +215,17 @@ class BoardClient(Board, ReconfigurableResourceRPCClientBase):
         duration: Optional[timedelta] = None,
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
+        md = kwargs.get('metadata', self.Metadata()).proto
         duration_pb: Optional[Duration] = None
         if duration is not None:
             duration_pb = [(d, d.FromTimedelta(duration)) for d in [Duration()]][0][0]
         request = SetPowerModeRequest(name=self.name, power_mode=mode, duration=duration_pb)
-        await self.client.SetPowerMode(request, timeout=timeout)
+        await self.client.SetPowerMode(request, timeout=timeout, metadata=md)
 
-    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[Geometry]:
+    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[Geometry]:
+        md = kwargs.get('metadata', self.Metadata())
         return await get_geometries(self.client, self.name, extra, timeout)
 
     async def write_analog(
@@ -241,22 +235,20 @@ class BoardClient(Board, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = WriteAnalogRequest(name=self.name, pin=pin, value=value, extra=dict_to_struct(extra))
-        await self.client.WriteAnalog(request, timeout=timeout)
+        await self.client.WriteAnalog(request, timeout=timeout, metadata=md)
 
     async def stream_ticks(
         self,
         interrupts: List[Board.DigitalInterrupt],
         *,
         extra: Optional[Dict[str, Any]] = None,
-        **__,
+        **kwargs,
     ) -> TickStream:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         names = []
         for di in interrupts:
             names.append(di.name)
@@ -266,7 +258,7 @@ class BoardClient(Board, ReconfigurableResourceRPCClientBase):
             tick_stream: ClientStream[StreamTicksRequest, StreamTicksResponse]
             async with self.client.StreamTicks.open() as tick_stream:
                 try:
-                    await tick_stream.send_message(request, end=True)
+                    await tick_stream.send_message(request, end=True, metadata=md)
                     async for tick in tick_stream:
                         yield tick
                 except Exception as e:

--- a/src/viam/components/camera/client.py
+++ b/src/viam/components/camera/client.py
@@ -36,22 +36,22 @@ class CameraClient(Camera, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> ViamImage:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetImageRequest(name=self.name, mime_type=mime_type, extra=dict_to_struct(extra))
-        response: GetImageResponse = await self.client.GetImage(request, timeout=timeout)
+        response: GetImageResponse = await self.client.GetImage(request, timeout=timeout, metadata=md)
         return ViamImage(response.image, CameraMimeType.from_string(response.mime_type))
 
     async def get_images(
         self,
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Tuple[List[NamedImage], ResponseMetadata]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetImagesRequest(name=self.name)
-        response: GetImagesResponse = await self.client.GetImages(request, timeout=timeout)
+        response: GetImagesResponse = await self.client.GetImages(request, timeout=timeout, metadata=md)
         imgs = []
         for img_data in response.images:
             mime_type = CameraMimeType.from_proto(img_data.format)
@@ -65,32 +65,34 @@ class CameraClient(Camera, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Tuple[bytes, str]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetPointCloudRequest(name=self.name, mime_type=CameraMimeType.PCD, extra=dict_to_struct(extra))
-        response: GetPointCloudResponse = await self.client.GetPointCloud(request, timeout=timeout)
+        response: GetPointCloudResponse = await self.client.GetPointCloud(request, timeout=timeout, metadata=md)
         return (response.point_cloud, response.mime_type)
 
     async def get_properties(
         self,
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Camera.Properties:
-        return await self.client.GetProperties(GetPropertiesRequest(name=self.name), timeout=timeout)
+        md = kwargs.get('metadata', self.Metadata()).proto
+        return await self.client.GetProperties(GetPropertiesRequest(name=self.name), timeout=timeout, metadata=md)
 
     async def do_command(
         self,
         command: Mapping[str, ValueTypes],
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Mapping[str, ValueTypes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         return struct_to_dict(response.result)
 
-    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[Geometry]:
-        return await get_geometries(self.client, self.name, extra, timeout)
+    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[Geometry]:
+        md = kwargs.get('metadata', self.Metadata())
+        return await get_geometries(self.client, self.name, extra, timeout, md)

--- a/src/viam/components/encoder/client.py
+++ b/src/viam/components/encoder/client.py
@@ -33,12 +33,11 @@ class EncoderClient(Encoder, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = ResetPositionRequest(name=self.name, extra=dict_to_struct(extra))
-        await self.client.ResetPosition(request, timeout=timeout)
+        await self.client.ResetPosition(request, timeout=timeout, metadata=md)
 
     async def get_position(
         self,
@@ -46,12 +45,11 @@ class EncoderClient(Encoder, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Tuple[float, PositionType.ValueType]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetPositionRequest(name=self.name, position_type=position_type, extra=dict_to_struct(extra))
-        response: GetPositionResponse = await self.client.GetPosition(request, timeout=timeout)
+        response: GetPositionResponse = await self.client.GetPosition(request, timeout=timeout, metadata=md)
         return response.value, response.position_type
 
     async def get_properties(
@@ -59,12 +57,11 @@ class EncoderClient(Encoder, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Encoder.Properties:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetPropertiesRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetPropertiesResponse = await self.client.GetProperties(request, timeout=timeout)
+        response: GetPropertiesResponse = await self.client.GetProperties(request, timeout=timeout, metadata=md)
         return Encoder.Properties(
             ticks_count_supported=response.ticks_count_supported, angle_degrees_supported=response.angle_degrees_supported
         )
@@ -74,11 +71,13 @@ class EncoderClient(Encoder, ReconfigurableResourceRPCClientBase):
         command: Mapping[str, ValueTypes],
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Mapping[str, ValueTypes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         return struct_to_dict(response.result)
 
-    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[Geometry]:
-        return await get_geometries(self.client, self.name, extra, timeout)
+    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[Geometry]:
+        md = kwargs.get('metadata', self.Metadata())
+        return await get_geometries(self.client, self.name, extra, timeout, md)

--- a/src/viam/components/gantry/client.py
+++ b/src/viam/components/gantry/client.py
@@ -37,12 +37,11 @@ class GantryClient(Gantry, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> List[float]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetPositionRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetPositionResponse = await self.client.GetPosition(request, timeout=timeout)
+        response: GetPositionResponse = await self.client.GetPosition(request, timeout=timeout, metadata=md)
         return list(response.positions_mm)
 
     async def move_to_position(
@@ -52,24 +51,22 @@ class GantryClient(Gantry, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = MoveToPositionRequest(name=self.name, positions_mm=positions, speeds_mm_per_sec=speeds, extra=dict_to_struct(extra))
-        await self.client.MoveToPosition(request, timeout=timeout)
+        await self.client.MoveToPosition(request, timeout=timeout, metadata=md)
 
     async def home(
         self,
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> bool:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = HomeRequest(name=self.name, extra=dict_to_struct(extra))
-        response: HomeResponse = await self.client.Home(request, timeout=timeout)
+        response: HomeResponse = await self.client.Home(request, timeout=timeout, metadata=md)
         return response.homed
 
     async def get_lengths(
@@ -77,12 +74,11 @@ class GantryClient(Gantry, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> List[float]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetLengthsRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetLengthsResponse = await self.client.GetLengths(request, timeout=timeout)
+        response: GetLengthsResponse = await self.client.GetLengths(request, timeout=timeout, metadata=md)
         return list(response.lengths_mm)
 
     async def stop(
@@ -90,16 +86,16 @@ class GantryClient(Gantry, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = StopRequest(name=self.name, extra=dict_to_struct(extra))
-        await self.client.Stop(request, timeout=timeout)
+        await self.client.Stop(request, timeout=timeout, metadata=md)
 
-    async def is_moving(self, *, timeout: Optional[float] = None) -> bool:
+    async def is_moving(self, *, timeout: Optional[float] = None, **kwargs) -> bool:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = IsMovingRequest(name=self.name)
-        response: IsMovingResponse = await self.client.IsMoving(request, timeout=timeout)
+        response: IsMovingResponse = await self.client.IsMoving(request, timeout=timeout, metadata=md)
         return response.is_moving
 
     async def do_command(
@@ -107,11 +103,13 @@ class GantryClient(Gantry, ReconfigurableResourceRPCClientBase):
         command: Mapping[str, ValueTypes],
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Mapping[str, ValueTypes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         return struct_to_dict(response.result)
 
-    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[Geometry]:
-        return await get_geometries(self.client, self.name, extra, timeout)
+    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[Geometry]:
+        md = kwargs.get('metadata', self.Metadata())
+        return await get_geometries(self.client, self.name, extra, timeout, md)

--- a/src/viam/components/generic/client.py
+++ b/src/viam/components/generic/client.py
@@ -40,7 +40,7 @@ class GenericClient(Generic, ReconfigurableResourceRPCClientBase):
         return struct_to_dict(response.result)
 
     async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[Geometry]:
-        md = kwargs.get('metadata', self.Metadata()).proto
+        md = kwargs.get('metadata', self.Metadata())
         return await get_geometries(self.client, self.name, extra, timeout, md)
 
 

--- a/src/viam/components/generic/client.py
+++ b/src/viam/components/generic/client.py
@@ -5,7 +5,7 @@ from grpclib.client import Channel
 
 from viam.proto.common import DoCommandRequest, DoCommandResponse, Geometry
 from viam.proto.component.generic import GenericServiceStub
-from viam.resource.rpc_client_base import ReconfigurableResourceRPCClientBase
+from viam.resource.rpc_client_base import ResourceRPCClientBase, ReconfigurableResourceRPCClientBase
 from viam.utils import ValueTypes, dict_to_struct, get_geometries, struct_to_dict
 
 from .generic import Generic
@@ -26,11 +26,12 @@ class GenericClient(Generic, ReconfigurableResourceRPCClientBase):
         command: Mapping[str, Any],
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Mapping[str, Any]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
         try:
-            response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+            response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         except GRPCError as e:
             if e.status == Status.UNIMPLEMENTED:
                 raise NotImplementedError()
@@ -38,12 +39,13 @@ class GenericClient(Generic, ReconfigurableResourceRPCClientBase):
 
         return struct_to_dict(response.result)
 
-    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[Geometry]:
-        return await get_geometries(self.client, self.name, extra, timeout)
+    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[Geometry]:
+        md = kwargs.get('metadata', self.Metadata()).proto
+        return await get_geometries(self.client, self.name, extra, timeout, md)
 
 
 async def do_command(
-    channel: Channel, name: str, command: Mapping[str, ValueTypes], *, timeout: Optional[float] = None
+    channel: Channel, name: str, command: Mapping[str, ValueTypes], *, timeout: Optional[float] = None, **kwargs
 ) -> Mapping[str, ValueTypes]:
     """Convenience method to allow component clients to execute ``do_command`` functions
 
@@ -55,5 +57,6 @@ async def do_command(
     Returns:
         Dict[str, Any]: The result of the executed command
     """
+    md = kwargs.get('metadata', ResourceRPCClientBase.Metadata()).proto
     client = GenericClient(name, channel)
-    return await client.do_command(command, timeout=timeout)
+    return await client.do_command(command, timeout=timeout, metadata=md)

--- a/src/viam/components/gripper/client.py
+++ b/src/viam/components/gripper/client.py
@@ -33,24 +33,22 @@ class GripperClient(Gripper, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = OpenRequest(name=self.name, extra=dict_to_struct(extra))
-        await self.client.Open(request, timeout=timeout)
+        await self.client.Open(request, timeout=timeout, metadata=md)
 
     async def grab(
         self,
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> bool:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GrabRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GrabResponse = await self.client.Grab(request, timeout=timeout)
+        response: GrabResponse = await self.client.Grab(request, timeout=timeout, metadata=md)
         return response.success
 
     async def stop(
@@ -58,16 +56,16 @@ class GripperClient(Gripper, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = StopRequest(name=self.name, extra=dict_to_struct(extra))
-        await self.client.Stop(request, timeout=timeout)
+        await self.client.Stop(request, timeout=timeout, metadata=md)
 
-    async def is_moving(self, *, timeout: Optional[float] = None) -> bool:
+    async def is_moving(self, *, timeout: Optional[float] = None, **kwargs) -> bool:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = IsMovingRequest(name=self.name)
-        response: IsMovingResponse = await self.client.IsMoving(request, timeout=timeout)
+        response: IsMovingResponse = await self.client.IsMoving(request, timeout=timeout, metadata=md)
         return response.is_moving
 
     async def do_command(
@@ -75,11 +73,13 @@ class GripperClient(Gripper, ReconfigurableResourceRPCClientBase):
         command: Mapping[str, ValueTypes],
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Mapping[str, ValueTypes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         return struct_to_dict(response.result)
 
-    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[Geometry]:
-        return await get_geometries(self.client, self.name, extra, timeout)
+    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[Geometry]:
+        md = kwargs.get('metadata', self.Metadata())
+        return await get_geometries(self.client, self.name, extra, timeout, md)

--- a/src/viam/components/input/client.py
+++ b/src/viam/components/input/client.py
@@ -133,7 +133,7 @@ class ControllerClient(Controller, ReconfigurableResourceRPCClientBase):
             return
 
         md = metadata.proto
-        request = StreamEventsRequest(controller=self.name, events=[], extra=self._callback_extra, metadata=md)
+        request = StreamEventsRequest(controller=self.name, events=[], extra=self._callback_extra)
         with self._lock:
             for control, callbacks in self.callbacks.items():
                 event = StreamEventsRequest.Events(
@@ -144,7 +144,7 @@ class ControllerClient(Controller, ReconfigurableResourceRPCClientBase):
                 request.events.append(event)
 
         try:
-            async with self.client.StreamEvents.open() as stream:
+            async with self.client.StreamEvents.open(metadata=md) as stream:
                 await stream.send_message(request, end=True)
                 self._send_connection_status(True)
                 reply: StreamEventsResponse
@@ -191,4 +191,4 @@ class ControllerClient(Controller, ReconfigurableResourceRPCClientBase):
 
     async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[Geometry]:
         md = kwargs.get('metadata', self.Metadata())
-        return await get_geometries(self.client, self.name, extra, timeout)
+        return await get_geometries(self.client, self.name, extra, timeout, md)

--- a/src/viam/components/input/client.py
+++ b/src/viam/components/input/client.py
@@ -21,7 +21,7 @@ from viam.proto.component.inputcontroller import (
     StreamEventsResponse,
     TriggerEventRequest,
 )
-from viam.resource.rpc_client_base import ReconfigurableResourceRPCClientBase
+from viam.resource.rpc_client_base import ReconfigurableResourceRPCClientBase, ResourceRPCClientBase
 from viam.utils import ValueTypes, dict_to_struct, get_geometries, struct_to_dict
 
 from .input import Control, ControlFunction, Controller, Event, EventType
@@ -48,12 +48,11 @@ class ControllerClient(Controller, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> List[Control]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetControlsRequest(controller=self.name, extra=dict_to_struct(extra))
-        response: GetControlsResponse = await self.client.GetControls(request, timeout=timeout)
+        response: GetControlsResponse = await self.client.GetControls(request, timeout=timeout, metadata=md)
         return [Control(control) for control in response.controls]
 
     async def get_events(
@@ -61,12 +60,11 @@ class ControllerClient(Controller, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Dict[Control, Event]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetEventsRequest(controller=self.name, extra=dict_to_struct(extra))
-        response: GetEventsResponse = await self.client.GetEvents(request, timeout=timeout)
+        response: GetEventsResponse = await self.client.GetEvents(request, timeout=timeout, metadata=md)
         return {Control(event.control): Event.from_proto(event) for (event) in response.events}
 
     def register_control_callback(
@@ -75,10 +73,9 @@ class ControllerClient(Controller, ReconfigurableResourceRPCClientBase):
         triggers: List[EventType],
         function: Optional[ControlFunction],
         extra: Optional[Dict[str, Any]] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata())
         self._callback_extra = dict_to_struct(extra)
         with self._lock:
             callbacks = self.callbacks.get(control, {})
@@ -99,7 +96,7 @@ class ControllerClient(Controller, ReconfigurableResourceRPCClientBase):
             except Exception:
                 LOGGER.exception("Exception raised by task = %r", task)
 
-        task = asyncio.create_task(self._stream_events(), name=f"{viam._TASK_PREFIX}-input_stream_events")
+        task = asyncio.create_task(self._stream_events(md), name=f"{viam._TASK_PREFIX}-input_stream_events")
         task.add_done_callback(handle_task_result)
 
     def reset_channel(self, channel: Channel):
@@ -115,19 +112,18 @@ class ControllerClient(Controller, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = TriggerEventRequest(controller=self.name, event=event.proto, extra=dict_to_struct(extra))
         try:
-            await self.client.TriggerEvent(request, timeout=timeout)
+            await self.client.TriggerEvent(request, timeout=timeout, metadata=md)
         except GRPCError as e:
             if e.status == Status.UNIMPLEMENTED and ("does not support triggering events" in e.message if e.message else False):
                 raise NotSupportedError(f"Input controller named {self.name} does not support triggering events")
             raise e
 
-    async def _stream_events(self):
+    async def _stream_events(self, metadata: ResourceRPCClientBase.Metadata):
         with self._stream_lock:
             if self._is_streaming:
                 return
@@ -136,7 +132,8 @@ class ControllerClient(Controller, ReconfigurableResourceRPCClientBase):
         if not self.callbacks:
             return
 
-        request = StreamEventsRequest(controller=self.name, events=[], extra=self._callback_extra)
+        md = metadata.proto
+        request = StreamEventsRequest(controller=self.name, events=[], extra=self._callback_extra, metadata=md)
         with self._lock:
             for control, callbacks in self.callbacks.items():
                 event = StreamEventsRequest.Events(
@@ -185,11 +182,13 @@ class ControllerClient(Controller, ReconfigurableResourceRPCClientBase):
         command: Mapping[str, ValueTypes],
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Mapping[str, ValueTypes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         return struct_to_dict(response.result)
 
-    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[Geometry]:
+    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[Geometry]:
+        md = kwargs.get('metadata', self.Metadata())
         return await get_geometries(self.client, self.name, extra, timeout)

--- a/src/viam/components/motor/client.py
+++ b/src/viam/components/motor/client.py
@@ -42,12 +42,11 @@ class MotorClient(Motor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = SetPowerRequest(name=self.name, power_pct=power, extra=dict_to_struct(extra))
-        await self.client.SetPower(request, timeout=timeout)
+        await self.client.SetPower(request, timeout=timeout, metadata=md)
 
     async def go_for(
         self,
@@ -58,7 +57,7 @@ class MotorClient(Motor, ReconfigurableResourceRPCClientBase):
         timeout: Optional[float] = None,
         **kwargs,
     ):
-        md = [(k, v) for k, v in kwargs.get('metadata', self.Metadata()).metadata.items()]
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GoForRequest(name=self.name, rpm=rpm, revolutions=revolutions, extra=dict_to_struct(extra))
         await self.client.GoFor(request, timeout=timeout, metadata=md)
 
@@ -69,12 +68,11 @@ class MotorClient(Motor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GoToRequest(name=self.name, rpm=rpm, position_revolutions=position_revolutions, extra=dict_to_struct(extra))
-        await self.client.GoTo(request, timeout=timeout)
+        await self.client.GoTo(request, timeout=timeout, metadata=md)
 
     async def set_rpm(
         self,
@@ -82,12 +80,11 @@ class MotorClient(Motor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = SetRPMRequest(name=self.name, rpm=rpm, extra=dict_to_struct(extra))
-        await self.client.SetRPM(request, timeout=timeout)
+        await self.client.SetRPM(request, timeout=timeout, metadata=md)
 
     async def reset_zero_position(
         self,
@@ -95,24 +92,22 @@ class MotorClient(Motor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = ResetZeroPositionRequest(name=self.name, offset=offset, extra=dict_to_struct(extra))
-        await self.client.ResetZeroPosition(request, timeout=timeout)
+        await self.client.ResetZeroPosition(request, timeout=timeout, metadata=md)
 
     async def get_position(
         self,
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> float:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetPositionRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetPositionResponse = await self.client.GetPosition(request, timeout=timeout)
+        response: GetPositionResponse = await self.client.GetPosition(request, timeout=timeout, metadata=md)
         return response.position
 
     async def get_properties(
@@ -120,12 +115,11 @@ class MotorClient(Motor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Motor.Properties:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetPropertiesRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetPropertiesResponse = await self.client.GetProperties(request, timeout=timeout)
+        response: GetPropertiesResponse = await self.client.GetProperties(request, timeout=timeout, metadata=md)
         return Motor.Properties(position_reporting=response.position_reporting)
 
     async def stop(
@@ -133,29 +127,28 @@ class MotorClient(Motor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = StopRequest(name=self.name, extra=dict_to_struct(extra))
-        await self.client.Stop(request, timeout=timeout)
+        await self.client.Stop(request, timeout=timeout, metadata=md)
 
     async def is_powered(
         self,
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Tuple[bool, float]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = IsPoweredRequest(name=self.name, extra=dict_to_struct(extra))
-        response: IsPoweredResponse = await self.client.IsPowered(request, timeout=timeout)
+        response: IsPoweredResponse = await self.client.IsPowered(request, timeout=timeout, metadata=md)
         return response.is_on, response.power_pct
 
-    async def is_moving(self, *, timeout: Optional[float] = None) -> bool:
+    async def is_moving(self, *, timeout: Optional[float] = None, **kwargs) -> bool:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = IsMovingRequest(name=self.name)
-        response: IsMovingResponse = await self.client.IsMoving(request, timeout=timeout)
+        response: IsMovingResponse = await self.client.IsMoving(request, timeout=timeout, metadata=md)
         return response.is_moving
 
     async def do_command(
@@ -163,11 +156,13 @@ class MotorClient(Motor, ReconfigurableResourceRPCClientBase):
         command: Mapping[str, ValueTypes],
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Mapping[str, ValueTypes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         return struct_to_dict(response.result)
 
-    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[Geometry]:
-        return await get_geometries(self.client, self.name, extra, timeout)
+    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[Geometry]:
+        md = kwargs.get('metadata', self.Metadata())
+        return await get_geometries(self.client, self.name, extra, timeout, md)

--- a/src/viam/components/motor/client.py
+++ b/src/viam/components/motor/client.py
@@ -56,12 +56,11 @@ class MotorClient(Motor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = [(k, v) for k, v in kwargs.get('metadata', self.Metadata()).metadata.items()]
         request = GoForRequest(name=self.name, rpm=rpm, revolutions=revolutions, extra=dict_to_struct(extra))
-        await self.client.GoFor(request, timeout=timeout)
+        await self.client.GoFor(request, timeout=timeout, metadata=md)
 
     async def go_to(
         self,

--- a/src/viam/components/movement_sensor/client.py
+++ b/src/viam/components/movement_sensor/client.py
@@ -41,12 +41,11 @@ class MovementSensorClient(MovementSensor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Tuple[GeoPoint, float]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetPositionRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetPositionResponse = await self.client.GetPosition(request, timeout=timeout)
+        response: GetPositionResponse = await self.client.GetPosition(request, timeout=timeout, metadata=md)
         return response.coordinate, response.altitude_m
 
     async def get_linear_velocity(
@@ -54,12 +53,11 @@ class MovementSensorClient(MovementSensor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Vector3:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetLinearVelocityRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetLinearVelocityResponse = await self.client.GetLinearVelocity(request, timeout=timeout)
+        response: GetLinearVelocityResponse = await self.client.GetLinearVelocity(request, timeout=timeout, metadata=md)
         return response.linear_velocity
 
     async def get_angular_velocity(
@@ -67,12 +65,11 @@ class MovementSensorClient(MovementSensor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Vector3:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetAngularVelocityRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetAngularVelocityResponse = await self.client.GetAngularVelocity(request, timeout=timeout)
+        response: GetAngularVelocityResponse = await self.client.GetAngularVelocity(request, timeout=timeout, metadata=md)
         return response.angular_velocity
 
     async def get_linear_acceleration(
@@ -80,12 +77,11 @@ class MovementSensorClient(MovementSensor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Vector3:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetLinearAccelerationRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetLinearAccelerationResponse = await self.client.GetLinearAcceleration(request, timeout=timeout)
+        response: GetLinearAccelerationResponse = await self.client.GetLinearAcceleration(request, timeout=timeout, metadata=md)
         return response.linear_acceleration
 
     async def get_compass_heading(
@@ -93,12 +89,11 @@ class MovementSensorClient(MovementSensor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> float:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetCompassHeadingRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetCompassHeadingResponse = await self.client.GetCompassHeading(request, timeout=timeout)
+        response: GetCompassHeadingResponse = await self.client.GetCompassHeading(request, timeout=timeout, metadata=md)
         return response.value
 
     async def get_orientation(
@@ -106,12 +101,11 @@ class MovementSensorClient(MovementSensor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Orientation:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetOrientationRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetOrientationResponse = await self.client.GetOrientation(request, timeout=timeout)
+        response: GetOrientationResponse = await self.client.GetOrientation(request, timeout=timeout, metadata=md)
         return response.orientation
 
     async def get_properties(
@@ -119,12 +113,11 @@ class MovementSensorClient(MovementSensor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> MovementSensor.Properties:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetPropertiesRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetPropertiesResponse = await self.client.GetProperties(request, timeout=timeout)
+        response: GetPropertiesResponse = await self.client.GetProperties(request, timeout=timeout, metadata=md)
         return MovementSensor.Properties.from_proto(response)
 
     async def get_accuracy(
@@ -132,24 +125,22 @@ class MovementSensorClient(MovementSensor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> MovementSensor.Accuracy:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetAccuracyRequest(name=self.name, extra=dict_to_struct(extra))
-        return await self.client.GetAccuracy(request, timeout=timeout)
+        return await self.client.GetAccuracy(request, timeout=timeout, metadata=md)
 
     async def get_readings(
         self,
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Mapping[str, SensorReading]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetReadingsRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetReadingsResponse = await self.client.GetReadings(request, timeout=timeout)
+        response: GetReadingsResponse = await self.client.GetReadings(request, timeout=timeout, metadata=md)
 
         return sensor_readings_value_to_native(response.readings)
 
@@ -158,11 +149,13 @@ class MovementSensorClient(MovementSensor, ReconfigurableResourceRPCClientBase):
         command: Mapping[str, ValueTypes],
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Mapping[str, ValueTypes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         return struct_to_dict(response.result)
 
-    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[Geometry]:
-        return await get_geometries(self.client, self.name, extra, timeout)
+    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[Geometry]:
+        md = kwargs.get('metadata', self.Metadata())
+        return await get_geometries(self.client, self.name, extra, timeout, md)

--- a/src/viam/components/pose_tracker/client.py
+++ b/src/viam/components/pose_tracker/client.py
@@ -26,12 +26,11 @@ class PoseTrackerClient(PoseTracker, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Mapping[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Dict[str, PoseInFrame]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetPosesRequest(name=self.name, body_names=body_names, extra=dict_to_struct(extra))
-        response: GetPosesResponse = await self.client.GetPoses(request, timeout=timeout)
+        response: GetPosesResponse = await self.client.GetPoses(request, timeout=timeout, metadata=md)
         return {key: response.body_poses[key] for key in response.body_poses.keys()}
 
     async def do_command(
@@ -39,11 +38,13 @@ class PoseTrackerClient(PoseTracker, ReconfigurableResourceRPCClientBase):
         command: Mapping[str, ValueTypes],
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Mapping[str, ValueTypes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         return struct_to_dict(response.result)
 
-    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[Geometry]:
+    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[Geometry]:
+        md = kwargs.get('metadata', self.Metadata())
         return await get_geometries(self.client, self.name, extra, timeout)

--- a/src/viam/components/pose_tracker/client.py
+++ b/src/viam/components/pose_tracker/client.py
@@ -47,4 +47,4 @@ class PoseTrackerClient(PoseTracker, ReconfigurableResourceRPCClientBase):
 
     async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[Geometry]:
         md = kwargs.get('metadata', self.Metadata())
-        return await get_geometries(self.client, self.name, extra, timeout)
+        return await get_geometries(self.client, self.name, extra, timeout, md)

--- a/src/viam/components/power_sensor/client.py
+++ b/src/viam/components/power_sensor/client.py
@@ -30,12 +30,11 @@ class PowerSensorClient(PowerSensor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Tuple[float, bool]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetVoltageRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetVoltageResponse = await self.client.GetVoltage(request, timeout=timeout)
+        response: GetVoltageResponse = await self.client.GetVoltage(request, timeout=timeout, metadata=md)
         return response.volts, response.is_ac
 
     async def get_current(
@@ -43,12 +42,11 @@ class PowerSensorClient(PowerSensor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Tuple[float, bool]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetCurrentRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetCurrentResponse = await self.client.GetCurrent(request, timeout=timeout)
+        response: GetCurrentResponse = await self.client.GetCurrent(request, timeout=timeout, metadata=md)
         return response.amperes, response.is_ac
 
     async def get_power(
@@ -56,12 +54,11 @@ class PowerSensorClient(PowerSensor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> float:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetPowerRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetPowerResponse = await self.client.GetPower(request, timeout=timeout)
+        response: GetPowerResponse = await self.client.GetPower(request, timeout=timeout, metadata=md)
         return response.watts
 
     async def get_readings(
@@ -69,12 +66,11 @@ class PowerSensorClient(PowerSensor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Mapping[str, SensorReading]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetReadingsRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetReadingsResponse = await self.client.GetReadings(request, timeout=timeout)
+        response: GetReadingsResponse = await self.client.GetReadings(request, timeout=timeout, metadata=md)
         return sensor_readings_value_to_native(response.readings)
 
     async def do_command(
@@ -82,8 +78,9 @@ class PowerSensorClient(PowerSensor, ReconfigurableResourceRPCClientBase):
         command: Mapping[str, ValueTypes],
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Mapping[str, ValueTypes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         return struct_to_dict(response.result)

--- a/src/viam/components/sensor/client.py
+++ b/src/viam/components/sensor/client.py
@@ -46,4 +46,4 @@ class SensorClient(Sensor, ReconfigurableResourceRPCClientBase):
 
     async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[Geometry]:
         md = kwargs.get('metadata', self.Metadata())
-        return await get_geometries(self.client, self.name, extra, timeout)
+        return await get_geometries(self.client, self.name, extra, timeout, md)

--- a/src/viam/components/sensor/client.py
+++ b/src/viam/components/sensor/client.py
@@ -25,12 +25,11 @@ class SensorClient(Sensor, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Mapping[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Mapping[str, SensorReading]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetReadingsRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetReadingsResponse = await self.client.GetReadings(request, timeout=timeout)
+        response: GetReadingsResponse = await self.client.GetReadings(request, timeout=timeout, metadata=md)
         return sensor_readings_value_to_native(response.readings)
 
     async def do_command(
@@ -38,11 +37,13 @@ class SensorClient(Sensor, ReconfigurableResourceRPCClientBase):
         command: Mapping[str, ValueTypes],
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Mapping[str, ValueTypes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         return struct_to_dict(response.result)
 
-    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[Geometry]:
+    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[Geometry]:
+        md = kwargs.get('metadata', self.Metadata())
         return await get_geometries(self.client, self.name, extra, timeout)

--- a/src/viam/components/servo/client.py
+++ b/src/viam/components/servo/client.py
@@ -33,12 +33,11 @@ class ServoClient(Servo, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Mapping[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> int:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetPositionRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetPositionResponse = await self.client.GetPosition(request, timeout=timeout)
+        response: GetPositionResponse = await self.client.GetPosition(request, timeout=timeout, metadata=md)
         return response.position_deg
 
     async def move(
@@ -47,28 +46,27 @@ class ServoClient(Servo, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Mapping[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = MoveRequest(name=self.name, angle_deg=angle, extra=dict_to_struct(extra))
-        await self.client.Move(request, timeout=timeout)
+        await self.client.Move(request, timeout=timeout, metadata=md)
 
     async def stop(
         self,
         *,
         extra: Optional[Mapping[str, Any]] = None,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = StopRequest(name=self.name, extra=dict_to_struct(extra))
-        await self.client.Stop(request, timeout=timeout)
+        await self.client.Stop(request, timeout=timeout, metadata=md)
 
-    async def is_moving(self, *, timeout: Optional[float] = None) -> bool:
+    async def is_moving(self, *, timeout: Optional[float] = None, **kwargs) -> bool:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = IsMovingRequest(name=self.name)
-        response: IsMovingResponse = await self.client.IsMoving(request, timeout=timeout)
+        response: IsMovingResponse = await self.client.IsMoving(request, timeout=timeout, metadata=md)
         return response.is_moving
 
     async def do_command(
@@ -76,11 +74,13 @@ class ServoClient(Servo, ReconfigurableResourceRPCClientBase):
         command: Mapping[str, ValueTypes],
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Mapping[str, ValueTypes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         return struct_to_dict(response.result)
 
-    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[Geometry]:
+    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[Geometry]:
+        md = kwargs.get('metadata', self.Metadata())
         return await get_geometries(self.client, self.name, extra, timeout)

--- a/src/viam/components/servo/client.py
+++ b/src/viam/components/servo/client.py
@@ -83,4 +83,4 @@ class ServoClient(Servo, ReconfigurableResourceRPCClientBase):
 
     async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[Geometry]:
         md = kwargs.get('metadata', self.Metadata())
-        return await get_geometries(self.client, self.name, extra, timeout)
+        return await get_geometries(self.client, self.name, extra, timeout, md)

--- a/src/viam/resource/rpc_client_base.py
+++ b/src/viam/resource/rpc_client_base.py
@@ -31,6 +31,14 @@ class ResourceRPCClientBase(Protocol):
             """Disables server-side debug logging for resource methods."""
             del self.metadata['dtname']
 
+        def add_metadata(self, key: str, value: str):
+            """Adds a key-value pair to the metadata"""
+            self.metadata[key] = value
+
+        def delete_metadata(self, key: str):
+            """Removes a key-value pair from the metadata by key"""
+            del self.metadata[key]
+
         @property
         def proto(self):
             """Returns metadata in a gRPC-appropriate form"""

--- a/src/viam/resource/rpc_client_base.py
+++ b/src/viam/resource/rpc_client_base.py
@@ -31,6 +31,11 @@ class ResourceRPCClientBase(Protocol):
             """Disables server-side debug logging for resource methods."""
             del self.metadata['dtname']
 
+        @property
+        def proto(self):
+            """Returns metadata in a gRPC-appropriate form"""
+            return [(k, v) for k, v in self.metadata.items()]
+
     channel: Channel
     client: Any
 

--- a/src/viam/resource/rpc_client_base.py
+++ b/src/viam/resource/rpc_client_base.py
@@ -1,4 +1,6 @@
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Mapping, Optional, Protocol, runtime_checkable
+from string import ascii_lowercase
+from random import choice
 
 from grpclib.client import Channel
 
@@ -12,9 +14,25 @@ class ResourceRPCClientBase(Protocol):
     Resource RPC clients must inherit from this class
     """
 
+    class Metadata:
+        metadata: Mapping[str, str] = {}
+
+        def enable_debug_logging(self, key: str = ''):
+            """Enables server-side debug logging for resource methods.
+
+            Args:
+                key (str): The key to associate debug logs with. If not provided, will default to a randomly generated string value.
+            """
+            if key == '':
+                key = ''.join(choice(ascii_lowercase) for i in range(6))
+            self.metadata['dtname'] = key
+
+        def disable_debug_logging(self):
+            """Disables server-side debug logging for resource methods."""
+            del self.metadata['dtname']
+
     channel: Channel
     client: Any
-
 
 class ReconfigurableResourceRPCClientBase(ResourceRPCClientBase):
     """A base RPC client that can reset its channel.

--- a/src/viam/resource/rpc_client_base.py
+++ b/src/viam/resource/rpc_client_base.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Optional, Protocol, runtime_checkable
+from typing import Any, Dict, Protocol, runtime_checkable
 from string import ascii_lowercase
 from random import choice
 
@@ -15,7 +15,7 @@ class ResourceRPCClientBase(Protocol):
     """
 
     class Metadata:
-        metadata: Mapping[str, str] = {}
+        metadata: Dict[str, str] = {}
 
         def enable_debug_logging(self, key: str = ''):
             """Enables server-side debug logging for resource methods.
@@ -38,6 +38,7 @@ class ResourceRPCClientBase(Protocol):
 
     channel: Channel
     client: Any
+
 
 class ReconfigurableResourceRPCClientBase(ResourceRPCClientBase):
     """A base RPC client that can reset its channel.

--- a/src/viam/resource/types.py
+++ b/src/viam/resource/types.py
@@ -210,5 +210,5 @@ Validator: TypeAlias = Callable[[ComponentConfig], Sequence[str]]
 class SupportsGetGeometries(Protocol):
     """The SupportsGetGeometries protocol defines the requirements for a resource to call get_geometries."""
 
-    async def GetGeometries(self, request: GetGeometriesRequest, *, timeout: Optional[float] = None) -> GetGeometriesResponse:
+    async def GetGeometries(self, request: GetGeometriesRequest, *, timeout: Optional[float] = None, **kwargs) -> GetGeometriesResponse:
         ...

--- a/src/viam/services/mlmodel/client.py
+++ b/src/viam/services/mlmodel/client.py
@@ -16,12 +16,14 @@ class MLModelClient(MLModel, ReconfigurableResourceRPCClientBase):
         self.client = MLModelServiceStub(channel)
         super().__init__(name)
 
-    async def infer(self, input_tensors: Dict[str, NDArray], *, timeout: Optional[float] = None) -> Dict[str, NDArray]:
+    async def infer(self, input_tensors: Dict[str, NDArray], *, timeout: Optional[float] = None, **kwargs) -> Dict[str, NDArray]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = InferRequest(name=self.name, input_tensors=ndarrays_to_flat_tensors(input_tensors))
-        response: InferResponse = await self.client.Infer(request)
+        response: InferResponse = await self.client.Infer(request, timeout=timeout, metadata=md)
         return flat_tensors_to_ndarrays(response.output_tensors)
 
-    async def metadata(self, *, timeout: Optional[float] = None) -> Metadata:
+    async def metadata(self, *, timeout: Optional[float] = None, **kwargs) -> Metadata:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = MetadataRequest(name=self.name)
-        response: MetadataResponse = await self.client.Metadata(request)
+        response: MetadataResponse = await self.client.Metadata(request, timeout=timeout, metadata=md)
         return response.metadata

--- a/src/viam/services/motion/client.py
+++ b/src/viam/services/motion/client.py
@@ -61,9 +61,9 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Mapping[str, Any]] = None,
         timeout: Optional[float] = None,
+        **kwargs,
     ) -> bool:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = MoveRequest(
             name=self.name,
             destination=destination,
@@ -72,7 +72,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
             constraints=constraints,
             extra=dict_to_struct(extra),
         )
-        response: MoveResponse = await self.client.Move(request, timeout=timeout)
+        response: MoveResponse = await self.client.Move(request, timeout=timeout, metadata=md)
         return response.success
 
     async def move_on_globe(
@@ -87,9 +87,9 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
         bounding_regions: Optional[Sequence[GeoGeometry]] = None,
         extra: Optional[Mapping[str, ValueTypes]] = None,
         timeout: Optional[float] = None,
+        **kwargs,
     ) -> str:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = MoveOnGlobeRequest(
             name=self.name,
             component_name=component_name,
@@ -101,7 +101,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
             bounding_regions=bounding_regions,
             extra=dict_to_struct(extra),
         )
-        response: MoveOnGlobeResponse = await self.client.MoveOnGlobe(request, timeout=timeout)
+        response: MoveOnGlobeResponse = await self.client.MoveOnGlobe(request, timeout=timeout, metadata=md)
         return response.execution_id
 
     async def move_on_map(
@@ -114,9 +114,9 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Mapping[str, ValueTypes]] = None,
         timeout: Optional[float] = None,
+        **kwargs,
     ) -> str:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = MoveOnMapRequest(
             name=self.name,
             destination=destination,
@@ -126,7 +126,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
             obstacles=obstacles,
             extra=dict_to_struct(extra),
         )
-        response: MoveOnMapResponse = await self.client.MoveOnMap(request, timeout=timeout)
+        response: MoveOnMapResponse = await self.client.MoveOnMap(request, timeout=timeout, metadata=md)
         return response.execution_id
 
     async def stop_plan(
@@ -135,16 +135,16 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Mapping[str, ValueTypes]] = None,
         timeout: Optional[float] = None,
+        **kwargs,
     ):
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
 
         request = StopPlanRequest(
             name=self.name,
             component_name=component_name,
             extra=dict_to_struct(extra),
         )
-        _: StopPlanResponse = await self.client.StopPlan(request, timeout=timeout)
+        _: StopPlanResponse = await self.client.StopPlan(request, timeout=timeout, metadata=md)
         return
 
     async def get_plan(
@@ -155,9 +155,9 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Mapping[str, ValueTypes]] = None,
         timeout: Optional[float] = None,
+        **kwargs,
     ) -> GetPlanResponse:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
 
         request = GetPlanRequest(
             name=self.name,
@@ -166,7 +166,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
             execution_id=execution_id,
             extra=dict_to_struct(extra),
         )
-        response: GetPlanResponse = await self.client.GetPlan(request, timeout=timeout)
+        response: GetPlanResponse = await self.client.GetPlan(request, timeout=timeout, metadata=md)
         return response
 
     async def list_plan_statuses(
@@ -175,16 +175,16 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Mapping[str, ValueTypes]] = None,
         timeout: Optional[float] = None,
+        **kwargs,
     ) -> Sequence[PlanStatusWithID]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
 
         request = ListPlanStatusesRequest(
             name=self.name,
             only_active_plans=only_active_plans,
             extra=dict_to_struct(extra),
         )
-        response: ListPlanStatusesResponse = await self.client.ListPlanStatuses(request, timeout=timeout)
+        response: ListPlanStatusesResponse = await self.client.ListPlanStatuses(request, timeout=timeout, metadata=md)
         return response.plan_statuses_with_ids
 
     async def get_pose(
@@ -195,9 +195,9 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Mapping[str, Any]] = None,
         timeout: Optional[float] = None,
+        **kwargs,
     ) -> PoseInFrame:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetPoseRequest(
             name=self.name,
             component_name=component_name,
@@ -205,10 +205,11 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
             supplemental_transforms=supplemental_transforms,
             extra=dict_to_struct(extra),
         )
-        response: GetPoseResponse = await self.client.GetPose(request, timeout=timeout)
+        response: GetPoseResponse = await self.client.GetPose(request, timeout=timeout, metadata=md)
         return response.pose
 
-    async def do_command(self, command: Mapping[str, ValueTypes], *, timeout: Optional[float] = None, **__) -> Mapping[str, ValueTypes]:
+    async def do_command(self, command: Mapping[str, ValueTypes], *, timeout: Optional[float] = None, **kwargs) -> Mapping[str, ValueTypes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         return struct_to_dict(response.result)

--- a/src/viam/services/navigation/client.py
+++ b/src/viam/services/navigation/client.py
@@ -41,49 +41,59 @@ class NavigationClient(Navigation, ReconfigurableResourceRPCClientBase):
         self.client = NavigationServiceStub(channel)
         super().__init__(name)
 
-    async def get_paths(self, *, timeout: Optional[float] = None) -> List[Path]:
+    async def get_paths(self, *, timeout: Optional[float] = None, **kwargs) -> List[Path]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetPathsRequest(name=self.name)
-        response: GetPathsResponse = await self.client.GetPaths(request, timeout=timeout)
+        response: GetPathsResponse = await self.client.GetPaths(request, timeout=timeout, metadata=md)
         return list(response.paths)
 
-    async def get_location(self, *, timeout: Optional[float] = None) -> GeoPoint:
+    async def get_location(self, *, timeout: Optional[float] = None, **kwargs) -> GeoPoint:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetLocationRequest(name=self.name)
-        response: GetLocationResponse = await self.client.GetLocation(request, timeout=timeout)
+        response: GetLocationResponse = await self.client.GetLocation(request, timeout=timeout, metadata=md)
         return response.location
 
-    async def get_obstacles(self, *, timeout: Optional[float] = None) -> List[GeoGeometry]:
+    async def get_obstacles(self, *, timeout: Optional[float] = None, **kwargs) -> List[GeoGeometry]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetObstaclesRequest(name=self.name)
-        response: GetObstaclesResponse = await self.client.GetObstacles(request, timeout=timeout)
+        response: GetObstaclesResponse = await self.client.GetObstacles(request, timeout=timeout, metadata=md)
         return list(response.obstacles)
 
-    async def get_waypoints(self, *, timeout: Optional[float] = None) -> List[Waypoint]:
+    async def get_waypoints(self, *, timeout: Optional[float] = None, **kwargs) -> List[Waypoint]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetWaypointsRequest(name=self.name)
-        response: GetWaypointsResponse = await self.client.GetWaypoints(request, timeout=timeout)
+        response: GetWaypointsResponse = await self.client.GetWaypoints(request, timeout=timeout, metadata=md)
         return list(response.waypoints)
 
-    async def add_waypoint(self, point: GeoPoint, *, timeout: Optional[float] = None):
+    async def add_waypoint(self, point: GeoPoint, *, timeout: Optional[float] = None, **kwargs):
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = AddWaypointRequest(name=self.name, location=point)
-        await self.client.AddWaypoint(request, timeout=timeout)
+        await self.client.AddWaypoint(request, timeout=timeout, metadata=md)
 
-    async def remove_waypoint(self, id: str, *, timeout: Optional[float] = None):
+    async def remove_waypoint(self, id: str, *, timeout: Optional[float] = None, **kwargs):
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = RemoveWaypointRequest(name=self.name, id=id)
-        await self.client.RemoveWaypoint(request, timeout=timeout)
+        await self.client.RemoveWaypoint(request, timeout=timeout, metadata=md)
 
-    async def get_mode(self, *, timeout: Optional[float] = None) -> Mode.ValueType:
+    async def get_mode(self, *, timeout: Optional[float] = None, **kwargs) -> Mode.ValueType:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetModeRequest(name=self.name)
-        response: GetModeResponse = await self.client.GetMode(request, timeout=timeout)
+        response: GetModeResponse = await self.client.GetMode(request, timeout=timeout, metadata=md)
         return response.mode
 
-    async def set_mode(self, mode: Mode.ValueType, *, timeout: Optional[float] = None):
+    async def set_mode(self, mode: Mode.ValueType, *, timeout: Optional[float] = None, **kwargs):
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = SetModeRequest(name=self.name, mode=mode)
-        await self.client.SetMode(request, timeout=timeout)
+        await self.client.SetMode(request, timeout=timeout, metadata=md)
 
-    async def get_properties(self, *, timeout: Optional[float] = None) -> MapType.ValueType:
+    async def get_properties(self, *, timeout: Optional[float] = None, **kwargs) -> MapType.ValueType:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetPropertiesRequest(name=self.name)
-        response: GetPropertiesResponse = await self.client.GetProperties(request, timeout=timeout)
+        response: GetPropertiesResponse = await self.client.GetProperties(request, timeout=timeout, metadata=md)
         return response.map_type
 
-    async def do_command(self, command: Mapping[str, ValueTypes], *, timeout: Optional[float] = None, **__) -> Mapping[str, ValueTypes]:
+    async def do_command(self, command: Mapping[str, ValueTypes], *, timeout: Optional[float] = None, **kwargs) -> Mapping[str, ValueTypes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         return struct_to_dict(response.result)

--- a/src/viam/services/sensors/client.py
+++ b/src/viam/services/sensors/client.py
@@ -22,20 +22,19 @@ class SensorsClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
         super().__init__(name, channel)
         self.client = SensorsServiceStub(channel)
 
-    async def get_sensors(self, *, extra: Optional[Mapping[str, Any]] = None, timeout: Optional[float] = None) -> List[ResourceName]:
+    async def get_sensors(self, *, extra: Optional[Mapping[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[ResourceName]:
         """Get the ``ResourceName`` of all the ``Sensor`` resources connected to this Robot
 
         Returns:
             List[viam.proto.common.ResourceName]: The list of all Sensors
         """
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetSensorsRequest(name=self.name, extra=dict_to_struct(extra))
-        response: GetSensorsResponse = await self.client.GetSensors(request, timeout=timeout)
+        response: GetSensorsResponse = await self.client.GetSensors(request, timeout=timeout, metadata=md)
         return list(response.sensor_names)
 
     async def get_readings(
-        self, sensors: List[ResourceName], *, extra: Optional[Mapping[str, Any]] = None, timeout: Optional[float] = None
+        self, sensors: List[ResourceName], *, extra: Optional[Mapping[str, Any]] = None, timeout: Optional[float] = None, **kwargs
     ) -> Mapping[ResourceName, Mapping[str, SensorReading]]:
         """Get the readings from the specific sensors provided
 
@@ -45,13 +44,12 @@ class SensorsClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
         Returns:
             Mapping[viam.proto.common.ResourceName, Mapping[str, Any]]: The readings from the sensors, mapped by ``ResourceName``
         """
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetReadingsRequest(name=self.name, sensor_names=sensors, extra=dict_to_struct(extra))
-        response: GetReadingsResponse = await self.client.GetReadings(request, timeout=timeout)
+        response: GetReadingsResponse = await self.client.GetReadings(request, timeout=timeout, metadata=md)
         return {reading.name: sensor_readings_value_to_native(reading.readings) for reading in response.readings}
 
-    async def do_command(self, command: Mapping[str, ValueTypes], *, timeout: Optional[float] = None, **__) -> Mapping[str, ValueTypes]:
+    async def do_command(self, command: Mapping[str, ValueTypes], *, timeout: Optional[float] = None, **kwargs) -> Mapping[str, ValueTypes]:
         """Send/receive arbitrary commands
 
         Args:
@@ -60,6 +58,7 @@ class SensorsClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
         Returns:
             Dict[str, ValueTypes]: Result of the executed command
         """
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         return struct_to_dict(response.result)

--- a/src/viam/services/sensors/client.py
+++ b/src/viam/services/sensors/client.py
@@ -22,7 +22,13 @@ class SensorsClient(ServiceClientBase, ReconfigurableResourceRPCClientBase):
         super().__init__(name, channel)
         self.client = SensorsServiceStub(channel)
 
-    async def get_sensors(self, *, extra: Optional[Mapping[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> List[ResourceName]:
+    async def get_sensors(
+        self,
+        *,
+        extra: Optional[Mapping[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> List[ResourceName]:
         """Get the ``ResourceName`` of all the ``Sensor`` resources connected to this Robot
 
         Returns:

--- a/src/viam/services/slam/client.py
+++ b/src/viam/services/slam/client.py
@@ -32,26 +32,31 @@ class SLAMClient(SLAM, ReconfigurableResourceRPCClientBase):
         self.client = SLAMServiceStub(channel)
         super().__init__(name)
 
-    async def get_position(self, *, timeout: Optional[float] = None) -> Pose:
+    async def get_position(self, *, timeout: Optional[float] = None, **kwargs) -> Pose:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetPositionRequest(name=self.name)
-        response: GetPositionResponse = await self.client.GetPosition(request, timeout=timeout)
+        response: GetPositionResponse = await self.client.GetPosition(request, timeout=timeout, metadata=md)
         return response.pose
 
-    async def get_point_cloud_map(self, return_edited_map: bool = False, *, timeout: Optional[float] = None) -> List[bytes]:
+    async def get_point_cloud_map(self, return_edited_map: bool = False, *, timeout: Optional[float] = None, **kwargs) -> List[bytes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetPointCloudMapRequest(name=self.name, return_edited_map=return_edited_map)
-        response: List[GetPointCloudMapResponse] = await self.client.GetPointCloudMap(request, timeout=timeout)
+        response: List[GetPointCloudMapResponse] = await self.client.GetPointCloudMap(request, timeout=timeout, metadata=md)
         return [r.point_cloud_pcd_chunk for r in response]
 
-    async def get_internal_state(self, *, timeout: Optional[float] = None) -> List[bytes]:
+    async def get_internal_state(self, *, timeout: Optional[float] = None, **kwargs) -> List[bytes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetInternalStateRequest(name=self.name)
-        response: List[GetInternalStateResponse] = await self.client.GetInternalState(request, timeout=timeout)
+        response: List[GetInternalStateResponse] = await self.client.GetInternalState(request, timeout=timeout, metadata=md)
         return [r.internal_state_chunk for r in response]
 
-    async def get_properties(self, *, timeout: Optional[float] = None) -> SLAM.Properties:
+    async def get_properties(self, *, timeout: Optional[float] = None, **kwargs) -> SLAM.Properties:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetPropertiesRequest(name=self.name)
-        return await self.client.GetProperties(request, timeout=timeout)
+        return await self.client.GetProperties(request, timeout=timeout, metadata=md)
 
-    async def do_command(self, command: Mapping[str, ValueTypes], *, timeout: Optional[float] = None, **__) -> Mapping[str, ValueTypes]:
+    async def do_command(self, command: Mapping[str, ValueTypes], *, timeout: Optional[float] = None, **kwargs) -> Mapping[str, ValueTypes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         return struct_to_dict(response.result)

--- a/src/viam/services/vision/client.py
+++ b/src/viam/services/vision/client.py
@@ -129,7 +129,8 @@ class VisionClient(Vision, ReconfigurableResourceRPCClientBase):
     ) -> List[Classification]:
         md = kwargs.get('metadata', self.Metadata()).proto
         request = GetClassificationsFromCameraRequest(name=self.name, camera_name=camera_name, n=count, extra=dict_to_struct(extra))
-        response: GetClassificationsFromCameraResponse = await self.client.GetClassificationsFromCamera(request, timeout=timeout, metadata=md)
+        response: GetClassificationsFromCameraResponse = await self.client.GetClassificationsFromCamera(
+                request, timeout=timeout, metadata=md)
         return list(response.classifications)
 
     async def get_classifications(

--- a/src/viam/services/vision/client.py
+++ b/src/viam/services/vision/client.py
@@ -53,9 +53,9 @@ class VisionClient(Vision, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Mapping[str, Any]] = None,
         timeout: Optional[float] = None,
+        **kwargs,
     ) -> CaptureAllResult:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = CaptureAllFromCameraRequest(
             name=self.name,
             camera_name=camera_name,
@@ -65,7 +65,7 @@ class VisionClient(Vision, ReconfigurableResourceRPCClientBase):
             return_object_point_clouds=return_object_point_clouds,
             extra=dict_to_struct(extra),
         )
-        response: CaptureAllFromCameraResponse = await self.client.CaptureAllFromCamera(request, timeout=timeout)
+        response: CaptureAllFromCameraResponse = await self.client.CaptureAllFromCamera(request, timeout=timeout, metadata=md)
         result = CaptureAllResult()
         result.extra = struct_to_dict(response.extra)
         if return_image:
@@ -86,11 +86,11 @@ class VisionClient(Vision, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Mapping[str, Any]] = None,
         timeout: Optional[float] = None,
+        **kwargs,
     ) -> List[Detection]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetDetectionsFromCameraRequest(name=self.name, camera_name=camera_name, extra=dict_to_struct(extra))
-        response: GetDetectionsFromCameraResponse = await self.client.GetDetectionsFromCamera(request, timeout=timeout)
+        response: GetDetectionsFromCameraResponse = await self.client.GetDetectionsFromCamera(request, timeout=timeout, metadata=md)
         return list(response.detections)
 
     async def get_detections(
@@ -99,9 +99,9 @@ class VisionClient(Vision, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Mapping[str, Any]] = None,
         timeout: Optional[float] = None,
+        **kwargs,
     ) -> List[Detection]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         mime_type = CameraMimeType.JPEG
 
         if image.width is None or image.height is None:
@@ -115,7 +115,7 @@ class VisionClient(Vision, ReconfigurableResourceRPCClientBase):
                 mime_type=mime_type,
                 extra=dict_to_struct(extra),
             )
-        response: GetDetectionsResponse = await self.client.GetDetections(request, timeout=timeout)
+        response: GetDetectionsResponse = await self.client.GetDetections(request, timeout=timeout, metadata=md)
         return list(response.detections)
 
     async def get_classifications_from_camera(
@@ -125,11 +125,11 @@ class VisionClient(Vision, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Mapping[str, Any]] = None,
         timeout: Optional[float] = None,
+        **kwargs,
     ) -> List[Classification]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetClassificationsFromCameraRequest(name=self.name, camera_name=camera_name, n=count, extra=dict_to_struct(extra))
-        response: GetClassificationsFromCameraResponse = await self.client.GetClassificationsFromCamera(request, timeout=timeout)
+        response: GetClassificationsFromCameraResponse = await self.client.GetClassificationsFromCamera(request, timeout=timeout, metadata=md)
         return list(response.classifications)
 
     async def get_classifications(
@@ -139,9 +139,9 @@ class VisionClient(Vision, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Mapping[str, Any]] = None,
         timeout: Optional[float] = None,
+        **kwargs,
     ) -> List[Classification]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
 
         mime_type = CameraMimeType.JPEG
         if image.width is None or image.height is None:
@@ -155,7 +155,7 @@ class VisionClient(Vision, ReconfigurableResourceRPCClientBase):
             n=count,
             extra=dict_to_struct(extra),
         )
-        response: GetClassificationsResponse = await self.client.GetClassifications(request, timeout=timeout)
+        response: GetClassificationsResponse = await self.client.GetClassifications(request, timeout=timeout, metadata=md)
         return list(response.classifications)
 
     async def get_object_point_clouds(
@@ -164,16 +164,16 @@ class VisionClient(Vision, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Mapping[str, Any]] = None,
         timeout: Optional[float] = None,
+        **kwargs,
     ) -> List[PointCloudObject]:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetObjectPointCloudsRequest(
             name=self.name,
             camera_name=camera_name,
             mime_type=CameraMimeType.PCD,
             extra=dict_to_struct(extra),
         )
-        response: GetObjectPointCloudsResponse = await self.client.GetObjectPointClouds(request, timeout=timeout)
+        response: GetObjectPointCloudsResponse = await self.client.GetObjectPointClouds(request, timeout=timeout, metadata=md)
         return list(response.objects)
 
     async def get_properties(
@@ -181,14 +181,14 @@ class VisionClient(Vision, ReconfigurableResourceRPCClientBase):
         *,
         extra: Optional[Mapping[str, Any]] = None,
         timeout: Optional[float] = None,
+        **kwargs,
     ) -> Vision.Properties:
-        if extra is None:
-            extra = {}
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = GetPropertiesRequest(
             name=self.name,
             extra=dict_to_struct(extra),
         )
-        response: GetPropertiesResponse = await self.client.GetProperties(request, timeout=timeout)
+        response: GetPropertiesResponse = await self.client.GetProperties(request, timeout=timeout, metadata=md)
         return response
 
     async def do_command(
@@ -196,8 +196,9 @@ class VisionClient(Vision, ReconfigurableResourceRPCClientBase):
         command: Mapping[str, ValueTypes],
         *,
         timeout: Optional[float] = None,
-        **__,
+        **kwargs,
     ) -> Mapping[str, ValueTypes]:
+        md = kwargs.get('metadata', self.Metadata()).proto
         request = DoCommandRequest(name=self.name, command=dict_to_struct(command))
-        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout)
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
         return struct_to_dict(response.result)

--- a/src/viam/utils.py
+++ b/src/viam/utils.py
@@ -135,7 +135,7 @@ def struct_to_message(struct: Struct, message_type: Type[_T]) -> _T:
     return ParseDict(dct, message_type())
 
 
-def dict_to_struct(obj: Mapping[str, ValueTypes]) -> Struct:
+def dict_to_struct(obj: Optional[Mapping[str, ValueTypes]]) -> Struct:
     def _convert(v: ValueTypes) -> Any:
         if isinstance(v, bool):
             return v

--- a/src/viam/utils.py
+++ b/src/viam/utils.py
@@ -148,6 +148,8 @@ def dict_to_struct(obj: Mapping[str, ValueTypes]) -> Struct:
             return {k: _convert(vv) for (k, vv) in v.items()}
         return v
 
+    if obj is None:
+        obj = {}
     struct = Struct()
     struct.update({k: _convert(v) for (k, v) in obj.items()})
     return struct

--- a/src/viam/utils.py
+++ b/src/viam/utils.py
@@ -15,6 +15,7 @@ from viam.proto.app.data import CaptureInterval, Filter, TagsFilter
 from viam.proto.common import Geometry, GeoPoint, GetGeometriesRequest, GetGeometriesResponse, Orientation, ResourceName, Vector3
 from viam.resource.base import ResourceBase
 from viam.resource.registry import Registry
+from viam.resource.rpc_client_base import ResourceRPCClientBase
 from viam.resource.types import Subtype, SupportsGetGeometries
 
 if sys.version_info >= (3, 9):
@@ -168,12 +169,15 @@ def datetime_to_timestamp(dt: Optional[datetime]) -> Optional[Timestamp]:
 
 
 async def get_geometries(
-    client: SupportsGetGeometries, name: str, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None
+        client: SupportsGetGeometries,
+        name: str,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        metadata: ResourceRPCClientBase.Metadata = ResourceRPCClientBase.Metadata(),
 ) -> List[Geometry]:
-    if extra is None:
-        extra = {}
+    md = metadata.proto
     request = GetGeometriesRequest(name=name, extra=dict_to_struct(extra))
-    response: GetGeometriesResponse = await client.GetGeometries(request, timeout=timeout)
+    response: GetGeometriesResponse = await client.GetGeometries(request, timeout=timeout, metadata=md)
     return [geometry for geometry in response.geometries]
 
 


### PR DESCRIPTION
Adds the gRPC debugging client api.

Note to reviewers: a lot of this is pretty boilerplate. I certainly won't complain if you look at all of it but I think the main places to focus are `rpc_client_base.py` and `utils.py`

Flyby: refactors `dict_to_struct` to make the obj argument type optional, such that we don't need to have `if extra is None: extra = {}` in every method.

Example code:

```python
robot = await connect()
motor = Motor.from_robot(robot, "<my-motor-name>")
# only a single metadata need be created, which can then be passed to any number of methods
# from any number of resources, provided the user is happy with the logs sharing the same key
md = motor.Metadata()
md.enable_debug_logging('my-cool-key') # the key is optional; if not provided, a random key will be generated
await motor.go_for(rpm=100, revolutions=5, metadata=md)
await robot.close()
```

example logs: 

![Screenshot 2024-09-26 at 11 43 18](https://github.com/user-attachments/assets/89442baf-93d0-4a07-962e-0ddaa3368880)
