### PR TITLE
RSDK-9339: Update python doc strings for tabular_data_by_sql/mql

### DIFF
--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -280,7 +280,7 @@ class DataClient:
                 bson.encode({ "$limit": 5 })
             ])
 
-            print(f"Tabular Data : {tabular_data}")
+            print(f"Tabular Data: {tabular_data}")
 
 
         Args:

--- a/src/viam/app/data_client.py
+++ b/src/viam/app/data_client.py
@@ -259,7 +259,7 @@ class DataClient:
             sql_query (str): The SQL query to run.
 
         Returns:
-            List[Dict[str, ValueTypes]]: An array of data objects.
+            List[Dict[str, Union[ValueTypes, datetime]]]: An array of decoded BSON data objects.
 
         For more information, see `Data Client API <https://docs.viam.com/appendix/apis/data-client/>`_.
         """
@@ -274,31 +274,23 @@ class DataClient:
 
             import bson
 
-            # using bson package (pip install bson)
-            tabular_data = await data_client.tabular_data_by_mql(organization_id="<YOUR-ORG-ID>", mql_binary=[
-                bson.dumps({ '$match': { 'location_id': '<YOUR-LOCATION-ID>' } }),
-                bson.dumps({ '$limit': 5 })
-            ])
-
-            print(f"Tabular Data 1: {tabular_data}")
-
             # using pymongo package (pip install pymongo)
             tabular_data = await data_client.tabular_data_by_mql(organization_id="<YOUR-ORG-ID>", mql_binary=[
                 bson.encode({ '$match': { 'location_id': '<YOUR-LOCATION-ID>' } }),
                 bson.encode({ "$limit": 5 })
             ])
 
-            print(f"Tabular Data 2: {tabular_data}")
+            print(f"Tabular Data : {tabular_data}")
 
 
         Args:
             organization_id (str): The ID of the organization that owns the data.
                 You can obtain your organization ID from the Viam app's organization settings page.
             mql_binary (List[bytes]): The MQL query to run as a list of BSON queries. You can encode your bson queries using a library like
-                `pymongo` or `bson`.
+                `pymongo`.
 
         Returns:
-            List[Dict[str, ValueTypes]]: An array of data objects.
+            List[Dict[str, Union[ValueTypes, datetime]]]: An array of decoded BSON data objects.
 
         For more information, see `Data Client API <https://docs.viam.com/appendix/apis/data-client/>`_.
         """


### PR DESCRIPTION
We changed the return type of `tabular_data_by_sql/mql` earlier in this PR: https://github.com/viamrobotics/viam-python-sdk/pull/774 but forgot to update the doc string. 

Also, removed the first example here: https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.tabular_data_by_mql since  it is discussed in [this](https://viaminc.slack.com/archives/C0307PGHR7E/p1732030413598659?thread_ts=1732024814.387789&cid=C0307PGHR7E) thread that bson from bson with bson.dumps() does not work, but bson from pymongo with bson.encode() works does work.