### PR TITLE
RSDK-9560: remove `AnalogNames` and `DigitalInterruptNames` from python sdk

### DIFF
--- a/examples/server/v1/components.py
+++ b/examples/server/v1/components.py
@@ -306,9 +306,6 @@ class ExampleBoard(Board):
         except KeyError:
             raise ResourceNotFoundError("Board.GPIOPin", name)
 
-    async def digital_interrupt_names(self) -> List[str]:
-        return [key for key in self.digital_interrupts.keys()]
-
     async def set_power_mode(self, **kwargs):
         raise NotImplementedError()
 

--- a/examples/server/v1/components.py
+++ b/examples/server/v1/components.py
@@ -306,9 +306,6 @@ class ExampleBoard(Board):
         except KeyError:
             raise ResourceNotFoundError("Board.GPIOPin", name)
 
-    async def analog_names(self) -> List[str]:
-        return [key for key in self.analogs.keys()]
-
     async def digital_interrupt_names(self) -> List[str]:
         return [key for key in self.digital_interrupts.keys()]
 

--- a/src/viam/components/board/board.py
+++ b/src/viam/components/board/board.py
@@ -365,25 +365,6 @@ class Board(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def analog_names(self) -> List[str]:
-        """
-        Get the names of all known analog readers and/or writers.
-
-        ::
-
-            my_board = Board.from_robot(robot=machine, name="my_board")
-
-            # Get the name of every Analog configured on the board.
-            names = await my_board.analog_names()
-
-        Returns:
-            List[str]: The list of names of all known analog readers/writers.
-
-        For more information, see `Board component <https://docs.viam.com/components/board/>`_.
-        """
-        ...
-
-    @abc.abstractmethod
     async def digital_interrupt_names(self) -> List[str]:
         """
         Get the names of all known digital interrupts.

--- a/src/viam/components/board/board.py
+++ b/src/viam/components/board/board.py
@@ -365,25 +365,6 @@ class Board(ComponentBase):
         ...
 
     @abc.abstractmethod
-    async def digital_interrupt_names(self) -> List[str]:
-        """
-        Get the names of all known digital interrupts.
-
-        ::
-
-            my_board = Board.from_robot(robot=machine, name="my_board")
-
-            # Get the name of every DigitalInterrupt configured on the board.
-            names = await my_board.digital_interrupt_names()
-
-        Returns:
-            List[str]: The names of the digital interrupts.
-
-        For more information, see `Board component <https://docs.viam.com/components/board/>`_.
-        """
-        ...
-
-    @abc.abstractmethod
     async def set_power_mode(
         self, mode: PowerMode.ValueType, duration: Optional[timedelta] = None, *, timeout: Optional[float] = None, **kwargs
     ):

--- a/src/viam/components/board/client.py
+++ b/src/viam/components/board/client.py
@@ -184,11 +184,6 @@ class BoardClient(Board, ReconfigurableResourceRPCClientBase):
     async def gpio_pin_by_name(self, name: str) -> Board.GPIOPin:
         return GPIOPinClient(name, self)
 
-    async def analog_names(self) -> List[str]:
-        if self._analog_names is None:
-            return []
-        return self._analog_names
-
     async def digital_interrupt_names(self) -> List[str]:
         if self._digital_interrupt_names is None:
             return []

--- a/src/viam/components/board/client.py
+++ b/src/viam/components/board/client.py
@@ -184,11 +184,6 @@ class BoardClient(Board, ReconfigurableResourceRPCClientBase):
     async def gpio_pin_by_name(self, name: str) -> Board.GPIOPin:
         return GPIOPinClient(name, self)
 
-    async def digital_interrupt_names(self) -> List[str]:
-        if self._digital_interrupt_names is None:
-            return []
-        return self._digital_interrupt_names
-
     async def do_command(
         self,
         command: Mapping[str, ValueTypes],

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -327,9 +327,6 @@ class MockBoard(Board):
         except KeyError:
             raise ResourceNotFoundError("Board.GPIOPin", name)
 
-    async def digital_interrupt_names(self) -> List[str]:
-        return [key for key in self.digital_interrupts.keys()]
-
     async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[Geometry]:
         self.extra = extra
         self.timeout = timeout

--- a/tests/mocks/components.py
+++ b/tests/mocks/components.py
@@ -327,9 +327,6 @@ class MockBoard(Board):
         except KeyError:
             raise ResourceNotFoundError("Board.GPIOPin", name)
 
-    async def analog_names(self) -> List[str]:
-        return [key for key in self.analogs.keys()]
-
     async def digital_interrupt_names(self) -> List[str]:
         return [key for key in self.digital_interrupts.keys()]
 

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -113,10 +113,6 @@ class TestBoard:
         pin = await board.gpio_pin_by_name("pin1")
         assert pin.name == "pin1"
 
-    async def test_digital_interrupt_names(self, board: MockBoard):
-        names = await board.digital_interrupt_names()
-        assert names == ["interrupt1"]
-
     async def test_do(self, board: MockBoard):
         command = {"command": "args"}
         resp = await board.do_command(command)
@@ -352,16 +348,6 @@ class TestClient:
 
             pin = await client.gpio_pin_by_name("pin1")
             assert pin.name == "pin1"
-
-    async def test_digital_interrupt_names(self, board: MockBoard, service: BoardRPCService):
-        async with ChannelFor([service]) as channel:
-            client = BoardClient(name=board.name, channel=channel)
-
-            interrupt = await client.digital_interrupt_by_name("interrupt1")
-            assert interrupt.name == "interrupt1"
-
-            names = await client.digital_interrupt_names()
-            assert names == ["interrupt1"]
 
     async def test_do(self, board: MockBoard, service: BoardRPCService):
         async with ChannelFor([service]) as channel:

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -113,10 +113,6 @@ class TestBoard:
         pin = await board.gpio_pin_by_name("pin1")
         assert pin.name == "pin1"
 
-    async def test_analog_names(self, board: MockBoard):
-        names = await board.analog_names()
-        assert names == ["analog1"]
-
     async def test_digital_interrupt_names(self, board: MockBoard):
         names = await board.digital_interrupt_names()
         assert names == ["interrupt1"]
@@ -356,16 +352,6 @@ class TestClient:
 
             pin = await client.gpio_pin_by_name("pin1")
             assert pin.name == "pin1"
-
-    async def test_analog_names(self, board: MockBoard, service: BoardRPCService):
-        async with ChannelFor([service]) as channel:
-            client = BoardClient(name=board.name, channel=channel)
-
-            reader = await client.analog_by_name("analog1")
-            assert reader.name == "analog1"
-
-            names = await client.analog_names()
-            assert names == ["analog1"]
 
     async def test_digital_interrupt_names(self, board: MockBoard, service: BoardRPCService):
         async with ChannelFor([service]) as channel:


### PR DESCRIPTION
removed:  
- `analog_names()`
- `digital_interrupt_names()`
- test functions of both