### PR TITLE
RSDK-9610 - reconnect loop should exit if it fails

### DIFF
--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 from dataclasses import dataclass
 from datetime import datetime
 from threading import RLock
@@ -431,6 +432,9 @@ class RobotClient:
                     self._sessions_client.reset()
                     self._close_channel()
                     await asyncio.sleep(reconnect_every)
+            if not self._connected:
+                # We failed to reconnect, sys.exit() so that this thread doesn't stick around forever.
+                sys.exit()
 
     def get_component(self, name: ResourceName) -> ComponentBase:
         """Get a component using its ResourceName.


### PR DESCRIPTION
Causes the `_check_connection` method to call `sys.exit()` if it reaches the end of the reconnect loop and remains disconnected. Without doing so, it remains alive and attempting to reconnect forever whenever RDK quits non-gracefully, causing a memory leak.

Returning is not sufficient, because the thread still exists and remains managed, so the server's await on process closing never returns. By exiting, the parent module recognizes that its processes have completed and shuts down successfully.

Tested locally by having RDK shutdown with exit code 1 abruptly. With this change, the python module exits once the reconnect loop completes. Without this change, the python module stays alive indefinitely until `kill`ed.