### PR TITLE
[hotfix] remove write analog

### DIFF
--- a/src/viam/components/board/client.py
+++ b/src/viam/components/board/client.py
@@ -225,19 +225,6 @@ class BoardClient(Board, ReconfigurableResourceRPCClientBase):
         md = kwargs.get("metadata", self.Metadata())
         return await get_geometries(self.client, self.name, extra, timeout, md)
 
-    async def write_analog(
-        self,
-        pin: str,
-        value: int,
-        *,
-        extra: Optional[Dict[str, Any]] = None,
-        timeout: Optional[float] = None,
-        **kwargs,
-    ):
-        md = kwargs.get("metadata", self.Metadata()).proto
-        request = WriteAnalogRequest(name=self.name, pin=pin, value=value, extra=dict_to_struct(extra))
-        await self.client.WriteAnalog(request, timeout=timeout, metadata=md)
-
     async def stream_ticks(
         self,
         interrupts: List[Board.DigitalInterrupt],

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -242,23 +242,17 @@ class MockAnalog(Board.Analog):
     async def write(self, value: int, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs):
         self.extra = extra
         self.timeout = timeout
-        self.value = value
+        self.value.value = value
 
 
 class MockDigitalInterrupt(Board.DigitalInterrupt):
     def __init__(self, name: str):
         self.high = False
-        self.last_tick = 0
-        self.num_ticks = 0
+        self.val = 182
         super().__init__(name)
 
     async def value(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> int:
-        return self.num_ticks
-
-    async def tick(self, high: bool, nanos: int):  # Call this to get the mock interrupt to change
-        self.high = high
-        self.last_tick = nanos
-        self.num_ticks += 1
+        return self.val
 
 
 class MockGPIOPin(Board.GPIOPin):


### PR DESCRIPTION
`write_analog` has been removed from the `Board` interface. 