### PR TITLE
[RSDK-9631] Add deprecation warnings to DiscoverComponents

### DIFF
--- a/src/viam/proto/robot/__init__.py
+++ b/src/viam/proto/robot/__init__.py
@@ -10,8 +10,8 @@ from ...gen.robot.v1.robot_pb2 import (
     CancelOperationRequest,
     CancelOperationResponse,
     ConfigStatus,
-    DiscoverComponentsRequest,
-    DiscoverComponentsResponse,
+    DiscoverComponentsRequest, # deprecated, remove on march 10th
+    DiscoverComponentsResponse, # deprecated, remove on march 10th
     Discovery,
     DiscoveryQuery,
     FrameSystemConfig,
@@ -73,8 +73,8 @@ __all__ = [
     "CancelOperationRequest",
     "CancelOperationResponse",
     "ConfigStatus",
-    "DiscoverComponentsRequest",
-    "DiscoverComponentsResponse",
+    "DiscoverComponentsRequest", # deprecated, remove on march 10th
+    "DiscoverComponentsResponse", # deprecated, remove on march 10th
     "Discovery",
     "DiscoveryQuery",
     "FrameSystemConfig",

--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+import warnings
 from dataclasses import dataclass
 from datetime import datetime
 from threading import RLock
@@ -732,6 +733,7 @@ class RobotClient:
         queries: List[DiscoveryQuery],
     ) -> List[Discovery]:
         """
+        Deprecated:: v0.38.0 use the Discovery Service API instead.
         Get a list of discovered potential component configurations, for example listing different supported resolutions. Currently only works for some cameras.
         Returns module names for modules.
 
@@ -759,6 +761,11 @@ class RobotClient:
         """
         request = DiscoverComponentsRequest(queries=queries)
         response: DiscoverComponentsResponse = await self._client.DiscoverComponents(request)
+        warnings.warn(
+            "RobotClient.discover_components is deprecated. It will be removed on March 10 2025. Use the DiscoverySerrvice APIS instead.",
+            DeprecationWarning, stacklevel=2)
+        LOGGER.warning(
+            "RobotClient.discover_components is deprecated. It will be removed on March 10 2025. Use the DiscoverySerrvice APIS instead.")
         return list(response.discovery)
 
     ############

--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -733,7 +733,7 @@ class RobotClient:
         queries: List[DiscoveryQuery],
     ) -> List[Discovery]:
         """
-        Deprecated:: v0.38.0 use the Discovery Service API instead.
+        Deprecated: v0.38.0, use the Discovery Service APIs instead.
         Get a list of discovered potential component configurations, for example listing different supported resolutions. Currently only works for some cameras.
         Returns module names for modules.
 
@@ -762,10 +762,10 @@ class RobotClient:
         request = DiscoverComponentsRequest(queries=queries)
         response: DiscoverComponentsResponse = await self._client.DiscoverComponents(request)
         warnings.warn(
-            "RobotClient.discover_components is deprecated. It will be removed on March 10 2025. Use the DiscoverySerrvice APIS instead.",
+            "RobotClient.discover_components is deprecated. It will be removed on March 10 2025. Use the DiscoveryService APIs instead.",
             DeprecationWarning, stacklevel=2)
         LOGGER.warning(
-            "RobotClient.discover_components is deprecated. It will be removed on March 10 2025. Use the DiscoverySerrvice APIS instead.")
+            "RobotClient.discover_components is deprecated. It will be removed on March 10 2025. Use the DiscoveryService APIs instead.")
         return list(response.discovery)
 
     ############

--- a/tests/mocks/robot.py
+++ b/tests/mocks/robot.py
@@ -9,8 +9,6 @@ from viam.proto.robot import (
     BlockForOperationResponse,
     CancelOperationRequest,
     CancelOperationResponse,
-    DiscoverComponentsRequest,
-    DiscoverComponentsResponse,
     FrameSystemConfigRequest,
     FrameSystemConfigResponse,
     GetCloudMetadataRequest,
@@ -99,9 +97,6 @@ class MockRobot(UnimplementedRobotServiceBase):
 
     async def TransformPose(self, stream: Stream[TransformPoseRequest, TransformPoseResponse]) -> None:
         raise MethodNotImplementedError("TransformPose").grpc_error
-
-    async def DiscoverComponents(self, stream: Stream[DiscoverComponentsRequest, DiscoverComponentsResponse]) -> None:
-        raise MethodNotImplementedError("DiscoverComponents").grpc_error
 
     async def StopAll(self, stream: Stream[StopAllRequest, StopAllResponse]) -> None:
         raise MethodNotImplementedError("StopAll").grpc_error

--- a/tests/test_robot.py
+++ b/tests/test_robot.py
@@ -21,8 +21,6 @@ from viam.proto.robot import (
     BlockForOperationResponse,
     CancelOperationRequest,
     CancelOperationResponse,
-    DiscoverComponentsRequest,
-    DiscoverComponentsResponse,
     Discovery,
     DiscoveryQuery,
     FrameSystemConfig,
@@ -168,12 +166,6 @@ def service() -> RobotService:
         response = TransformPoseResponse(pose=TRANSFORM_RESPONSE)
         await stream.send_message(response)
 
-    async def DiscoverComponents(stream: Stream[DiscoverComponentsRequest, DiscoverComponentsResponse]) -> None:
-        request = await stream.recv_message()
-        assert request is not None
-        response = DiscoverComponentsResponse(discovery=DISCOVERY_RESPONSE)
-        await stream.send_message(response)
-
     async def GetOperations(stream: Stream[GetOperationsRequest, GetOperationsResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
@@ -205,7 +197,6 @@ def service() -> RobotService:
     service = RobotService(manager)
     service.FrameSystemConfig = Config
     service.TransformPose = TransformPose
-    service.DiscoverComponents = DiscoverComponents
     service.GetOperations = GetOperations
     service.GetCloudMetadata = GetCloudMetadata
     service.Shutdown = Shutdown
@@ -372,13 +363,6 @@ class TestRobotClient:
             client = await RobotClient.with_channel(channel, RobotClient.Options())
             pose = await client.transform_pose(PoseInFrame(), "some dest")
             assert pose == TRANSFORM_RESPONSE
-            await client.close()
-
-    async def test_discover_components(self, service: RobotService):
-        async with ChannelFor([service]) as channel:
-            client = await RobotClient.with_channel(channel, RobotClient.Options())
-            discoveries = await client.discover_components([DISCOVERY_QUERY])
-            assert discoveries == DISCOVERY_RESPONSE
             await client.close()
 
     async def test_get_cloud_metadata(self, service: RobotService):


### PR DESCRIPTION
This PR adds warnings to client calls and Deprecation docstrings to the `discover_components` API in the robot client. To my knowledge, this SDK does not have a server side implementation of this API.

I also pre-emptively removed the tests that call this api - let me know if you'd rather keep those.


I don't usually contribute to the python sdk - so here are my local `uv run make test` warnings and failures - if they matter:
```sh
============================================================== FAILURES ===============================================================
____________________________________________________ test_ndarrays_to_flat_tensors ____________________________________________________

    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
    def test_ndarrays_to_flat_tensors():
        output = ndarrays_to_flat_tensors(MockMLModel.INTS_NDARRAYS)
        assert len(output.tensors) == 4
        assert all(name in output.tensors.keys() for name in ["0", "1", "2", "3"])
        assert type(output.tensors["0"].int8_tensor.data) is builtins.bytes
        bytes_buffer = output.tensors["0"].int8_tensor.data
        assert np.array_equal(np.frombuffer(bytes_buffer, dtype=np.int8).reshape(output.tensors["0"].shape), MockMLModel.INT8_NDARRAY)
>       assert np.array_equal(np.array(output.tensors["1"].int16_tensor.data, dtype=np.int16), MockMLModel.INT16_NDARRAY)
E       OverflowError: Python integer 4294967295 out of bounds for int16

tests/test_mlmodel_utils.py:56: OverflowError
========================================================== warnings summary ===========================================================
tests/test_board.py::TestClient::test_stream_ticks
  /opt/homebrew/Cellar/python@3.13/3.13.1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/base_events.py:745: RuntimeWarning: coroutine method 'aclose' of 'BoardClient.stream_ticks.<locals>.read' was never awaited
    self._ready.clear()
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================= short test summary info =======================================================
FAILED tests/test_mlmodel_utils.py::test_ndarrays_to_flat_tensors - OverflowError: Python integer 4294967295 out of bounds for int16
============================================== 1 failed, 645 passed, 1 warning in 12.27s ==============================================
make: *** [test] Error 1
``` 