### PR TITLE
Add default validator to easy resource

### DIFF
--- a/src/viam/resource/easy_resource.py
+++ b/src/viam/resource/easy_resource.py
@@ -1,7 +1,7 @@
 import inspect
 import re
 from abc import ABCMeta
-from typing import Callable, ClassVar, Mapping, Union
+from typing import Callable, ClassVar, Mapping, Sequence, Union
 
 from viam.proto.app.robot import ComponentConfig
 from viam.proto.common import ResourceName
@@ -122,6 +122,19 @@ class EasyResource:
         return self
 
     @classmethod
+    def validate_config(cls, config: ComponentConfig) -> Sequence[str]:
+        """This method allows you to validate the configuration object received from the machine,
+        as well as to return any implicit dependencies based on that `config`.
+
+        Args:
+            config (ComponentConfig): The configuration for this resource
+
+        Returns:
+            Sequence[str]: A list of implicit dependencies
+        """
+        return []
+
+    @classmethod
     def register(cls):
         """
         This adds the model to the global registry. It is called by __init_subclass__ and you typically
@@ -133,7 +146,7 @@ class EasyResource:
         Registry.register_resource_creator(
             cls.SUBTYPE,
             cls.MODEL,
-            ResourceCreatorRegistration(cls.new),  # pyright: ignore [reportArgumentType]
+            ResourceCreatorRegistration(cls.new, cls.validate_config),  # pyright: ignore [reportArgumentType]
         )
 
     def reconfigure(self, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]):


### PR DESCRIPTION
This allows for users who have a `validate_config` function to continue to use `EasyResource`, and doesn't affect it otherwise. 

Useful for the module generator where we default to `EasyResource`