### PR TITLE
RSDK-9146: Change Python TabularDataBySQL/MQL return type to raw BSON

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "grpclib>=0.4.7",
     "protobuf==5.28.2",
     "typing-extensions>=4.12.2",
+	"pymongo>=4.10.1"
 ]
 
 [project.urls]
@@ -57,7 +58,6 @@ dev-dependencies = [
 	"sphinx-autoapi>=3.0.0; python_version>='3.9'",
 	"sphinx-rtd-theme>=2.0.0",
 	"types-pillow>=10.2.0.20240822",
-	"pymongo>=4.10.1"
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev-dependencies = [
 	"sphinx-autoapi>=3.0.0; python_version>='3.9'",
 	"sphinx-rtd-theme>=2.0.0",
 	"types-pillow>=10.2.0.20240822",
+	"pymongo>=4.10.1"
 ]
 
 [tool.pytest.ini_options]

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -267,7 +267,7 @@ class DataClient:
         response: TabularDataBySQLResponse = await self._data_client.TabularDataBySQL(request, metadata=self._metadata)
         return [bson.decode(bson_bytes) for bson_bytes in response.raw_data]
 
-    async def tabular_data_by_mql(self, organization_id: str, mql_binary: List[bytes]) -> List[Dict[str, ValueTypes]]:
+    async def tabular_data_by_mql(self, organization_id: str, mql_binary: List[bytes]) -> List[Dict[str, Union[ValueTypes, datetime]]]:
         """Obtain unified tabular data and metadata, queried with MQL.
 
         ::
@@ -304,7 +304,7 @@ class DataClient:
         """
         request = TabularDataByMQLRequest(organization_id=organization_id, mql_binary=mql_binary)
         response: TabularDataByMQLResponse = await self._data_client.TabularDataByMQL(request, metadata=self._metadata)
-        return [struct_to_dict(struct) for struct in response.data]
+        return [bson.decode(bson_bytes) for bson_bytes in response.raw_data]
 
     async def binary_data_by_filter(
         self,

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -266,16 +266,6 @@ class DataClient:
         """
         request = TabularDataBySQLRequest(organization_id=organization_id, sql_query=sql_query)
         response: TabularDataBySQLResponse = await self._data_client.TabularDataBySQL(request, metadata=self._metadata)
-        # data = []
-        # for bson_bytes in response.raw_data:
-        #     decoded_data = bson.decode(bson_bytes)
-        #     for key, value in decoded_data.items():
-        #         if isinstance(value, Timestamp):
-        #             decoded_data[key] = value.ToDatetime()
-        #     data.append(decoded_data)
-        # # return [bson.decode(bson_bytes) for bson_bytes in response.raw_data]
-        # return data
-        #this is incredibly hard to read but it follows the previous pattern
         return [{key: (value.ToDatetime() if isinstance(value, Timestamp) else value) for key, value in bson.decode(bson_bytes).items()} for bson_bytes in response.raw_data]
 
     async def tabular_data_by_mql(self, organization_id: str, mql_binary: List[bytes]) -> List[Dict[str, Union[ValueTypes, datetime]]]:
@@ -315,17 +305,7 @@ class DataClient:
         """
         request = TabularDataByMQLRequest(organization_id=organization_id, mql_binary=mql_binary)
         response: TabularDataByMQLResponse = await self._data_client.TabularDataByMQL(request, metadata=self._metadata)
-        # data = []
-        # for bson_bytes in response.raw_data:
-        #     decoded_data = bson.decode(bson_bytes)
-        #     for key, value in decoded_data.items():
-        #         if isinstance(value, Timestamp):
-        #             decoded_data[key] = value.ToDatetime()
-        #     data.append(decoded_data)
-        # return data
         return [{key: (value.ToDatetime() if isinstance(value, Timestamp) else value) for key, value in bson.decode(bson_bytes).items()} for bson_bytes in response.raw_data]
-
-        # return [bson.decode(bson_bytes) for bson_bytes in response.raw_data]
 
     async def binary_data_by_filter(
         self,

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 import bson
 
-from google.protobuf.timestamp_pb2 import Timestamp
 from google.protobuf.struct_pb2 import Struct
 from grpclib.client import Channel, Stream
 
@@ -266,7 +265,7 @@ class DataClient:
         """
         request = TabularDataBySQLRequest(organization_id=organization_id, sql_query=sql_query)
         response: TabularDataBySQLResponse = await self._data_client.TabularDataBySQL(request, metadata=self._metadata)
-        return [{key: (value.ToDatetime() if isinstance(value, Timestamp) else value) for key, value in bson.decode(bson_bytes).items()} for bson_bytes in response.raw_data]
+        return [bson.decode(bson_bytes) for bson_bytes in response.raw_data]
 
     async def tabular_data_by_mql(self, organization_id: str, mql_binary: List[bytes]) -> List[Dict[str, Union[ValueTypes, datetime]]]:
         """Obtain unified tabular data and metadata, queried with MQL.
@@ -305,7 +304,7 @@ class DataClient:
         """
         request = TabularDataByMQLRequest(organization_id=organization_id, mql_binary=mql_binary)
         response: TabularDataByMQLResponse = await self._data_client.TabularDataByMQL(request, metadata=self._metadata)
-        return [{key: (value.ToDatetime() if isinstance(value, Timestamp) else value) for key, value in bson.decode(bson_bytes).items()} for bson_bytes in response.raw_data]
+        return [bson.decode(bson_bytes) for bson_bytes in response.raw_data]
 
     async def binary_data_by_filter(
         self,

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 import bson
 
+from google.protobuf.timestamp_pb2 import Timestamp
 from google.protobuf.struct_pb2 import Struct
 from grpclib.client import Channel, Stream
 
@@ -265,7 +266,17 @@ class DataClient:
         """
         request = TabularDataBySQLRequest(organization_id=organization_id, sql_query=sql_query)
         response: TabularDataBySQLResponse = await self._data_client.TabularDataBySQL(request, metadata=self._metadata)
-        return [bson.decode(bson_bytes) for bson_bytes in response.raw_data]
+        # data = []
+        # for bson_bytes in response.raw_data:
+        #     decoded_data = bson.decode(bson_bytes)
+        #     for key, value in decoded_data.items():
+        #         if isinstance(value, Timestamp):
+        #             decoded_data[key] = value.ToDatetime()
+        #     data.append(decoded_data)
+        # # return [bson.decode(bson_bytes) for bson_bytes in response.raw_data]
+        # return data
+        #this is incredibly hard to read but it follows the previous pattern
+        return [{key: (value.ToDatetime() if isinstance(value, Timestamp) else value) for key, value in bson.decode(bson_bytes).items()} for bson_bytes in response.raw_data]
 
     async def tabular_data_by_mql(self, organization_id: str, mql_binary: List[bytes]) -> List[Dict[str, Union[ValueTypes, datetime]]]:
         """Obtain unified tabular data and metadata, queried with MQL.
@@ -304,7 +315,17 @@ class DataClient:
         """
         request = TabularDataByMQLRequest(organization_id=organization_id, mql_binary=mql_binary)
         response: TabularDataByMQLResponse = await self._data_client.TabularDataByMQL(request, metadata=self._metadata)
-        return [bson.decode(bson_bytes) for bson_bytes in response.raw_data]
+        # data = []
+        # for bson_bytes in response.raw_data:
+        #     decoded_data = bson.decode(bson_bytes)
+        #     for key, value in decoded_data.items():
+        #         if isinstance(value, Timestamp):
+        #             decoded_data[key] = value.ToDatetime()
+        #     data.append(decoded_data)
+        # return data
+        return [{key: (value.ToDatetime() if isinstance(value, Timestamp) else value) for key, value in bson.decode(bson_bytes).items()} for bson_bytes in response.raw_data]
+
+        # return [bson.decode(bson_bytes) for bson_bytes in response.raw_data]
 
     async def binary_data_by_filter(
         self,

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -994,6 +994,7 @@ class MockData(UnimplementedDataServiceBase):
         assert request is not None
         await stream.send_message(TabularDataByMQLResponse(raw_data=[bson.encode(dict) for dict in self.tabular_query_response]))
 
+
 class MockDataset(DatasetServiceBase):
     def __init__(self, create_response: str, datasets_response: Sequence[Dataset]):
         self.create_response = create_response

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -6,7 +6,6 @@ from numpy.typing import NDArray
 from datetime import datetime
 import bson
 
-from google.protobuf.timestamp_pb2 import Timestamp
 from viam.app.data_client import DataClient
 from viam.gen.app.v1.app_pb2 import FragmentHistoryEntry, GetFragmentHistoryRequest, GetFragmentHistoryResponse
 from viam.media.video import ViamImage
@@ -988,20 +987,12 @@ class MockData(UnimplementedDataServiceBase):
     async def TabularDataBySQL(self, stream: Stream[TabularDataBySQLRequest, TabularDataBySQLResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        await stream.send_message(TabularDataBySQLResponse(
-        raw_data=[bson.encode({key: (value.ToDatetime() if isinstance(value, Timestamp) else value)
-                               for key, value in dict.items()})
-                               for dict in self.tabular_query_response]))
+        await stream.send_message(TabularDataBySQLResponse(raw_data=[bson.encode(dict) for dict in self.tabular_query_response]))
 
     async def TabularDataByMQL(self, stream: Stream[TabularDataByMQLRequest, TabularDataByMQLResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        await stream.send_message(TabularDataByMQLResponse(
-        raw_data=[bson.encode({key: (value.ToDatetime() if isinstance(value, Timestamp) else value)
-                               for key, value in dict.items()})
-                               for dict in self.tabular_query_response]))
-
-
+        await stream.send_message(TabularDataByMQLResponse(raw_data=[bson.encode(dict) for dict in self.tabular_query_response]))
 
 class MockDataset(DatasetServiceBase):
     def __init__(self, create_response: str, datasets_response: Sequence[Dataset]):

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -5,6 +5,8 @@ from grpclib.server import Stream
 from numpy.typing import NDArray
 from datetime import datetime
 import bson
+from google.protobuf.timestamp_pb2 import Timestamp
+from datetime import datetime
 
 from viam.app.data_client import DataClient
 from viam.gen.app.v1.app_pb2 import FragmentHistoryEntry, GetFragmentHistoryRequest, GetFragmentHistoryResponse
@@ -987,12 +989,22 @@ class MockData(UnimplementedDataServiceBase):
     async def TabularDataBySQL(self, stream: Stream[TabularDataBySQLRequest, TabularDataBySQLResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        await stream.send_message(TabularDataBySQLResponse(raw_data=[bson.encode(dict) for dict in self.tabular_query_response]))
+        # await stream.send_message(TabularDataBySQLResponse(raw_data=[bson.encode(dict) for dict in self.tabular_query_response]))
+        # In TabularDataBySQL or TabularDataByMQL
+        await stream.send_message(TabularDataBySQLResponse(
+        raw_data=[bson.encode({key: (value.ToDatetime() if isinstance(value, Timestamp) else value)
+                               for key, value in dict.items()})
+                               for dict in self.tabular_query_response]))
+
 
     async def TabularDataByMQL(self, stream: Stream[TabularDataByMQLRequest, TabularDataByMQLResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        await stream.send_message(TabularDataByMQLResponse(raw_data=[bson.encode(dict) for dict in self.tabular_query_response]))
+        # await stream.send_message(TabularDataByMQLResponse(raw_data=[bson.encode(dict) for dict in self.tabular_query_response]))
+        await stream.send_message(TabularDataByMQLResponse(
+        raw_data=[bson.encode({key: (value.ToDatetime() if isinstance(value, Timestamp) else value)
+                               for key, value in dict.items()})
+                               for dict in self.tabular_query_response]))
 
 
 

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -989,10 +989,10 @@ class MockData(UnimplementedDataServiceBase):
         assert request is not None
         await stream.send_message(TabularDataBySQLResponse(raw_data=[bson.encode(dict) for dict in self.tabular_query_response]))
 
-    # async def TabularDataByMQL(self, stream: Stream[TabularDataByMQLRequest, TabularDataByMQLResponse]) -> None:
-    #     request = await stream.recv_message()
-    #     assert request is not None
-    #     await stream.send_message(TabularDataByMQLResponse(data=[dict_to_struct(dict) for dict in self.tabular_query_response]))
+    async def TabularDataByMQL(self, stream: Stream[TabularDataByMQLRequest, TabularDataByMQLResponse]) -> None:
+        request = await stream.recv_message()
+        assert request is not None
+        await stream.send_message(TabularDataByMQLResponse(data=[dict_to_struct(dict) for dict in self.tabular_query_response]))
 
 
 class MockDataset(DatasetServiceBase):

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -1,8 +1,10 @@
-from typing import Any, Dict, List, Mapping, Optional, Sequence
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
 import numpy as np
 from grpclib.server import Stream
 from numpy.typing import NDArray
+from datetime import datetime
+import bson
 
 from viam.app.data_client import DataClient
 from viam.gen.app.v1.app_pb2 import FragmentHistoryEntry, GetFragmentHistoryRequest, GetFragmentHistoryResponse
@@ -791,12 +793,11 @@ class MockProvisioning(ProvisioningServiceBase):
         self.cloud_config = request.cloud
         await stream.send_message(SetSmartMachineCredentialsResponse())
 
-
 class MockData(UnimplementedDataServiceBase):
     def __init__(
         self,
         tabular_response: List[DataClient.TabularData],
-        tabular_query_response: List[Dict[str, ValueTypes]],
+        tabular_query_response: List[Dict[str, Union[ValueTypes, datetime]]],
         binary_response: List[BinaryData],
         delete_remove_response: int,
         tags_response: List[str],
@@ -986,12 +987,12 @@ class MockData(UnimplementedDataServiceBase):
     async def TabularDataBySQL(self, stream: Stream[TabularDataBySQLRequest, TabularDataBySQLResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        await stream.send_message(TabularDataBySQLResponse(data=[dict_to_struct(dict) for dict in self.tabular_query_response]))
+        await stream.send_message(TabularDataBySQLResponse(raw_data=[bson.encode(dict) for dict in self.tabular_query_response]))
 
-    async def TabularDataByMQL(self, stream: Stream[TabularDataByMQLRequest, TabularDataByMQLResponse]) -> None:
-        request = await stream.recv_message()
-        assert request is not None
-        await stream.send_message(TabularDataByMQLResponse(data=[dict_to_struct(dict) for dict in self.tabular_query_response]))
+    # async def TabularDataByMQL(self, stream: Stream[TabularDataByMQLRequest, TabularDataByMQLResponse]) -> None:
+    #     request = await stream.recv_message()
+    #     assert request is not None
+    #     await stream.send_message(TabularDataByMQLResponse(data=[dict_to_struct(dict) for dict in self.tabular_query_response]))
 
 
 class MockDataset(DatasetServiceBase):

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -5,9 +5,8 @@ from grpclib.server import Stream
 from numpy.typing import NDArray
 from datetime import datetime
 import bson
-from google.protobuf.timestamp_pb2 import Timestamp
-from datetime import datetime
 
+from google.protobuf.timestamp_pb2 import Timestamp
 from viam.app.data_client import DataClient
 from viam.gen.app.v1.app_pb2 import FragmentHistoryEntry, GetFragmentHistoryRequest, GetFragmentHistoryResponse
 from viam.media.video import ViamImage
@@ -989,18 +988,14 @@ class MockData(UnimplementedDataServiceBase):
     async def TabularDataBySQL(self, stream: Stream[TabularDataBySQLRequest, TabularDataBySQLResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        # await stream.send_message(TabularDataBySQLResponse(raw_data=[bson.encode(dict) for dict in self.tabular_query_response]))
-        # In TabularDataBySQL or TabularDataByMQL
         await stream.send_message(TabularDataBySQLResponse(
         raw_data=[bson.encode({key: (value.ToDatetime() if isinstance(value, Timestamp) else value)
                                for key, value in dict.items()})
                                for dict in self.tabular_query_response]))
 
-
     async def TabularDataByMQL(self, stream: Stream[TabularDataByMQLRequest, TabularDataByMQLResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        # await stream.send_message(TabularDataByMQLResponse(raw_data=[bson.encode(dict) for dict in self.tabular_query_response]))
         await stream.send_message(TabularDataByMQLResponse(
         raw_data=[bson.encode({key: (value.ToDatetime() if isinstance(value, Timestamp) else value)
                                for key, value in dict.items()})

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -992,7 +992,8 @@ class MockData(UnimplementedDataServiceBase):
     async def TabularDataByMQL(self, stream: Stream[TabularDataByMQLRequest, TabularDataByMQLResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
-        await stream.send_message(TabularDataByMQLResponse(data=[dict_to_struct(dict) for dict in self.tabular_query_response]))
+        await stream.send_message(TabularDataByMQLResponse(raw_data=[bson.encode(dict) for dict in self.tabular_query_response]))
+
 
 
 class MockDataset(DatasetServiceBase):

--- a/tests/test_data_client.py
+++ b/tests/test_data_client.py
@@ -4,7 +4,7 @@ import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
 from grpclib.testing import ChannelFor
 
-
+from datetime import datetime
 from viam.app.data_client import DataClient
 from viam.proto.app.data import Annotations, BinaryData, BinaryID, BinaryMetadata, BoundingBox, CaptureMetadata, Filter, Order
 from viam.utils import create_filter
@@ -101,9 +101,6 @@ BINARY_METADATA = BinaryMetadata(
 )
 
 TABULAR_RESPONSE = [DataClient.TabularData(TABULAR_DATA, TABULAR_METADATA, START_DATETIME, END_DATETIME)]
-# TABULAR_QUERY_RESPONSE = [
-#     {"key1": 1, "key2": "2", "key3": [1, 2, 3], "key4": {"key4sub1": 1}},
-# ]
 TABULAR_QUERY_RESPONSE = [
     {"key1": START_DATETIME, "key2": "2", "key3": [1, 2, 3], "key4": {"key4sub1": END_DATETIME}},
 ]
@@ -157,13 +154,14 @@ class TestClient:
         async with ChannelFor([service]) as channel:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             response = await client.tabular_data_by_sql(ORG_ID, SQL_QUERY)
-            # assert isinstance(response[0]["key1"], datetime)
+            assert isinstance(response[0]["key1"], datetime)
             assert response == TABULAR_QUERY_RESPONSE
 
     async def test_tabular_data_by_mql(self, service: MockData):
         async with ChannelFor([service]) as channel:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             response = await client.tabular_data_by_mql(ORG_ID, MQL_BINARY)
+            assert isinstance(response[0]["key1"], datetime)
             assert response == TABULAR_QUERY_RESPONSE
 
     async def test_binary_data_by_filter(self, service: MockData):

--- a/tests/test_data_client.py
+++ b/tests/test_data_client.py
@@ -3,6 +3,8 @@ from typing import List
 import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
 from grpclib.testing import ChannelFor
+from datetime import datetime
+
 
 from viam.app.data_client import DataClient
 from viam.proto.app.data import Annotations, BinaryData, BinaryID, BinaryMetadata, BoundingBox, CaptureMetadata, Filter, Order
@@ -100,8 +102,11 @@ BINARY_METADATA = BinaryMetadata(
 )
 
 TABULAR_RESPONSE = [DataClient.TabularData(TABULAR_DATA, TABULAR_METADATA, START_DATETIME, END_DATETIME)]
+# TABULAR_QUERY_RESPONSE = [
+#     {"key1": 1, "key2": "2", "key3": [1, 2, 3], "key4": {"key4sub1": 1}},
+# ]
 TABULAR_QUERY_RESPONSE = [
-    {"key1": 1, "key2": "2", "key3": [1, 2, 3], "key4": {"key4sub1": 1}},
+    {"key1": START_DATETIME, "key2": "2", "key3": [1, 2, 3], "key4": {"key4sub1": END_DATETIME}},
 ]
 BINARY_RESPONSE = [BinaryData(binary=BINARY_DATA, metadata=BINARY_METADATA)]
 DELETE_REMOVE_RESPONSE = 1
@@ -153,13 +158,14 @@ class TestClient:
         async with ChannelFor([service]) as channel:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             response = await client.tabular_data_by_sql(ORG_ID, SQL_QUERY)
+            # assert isinstance(response[0]["key1"], datetime)
             assert response == TABULAR_QUERY_RESPONSE
 
-    async def test_tabular_data_by_mql(self, service: MockData):
-        async with ChannelFor([service]) as channel:
-            client = DataClient(channel, DATA_SERVICE_METADATA)
-            response = await client.tabular_data_by_mql(ORG_ID, MQL_BINARY)
-            assert response == TABULAR_QUERY_RESPONSE
+    # async def test_tabular_data_by_mql(self, service: MockData):
+    #     async with ChannelFor([service]) as channel:
+    #         client = DataClient(channel, DATA_SERVICE_METADATA)
+    #         response = await client.tabular_data_by_mql(ORG_ID, MQL_BINARY)
+    #         assert response == TABULAR_QUERY_RESPONSE
 
     async def test_binary_data_by_filter(self, service: MockData):
         async with ChannelFor([service]) as channel:

--- a/tests/test_data_client.py
+++ b/tests/test_data_client.py
@@ -3,7 +3,6 @@ from typing import List
 import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
 from grpclib.testing import ChannelFor
-from datetime import datetime
 
 
 from viam.app.data_client import DataClient
@@ -161,11 +160,11 @@ class TestClient:
             # assert isinstance(response[0]["key1"], datetime)
             assert response == TABULAR_QUERY_RESPONSE
 
-    # async def test_tabular_data_by_mql(self, service: MockData):
-    #     async with ChannelFor([service]) as channel:
-    #         client = DataClient(channel, DATA_SERVICE_METADATA)
-    #         response = await client.tabular_data_by_mql(ORG_ID, MQL_BINARY)
-    #         assert response == TABULAR_QUERY_RESPONSE
+    async def test_tabular_data_by_mql(self, service: MockData):
+        async with ChannelFor([service]) as channel:
+            client = DataClient(channel, DATA_SERVICE_METADATA)
+            response = await client.tabular_data_by_mql(ORG_ID, MQL_BINARY)
+            assert response == TABULAR_QUERY_RESPONSE
 
     async def test_binary_data_by_filter(self, service: MockData):
         async with ChannelFor([service]) as channel:

--- a/tests/test_data_client.py
+++ b/tests/test_data_client.py
@@ -102,7 +102,7 @@ BINARY_METADATA = BinaryMetadata(
 
 TABULAR_RESPONSE = [DataClient.TabularData(TABULAR_DATA, TABULAR_METADATA, START_DATETIME, END_DATETIME)]
 TABULAR_QUERY_RESPONSE = [
-    {"key1": START_TS, "key2": "2", "key3": [1, 2, 3], "key4": {"key4sub1": END_DATETIME}},
+    {"key1": START_DATETIME, "key2": "2", "key3": [1, 2, 3], "key4": {"key4sub1": END_DATETIME}},
 ]
 BINARY_RESPONSE = [BinaryData(binary=BINARY_DATA, metadata=BINARY_METADATA)]
 DELETE_REMOVE_RESPONSE = 1
@@ -155,27 +155,14 @@ class TestClient:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             response = await client.tabular_data_by_sql(ORG_ID, SQL_QUERY)
             assert isinstance(response[0]["key1"], datetime)
-            for item, expected_item in zip(response, TABULAR_QUERY_RESPONSE):
-                assert self.custom_compare(item, expected_item)
+            assert response == TABULAR_QUERY_RESPONSE
 
     async def test_tabular_data_by_mql(self, service: MockData):
         async with ChannelFor([service]) as channel:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             response = await client.tabular_data_by_mql(ORG_ID, MQL_BINARY)
             assert isinstance(response[0]["key1"], datetime)
-            for item, expected_item in zip(response, TABULAR_QUERY_RESPONSE):
-                assert self.custom_compare(item, expected_item)
-
-    def custom_compare(self, lhs, rhs):
-        for key in lhs:
-            if lhs[key] == rhs[key]:
-                continue
-            if isinstance(lhs[key], Timestamp) and lhs[key].ToDatetime() == rhs[key]:
-                continue
-            if isinstance(rhs[key], Timestamp) and rhs[key].ToDatetime() == lhs[key]:
-                continue
-            return False
-        return True
+            assert response == TABULAR_QUERY_RESPONSE
 
     async def test_binary_data_by_filter(self, service: MockData):
         async with ChannelFor([service]) as channel:

--- a/tests/test_data_client.py
+++ b/tests/test_data_client.py
@@ -150,41 +150,13 @@ class TestClient:
             assert last_response != ""
             self.assert_filter(filter=service.filter)
 
-    # def custom_compare(self, lhs: dict, rhs: dict):
-    #     for key in lhs:
-    #         if lhs[key] == rhs[key]:
-    #             continue
-    #         if isinstance(lhs[key], Timestamp) and lhs[key].ToDatetime() == rhs[key]:
-    #             continue
-    #         return False
-    #     return True
-
-
-    def custom_compare(self, lhs, rhs):
-        for key in lhs:
-            # Check if the values are equal as is
-            if lhs[key] == rhs[key]:
-                continue
-            # Handle case where lhs is Timestamp and rhs is datetime
-            if isinstance(lhs[key], Timestamp) and lhs[key].ToDatetime() == rhs[key]:
-                continue
-            # Handle case where rhs is Timestamp and lhs is datetime
-            if isinstance(rhs[key], Timestamp) and rhs[key].ToDatetime() == lhs[key]:
-                continue
-            return False
-        return True
-
     async def test_tabular_data_by_sql(self, service: MockData):
         async with ChannelFor([service]) as channel:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             response = await client.tabular_data_by_sql(ORG_ID, SQL_QUERY)
             assert isinstance(response[0]["key1"], datetime)
-            # Compare each item in the response with the expected response
-            # for item, expected_item in zip(response, TABULAR_QUERY_RESPONSE):
-            #     assert self.custom_compare(item, expected_item), "The response does not match the expected format."
             for item, expected_item in zip(response, TABULAR_QUERY_RESPONSE):
-                assert self.custom_compare(item, expected_item), "Mismatch in response data."
-            # assert response == TABULAR_QUERY_RESPONSE
+                assert self.custom_compare(item, expected_item)
 
     async def test_tabular_data_by_mql(self, service: MockData):
         async with ChannelFor([service]) as channel:
@@ -192,8 +164,18 @@ class TestClient:
             response = await client.tabular_data_by_mql(ORG_ID, MQL_BINARY)
             assert isinstance(response[0]["key1"], datetime)
             for item, expected_item in zip(response, TABULAR_QUERY_RESPONSE):
-                assert self.custom_compare(item, expected_item), "Mismatch in response data."
-            # assert response == TABULAR_QUERY_RESPONSE
+                assert self.custom_compare(item, expected_item)
+
+    def custom_compare(self, lhs, rhs):
+        for key in lhs:
+            if lhs[key] == rhs[key]:
+                continue
+            if isinstance(lhs[key], Timestamp) and lhs[key].ToDatetime() == rhs[key]:
+                continue
+            if isinstance(rhs[key], Timestamp) and rhs[key].ToDatetime() == lhs[key]:
+                continue
+            return False
+        return True
 
     async def test_binary_data_by_filter(self, service: MockData):
         async with ChannelFor([service]) as channel:

--- a/tests/test_data_client.py
+++ b/tests/test_data_client.py
@@ -102,7 +102,7 @@ BINARY_METADATA = BinaryMetadata(
 
 TABULAR_RESPONSE = [DataClient.TabularData(TABULAR_DATA, TABULAR_METADATA, START_DATETIME, END_DATETIME)]
 TABULAR_QUERY_RESPONSE = [
-    {"key1": START_DATETIME, "key2": "2", "key3": [1, 2, 3], "key4": {"key4sub1": END_DATETIME}},
+    {"key1": START_TS, "key2": "2", "key3": [1, 2, 3], "key4": {"key4sub1": END_DATETIME}},
 ]
 BINARY_RESPONSE = [BinaryData(binary=BINARY_DATA, metadata=BINARY_METADATA)]
 DELETE_REMOVE_RESPONSE = 1
@@ -150,19 +150,50 @@ class TestClient:
             assert last_response != ""
             self.assert_filter(filter=service.filter)
 
+    # def custom_compare(self, lhs: dict, rhs: dict):
+    #     for key in lhs:
+    #         if lhs[key] == rhs[key]:
+    #             continue
+    #         if isinstance(lhs[key], Timestamp) and lhs[key].ToDatetime() == rhs[key]:
+    #             continue
+    #         return False
+    #     return True
+
+
+    def custom_compare(self, lhs, rhs):
+        for key in lhs:
+            # Check if the values are equal as is
+            if lhs[key] == rhs[key]:
+                continue
+            # Handle case where lhs is Timestamp and rhs is datetime
+            if isinstance(lhs[key], Timestamp) and lhs[key].ToDatetime() == rhs[key]:
+                continue
+            # Handle case where rhs is Timestamp and lhs is datetime
+            if isinstance(rhs[key], Timestamp) and rhs[key].ToDatetime() == lhs[key]:
+                continue
+            return False
+        return True
+
     async def test_tabular_data_by_sql(self, service: MockData):
         async with ChannelFor([service]) as channel:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             response = await client.tabular_data_by_sql(ORG_ID, SQL_QUERY)
             assert isinstance(response[0]["key1"], datetime)
-            assert response == TABULAR_QUERY_RESPONSE
+            # Compare each item in the response with the expected response
+            # for item, expected_item in zip(response, TABULAR_QUERY_RESPONSE):
+            #     assert self.custom_compare(item, expected_item), "The response does not match the expected format."
+            for item, expected_item in zip(response, TABULAR_QUERY_RESPONSE):
+                assert self.custom_compare(item, expected_item), "Mismatch in response data."
+            # assert response == TABULAR_QUERY_RESPONSE
 
     async def test_tabular_data_by_mql(self, service: MockData):
         async with ChannelFor([service]) as channel:
             client = DataClient(channel, DATA_SERVICE_METADATA)
             response = await client.tabular_data_by_mql(ORG_ID, MQL_BINARY)
             assert isinstance(response[0]["key1"], datetime)
-            assert response == TABULAR_QUERY_RESPONSE
+            for item, expected_item in zip(response, TABULAR_QUERY_RESPONSE):
+                assert self.custom_compare(item, expected_item), "Mismatch in response data."
+            # assert response == TABULAR_QUERY_RESPONSE
 
     async def test_binary_data_by_filter(self, service: MockData):
         async with ChannelFor([service]) as channel:

--- a/uv.lock
+++ b/uv.lock
@@ -408,6 +408,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/7d/c871f55054e403fdfd6b8f65fd6d1c4e147ed100d3e9f9ba1fe695403939/dnspython-2.6.1.tar.gz", hash = "sha256:e8f0f9c23a7b7cb99ded64e6c3a6f3e701d78f50c55e002b839dea7225cff7cc", size = 332727 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/a1/8c5287991ddb8d3e4662f71356d9656d91ab3a36618c3dd11b280df0d255/dnspython-2.6.1-py3-none-any.whl", hash = "sha256:5ef3b9680161f6fa89daf8ad451b5f1a33b18ae8a1c6778cdf4b43f08c0a6e50", size = 307696 },
+]
+
+[[package]]
 name = "docutils"
 version = "0.19"
 source = { registry = "https://pypi.org/simple" }
@@ -1455,8 +1464,6 @@ version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/c7/8c6872f7372eb6a6b2e4708b88419fb46b857f7a2e1892966b851cc79fc9/psutil-6.0.0.tar.gz", hash = "sha256:8faae4f310b6d969fa26ca0545338b21f73c6b15db7c4a8d934a5482faa818f2", size = 508067 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/66/78c9c3020f573c58101dc43a44f6855d01bbbd747e24da2f0c4491200ea3/psutil-6.0.0-cp27-none-win32.whl", hash = "sha256:02b69001f44cc73c1c5279d02b30a817e339ceb258ad75997325e0e6169d8b35", size = 249766 },
-    { url = "https://files.pythonhosted.org/packages/e1/3f/2403aa9558bea4d3854b0e5e567bc3dd8e9fbc1fc4453c0aa9aafeb75467/psutil-6.0.0-cp27-none-win_amd64.whl", hash = "sha256:21f1fb635deccd510f69f485b87433460a603919b45e2a324ad65b0cc74f8fb1", size = 253024 },
     { url = "https://files.pythonhosted.org/packages/0b/37/f8da2fbd29690b3557cca414c1949f92162981920699cd62095a984983bf/psutil-6.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c588a7e9b1173b6e866756dde596fd4cad94f9399daf99ad8c3258b3cb2b47a0", size = 250961 },
     { url = "https://files.pythonhosted.org/packages/35/56/72f86175e81c656a01c4401cd3b1c923f891b31fbcebe98985894176d7c9/psutil-6.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ed2440ada7ef7d0d608f20ad89a04ec47d2d3ab7190896cd62ca5fc4fe08bf0", size = 287478 },
     { url = "https://files.pythonhosted.org/packages/19/74/f59e7e0d392bc1070e9a70e2f9190d652487ac115bb16e2eff6b22ad1d24/psutil-6.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fd9a97c8e94059b0ef54a7d4baf13b405011176c3b6ff257c247cae0d560ecd", size = 290455 },
@@ -1500,6 +1507,75 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199", size = 4891905 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a", size = 1205513 },
+]
+
+[[package]]
+name = "pymongo"
+version = "4.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/35/b62a3139f908c68b69aac6a6a3f8cc146869de0a7929b994600e2c587c77/pymongo-4.10.1.tar.gz", hash = "sha256:a9de02be53b6bb98efe0b9eda84ffa1ec027fcb23a2de62c4f941d9a2f2f3330", size = 1903902 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ca/f56b1dd84541de658d246f86828be27e32285f2151fab97efbce1db3ed57/pymongo-4.10.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e699aa68c4a7dea2ab5a27067f7d3e08555f8d2c0dc6a0c8c60cfd9ff2e6a4b1", size = 835459 },
+    { url = "https://files.pythonhosted.org/packages/97/01/fe4ee34b33c6863be6a09d1e805ceb1122d9cd5d4a5d1664e360b91adf7e/pymongo-4.10.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:70645abc714f06b4ad6b72d5bf73792eaad14e3a2cfe29c62a9c81ada69d9e4b", size = 835716 },
+    { url = "https://files.pythonhosted.org/packages/46/ff/9eb21c1d5861729ae1c91669b02f5bfbd23221ba9809fb97fade761f3f3b/pymongo-4.10.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ae2fd94c9fe048c94838badcc6e992d033cb9473eb31e5710b3707cba5e8aee2", size = 1407173 },
+    { url = "https://files.pythonhosted.org/packages/e5/d9/8cf042449d6804e00e38d3bb138b0e9acb8a8e0c9dd9dd989ffffd481c3b/pymongo-4.10.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5ded27a4a5374dae03a92e084a60cdbcecd595306555bda553b833baf3fc4868", size = 1456455 },
+    { url = "https://files.pythonhosted.org/packages/37/9a/da0d121f98c1413853e1172e2095fe77c1629c83a1db107d45a37ca935c2/pymongo-4.10.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1ecc2455e3974a6c429687b395a0bc59636f2d6aedf5785098cf4e1f180f1c71", size = 1433360 },
+    { url = "https://files.pythonhosted.org/packages/7d/6d/50480f0452e2fb59256d9d641d192366c0079920c36851b818ebeff0cec9/pymongo-4.10.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a920fee41f7d0259f5f72c1f1eb331bc26ffbdc952846f9bd8c3b119013bb52c", size = 1410758 },
+    { url = "https://files.pythonhosted.org/packages/cd/8f/b83b9910c54f63bfff34305074e79cd08cf5e12dda22d1a2b4ad009b32b3/pymongo-4.10.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e0a15665b2d6cf364f4cd114d62452ce01d71abfbd9c564ba8c74dcd7bbd6822", size = 1380257 },
+    { url = "https://files.pythonhosted.org/packages/ed/e3/8f381b576e5f912cf0fe34218c6b0ef23d7afdef13fed592900fb52f0ed4/pymongo-4.10.1-cp310-cp310-win32.whl", hash = "sha256:29e1c323c28a4584b7095378ff046815e39ff82cdb8dc4cc6dfe3acf6f9ad1f8", size = 812324 },
+    { url = "https://files.pythonhosted.org/packages/ab/14/1cae5359e2c4677856527a2965c999c23f596cced4b7828d880cb8fc0f54/pymongo-4.10.1-cp310-cp310-win_amd64.whl", hash = "sha256:88dc4aa45f8744ccfb45164aedb9a4179c93567bbd98a33109d7dc400b00eb08", size = 826774 },
+    { url = "https://files.pythonhosted.org/packages/e4/a3/d6403ec53fa2fe922b4a5c86388ea5fada01dd51d803e17bb2a7c9cda839/pymongo-4.10.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:57ee6becae534e6d47848c97f6a6dff69e3cce7c70648d6049bd586764febe59", size = 889238 },
+    { url = "https://files.pythonhosted.org/packages/29/a2/9643450424bcf241e80bb713497ec2e3273c183d548b4eca357f75d71885/pymongo-4.10.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6f437a612f4d4f7aca1812311b1e84477145e950fdafe3285b687ab8c52541f3", size = 889504 },
+    { url = "https://files.pythonhosted.org/packages/ec/40/4759984f34415509e9111be8ee863034611affdc1e0b41016c9d53b2f1b3/pymongo-4.10.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a970fd3117ab40a4001c3dad333bbf3c43687d90f35287a6237149b5ccae61d", size = 1649069 },
+    { url = "https://files.pythonhosted.org/packages/56/0f/b6e917478a3ada81e768475516cd544982cc42cbb7d3be325182768139e1/pymongo-4.10.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c4d0e7cd08ef9f8fbf2d15ba281ed55604368a32752e476250724c3ce36c72e", size = 1714927 },
+    { url = "https://files.pythonhosted.org/packages/56/c5/4237d94dfa19ebdf9a92b1071e2139c91f48908c5782e592c571c33b67ab/pymongo-4.10.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ca6f700cff6833de4872a4e738f43123db34400173558b558ae079b5535857a4", size = 1683454 },
+    { url = "https://files.pythonhosted.org/packages/9a/16/dbffca9d4ad66f2a325c280f1177912fa23235987f7b9033e283da889b7a/pymongo-4.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cec237c305fcbeef75c0bcbe9d223d1e22a6e3ba1b53b2f0b79d3d29c742b45b", size = 1653840 },
+    { url = "https://files.pythonhosted.org/packages/2b/4d/21df934ef5cf8f0e587bac922a129e13d4c0346c54e9bf2371b90dd31112/pymongo-4.10.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3337804ea0394a06e916add4e5fac1c89902f1b6f33936074a12505cab4ff05", size = 1613233 },
+    { url = "https://files.pythonhosted.org/packages/24/07/dd9c3db30e754680606295d5574521956898005db0629411a89163cc6eee/pymongo-4.10.1-cp311-cp311-win32.whl", hash = "sha256:778ac646ce6ac1e469664062dfe9ae1f5c9961f7790682809f5ec3b8fda29d65", size = 857331 },
+    { url = "https://files.pythonhosted.org/packages/02/68/b71c4106d03eef2482eade440c6f5737c2a4a42f6155726009f80ea38d06/pymongo-4.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:9df4ab5594fdd208dcba81be815fa8a8a5d8dedaf3b346cbf8b61c7296246a7a", size = 876473 },
+    { url = "https://files.pythonhosted.org/packages/10/d1/60ad99fe3f64d45e6c71ac0e3078e88d9b64112b1bae571fc3707344d6d1/pymongo-4.10.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fbedc4617faa0edf423621bb0b3b8707836687161210d470e69a4184be9ca011", size = 943356 },
+    { url = "https://files.pythonhosted.org/packages/ca/9b/21d4c6b4ee9c1fa9691c68dc2a52565e0acb644b9e95148569b4736a4ebd/pymongo-4.10.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7bd26b2aec8ceeb95a5d948d5cc0f62b0eb6d66f3f4230705c1e3d3d2c04ec76", size = 943142 },
+    { url = "https://files.pythonhosted.org/packages/07/af/691b7454e219a8eb2d1641aecedd607e3a94b93650c2011ad8a8fd74ef9f/pymongo-4.10.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb104c3c2a78d9d85571c8ac90ec4f95bca9b297c6eee5ada71fabf1129e1674", size = 1909129 },
+    { url = "https://files.pythonhosted.org/packages/0c/74/fd75d5ad4181d6e71ce0fca32404fb71b5046ac84d9a1a2f0862262dd032/pymongo-4.10.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4924355245a9c79f77b5cda2db36e0f75ece5faf9f84d16014c0a297f6d66786", size = 1987763 },
+    { url = "https://files.pythonhosted.org/packages/8a/56/6d3d0ef63c6d8cb98c7c653a3a2e617675f77a95f3853851d17a7664876a/pymongo-4.10.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:11280809e5dacaef4971113f0b4ff4696ee94cfdb720019ff4fa4f9635138252", size = 1950821 },
+    { url = "https://files.pythonhosted.org/packages/70/ed/1603fa0c0e51444752c3fa91f16c3a97e6d92eb9fe5e553dae4f18df16f6/pymongo-4.10.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5d55f2a82e5eb23795f724991cac2bffbb1c0f219c0ba3bf73a835f97f1bb2e", size = 1912247 },
+    { url = "https://files.pythonhosted.org/packages/c1/66/e98b2308971d45667cb8179d4d66deca47336c90663a7e0527589f1038b7/pymongo-4.10.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e974ab16a60be71a8dfad4e5afccf8dd05d41c758060f5d5bda9a758605d9a5d", size = 1862230 },
+    { url = "https://files.pythonhosted.org/packages/6c/80/ba9b7ed212a5f8cf8ad7037ed5bbebc1c587fc09242108f153776e4a338b/pymongo-4.10.1-cp312-cp312-win32.whl", hash = "sha256:544890085d9641f271d4f7a47684450ed4a7344d6b72d5968bfae32203b1bb7c", size = 903045 },
+    { url = "https://files.pythonhosted.org/packages/76/8b/5afce891d78159912c43726fab32641e3f9718f14be40f978c148ea8db48/pymongo-4.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:dcc07b1277e8b4bf4d7382ca133850e323b7ab048b8353af496d050671c7ac52", size = 926686 },
+    { url = "https://files.pythonhosted.org/packages/83/76/df0fd0622a85b652ad0f91ec8a0ebfd0cb86af6caec8999a22a1f7481203/pymongo-4.10.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:90bc6912948dfc8c363f4ead54d54a02a15a7fee6cfafb36dc450fc8962d2cb7", size = 996981 },
+    { url = "https://files.pythonhosted.org/packages/4c/39/fa50531de8d1d8af8c253caeed20c18ccbf1de5d970119c4a42c89f2bd09/pymongo-4.10.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:594dd721b81f301f33e843453638e02d92f63c198358e5a0fa8b8d0b1218dabc", size = 996769 },
+    { url = "https://files.pythonhosted.org/packages/bf/50/6936612c1b2e32d95c30e860552d3bc9e55cfa79a4f73b73225fa05a028c/pymongo-4.10.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0783e0c8e95397c84e9cf8ab092ab1e5dd7c769aec0ef3a5838ae7173b98dea0", size = 2169159 },
+    { url = "https://files.pythonhosted.org/packages/78/8c/45cb23096e66c7b1da62bb8d9c7ac2280e7c1071e13841e7fb71bd44fd9f/pymongo-4.10.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6fb6a72e88df46d1c1040fd32cd2d2c5e58722e5d3e31060a0393f04ad3283de", size = 2260569 },
+    { url = "https://files.pythonhosted.org/packages/29/b6/e5ec697087e527a6a15c5f8daa5bcbd641edb8813487345aaf963d3537dc/pymongo-4.10.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2e3a593333e20c87415420a4fb76c00b7aae49b6361d2e2205b6fece0563bf40", size = 2218142 },
+    { url = "https://files.pythonhosted.org/packages/ad/8a/c0b45bee0f0c57732c5c36da5122c1796efd5a62d585fbc504e2f1401244/pymongo-4.10.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72e2ace7456167c71cfeca7dcb47bd5dceda7db2231265b80fc625c5e8073186", size = 2170623 },
+    { url = "https://files.pythonhosted.org/packages/3b/26/6c0a5360a571df24c9bfbd51b1dae279f4f0c511bdbc0906f6df6d1543fa/pymongo-4.10.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ad05eb9c97e4f589ed9e74a00fcaac0d443ccd14f38d1258eb4c39a35dd722b", size = 2111112 },
+    { url = "https://files.pythonhosted.org/packages/38/bc/5b91b728e1cf505d931f04e24cbac71ae519523785570ed046cdc31e6efc/pymongo-4.10.1-cp313-cp313-win32.whl", hash = "sha256:ee4c86d8e6872a61f7888fc96577b0ea165eb3bdb0d841962b444fa36001e2bb", size = 948727 },
+    { url = "https://files.pythonhosted.org/packages/0d/2a/7c24a6144eaa06d18ed52822ea2b0f119fd9267cd1abbb75dae4d89a3803/pymongo-4.10.1-cp313-cp313-win_amd64.whl", hash = "sha256:45ee87a4e12337353242bc758accc7fb47a2f2d9ecc0382a61e64c8f01e86708", size = 976873 },
+    { url = "https://files.pythonhosted.org/packages/31/22/0580e055aa609ae61c5c054afc746968be771d75d42b6a43f3979fa1c20e/pymongo-4.10.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:442ca247f53ad24870a01e80a71cd81b3f2318655fd9d66748ee2bd1b1569d9e", size = 727824 },
+    { url = "https://files.pythonhosted.org/packages/82/9f/62599a11b2371ea176ddc4444fe9cef7bb1b8d8c2ba3ec2fce03a63f6b37/pymongo-4.10.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:23e1d62df5592518204943b507be7b457fb8a4ad95a349440406fd42db5d0923", size = 728136 },
+    { url = "https://files.pythonhosted.org/packages/7f/87/ea553a6b3e2607d409ffcb8958153e84370f1cd54e1f2191b16dcc28b408/pymongo-4.10.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6131bc6568b26e7495a9f3ef2b1700566b76bbecd919f4472bfe90038a61f425", size = 928973 },
+    { url = "https://files.pythonhosted.org/packages/6e/be/f7d3df1415af12200b63b3cfebd2d156ea3215f3ce054bf3f73d81e0be73/pymongo-4.10.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fdeba88c540c9ed0338c0b2062d9f81af42b18d6646b3e6dda05cf6edd46ada9", size = 945186 },
+    { url = "https://files.pythonhosted.org/packages/f6/0c/8b3981432b8d635763aef504475c1f1ec51447889fd13ac30676cecf1229/pymongo-4.10.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:15a624d752dd3c89d10deb0ef6431559b6d074703cab90a70bb849ece02adc6b", size = 938573 },
+    { url = "https://files.pythonhosted.org/packages/5f/54/7da021c70dbac3e993aee5544398f6c1ec58d0aaaf6f91de555e4b6a6e29/pymongo-4.10.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba164e73fdade9b4614a2497321c5b7512ddf749ed508950bdecc28d8d76a2d9", size = 930164 },
+    { url = "https://files.pythonhosted.org/packages/bb/f1/848132a5db3f5fba1928018d53d990f4ba81db9126129f2e5a99d9da8d55/pymongo-4.10.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9235fa319993405ae5505bf1333366388add2e06848db7b3deee8f990b69808e", size = 919676 },
+    { url = "https://files.pythonhosted.org/packages/ad/31/9b5a831f7bd96e932c0b6e234a154896fe0373c19ba32054e959ae258b57/pymongo-4.10.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e4a65567bd17d19f03157c7ec992c6530eafd8191a4e5ede25566792c4fe3fa2", size = 920828 },
+    { url = "https://files.pythonhosted.org/packages/65/5b/d134139e96fa085ebc7545a7bfb335606e7ee3ae403c170a3fe64ba7b854/pymongo-4.10.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:f1945d48fb9b8a87d515da07f37e5b2c35b364a435f534c122e92747881f4a7c", size = 928386 },
+    { url = "https://files.pythonhosted.org/packages/9e/35/b932c0db60508971701ef42c47ab6db3e60497f0821da4f340ecff9eebf0/pymongo-4.10.1-cp38-cp38-win32.whl", hash = "sha256:345f8d340802ebce509f49d5833cc913da40c82f2e0daf9f60149cacc9ca680f", size = 722400 },
+    { url = "https://files.pythonhosted.org/packages/38/52/a58196a45232e9046c8b13f4fa3d89cca0e462b5c6d28969759226f781ee/pymongo-4.10.1-cp38-cp38-win_amd64.whl", hash = "sha256:3a70d5efdc0387ac8cd50f9a5f379648ecfc322d14ec9e1ba8ec957e5d08c372", size = 727386 },
+    { url = "https://files.pythonhosted.org/packages/39/69/a13a61fd9a19e659cb43cb98240a75dab2f8e7b60bee568c309a123f8edc/pymongo-4.10.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:15b1492cc5c7cd260229590be7218261e81684b8da6d6de2660cf743445500ce", size = 781650 },
+    { url = "https://files.pythonhosted.org/packages/14/13/a5a3da69ee146bac81baacc7b27995849bfbb89eaabfb3d19824c7056fb4/pymongo-4.10.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:95207503c41b97e7ecc7e596d84a61f441b4935f11aa8332828a754e7ada8c82", size = 781929 },
+    { url = "https://files.pythonhosted.org/packages/b0/65/118bc20fc66451ae4b8ceafbd9aab1168bb13cf4e5699b81807bb911a443/pymongo-4.10.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb99f003c720c6d83be02c8f1a7787c22384a8ca9a4181e406174db47a048619", size = 1167200 },
+    { url = "https://files.pythonhosted.org/packages/d1/4a/19c3d45659835f814efef8b250456923899cc7542c52f8beb1a6a164106f/pymongo-4.10.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f2bc1ee4b1ca2c4e7e6b7a5e892126335ec8d9215bcd3ac2fe075870fefc3358", size = 1200021 },
+    { url = "https://files.pythonhosted.org/packages/1c/03/69cee6f23463251a8f6de6670fb665e2531cc0df500d61150e57d1aedf70/pymongo-4.10.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:93a0833c10a967effcd823b4e7445ec491f0bf6da5de0ca33629c0528f42b748", size = 1185518 },
+    { url = "https://files.pythonhosted.org/packages/00/58/01d8b3b374e45931581364752bf7a4693e9c7422704f81e6e91ffa42c38d/pymongo-4.10.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f56707497323150bd2ed5d63067f4ffce940d0549d4ea2dfae180deec7f9363", size = 1169799 },
+    { url = "https://files.pythonhosted.org/packages/be/6f/9aa0ba2f4cfa4c30c962bd1f5a38b2eb95b23e3965918d211da82ebaacf6/pymongo-4.10.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:409ab7d6c4223e5c85881697f365239dd3ed1b58f28e4124b846d9d488c86880", size = 1149344 },
+    { url = "https://files.pythonhosted.org/packages/fc/af/40f0112605f75f5ae5da554b2f779a83c40ecf2298c57e120e6d7bfcff65/pymongo-4.10.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:dac78a650dc0637d610905fd06b5fa6419ae9028cf4d04d6a2657bc18a66bbce", size = 1134277 },
+    { url = "https://files.pythonhosted.org/packages/a1/92/9a4afaf02d4d633c3211b7535e6bfbb2527524ca8ac8039b8d7eb3c765eb/pymongo-4.10.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:1ec3fa88b541e0481aff3c35194c9fac96e4d57ec5d1c122376000eb28c01431", size = 1167588 },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c23e7739b0d0dafa4d802e9773011cf54e305c7cb788a52d50c3ef585d2/pymongo-4.10.1-cp39-cp39-win32.whl", hash = "sha256:e0e961923a7b8a1c801c43552dcb8153e45afa41749d9efbd3a6d33f45489f7a", size = 767325 },
+    { url = "https://files.pythonhosted.org/packages/36/d4/49198168f296838c49d732743ae073f9ca9e8f65f15f5209637456892968/pymongo-4.10.1-cp39-cp39-win_amd64.whl", hash = "sha256:dabe8bf1ad644e6b93f3acf90ff18536d94538ca4d27e583c6db49889e98e48f", size = 777078 },
 ]
 
 [[package]]
@@ -2285,12 +2361,13 @@ wheels = [
 
 [[package]]
 name = "viam-sdk"
-version = "0.30.0"
+version = "0.31.1"
 source = { editable = "." }
 dependencies = [
     { name = "googleapis-common-protos" },
     { name = "grpclib" },
     { name = "protobuf" },
+    { name = "pymongo" },
     { name = "typing-extensions" },
 ]
 
@@ -2327,6 +2404,7 @@ requires-dist = [
     { name = "grpclib", specifier = ">=0.4.7" },
     { name = "numpy", marker = "extra == 'mlmodel'" },
     { name = "protobuf", specifier = "==5.28.2" },
+    { name = "pymongo", specifier = ">=4.10.1" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
 ]
 


### PR DESCRIPTION
For context: The return type of the `TabularDataBySQL/MQL` proto has changed to return both a list of structs, the existing return type, and also a list of bytearrays that represent BSON.

- Added a required dependency to `pymongo` to use the `BSON` library
- `BSON` provides a `decode()` function for converting lists of byte sequences into Python dictionaries. 

**Testing**:
- I ensured that date fields are returned as native Python `datetime` objects instead of strings by running tabular_data_by_mql against real tabular data on viam-dev and printed the decoded data and their types: 
        <img width="495" alt="Screenshot 2024-10-29 at 11 56 09 AM" src="https://github.com/user-attachments/assets/6a8cc4a2-6a01-4ed0-94f5-3f955eceb3c9">
- Updated the `TABULAR_QUERY_RESPONSE` testing data to include datetime objects, as the Python SDK will receive date fields in this format.
