### PR TITLE
RSDK-9798 - ensure machine status is ready

### DIFF
--- a/docs/examples/_server.py
+++ b/docs/examples/_server.py
@@ -6,11 +6,6 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from grpclib.server import Server, Stream
 from grpclib.utils import graceful_exit
 
-from viam.proto.robot import (
-        UnimplementedRobotServiceBase,
-        GetMachineStatusRequest,
-        GetMachineStatusResponse
-)
 from viam.app.data_client import DataClient
 from viam.proto.app import (
     AddRoleRequest,
@@ -600,13 +595,8 @@ class MockApp(UnimplementedAppServiceBase):
         raise NotImplementedError()
 
 
-class MockRobot(UnimplementedRobotServiceBase):
-    async def GetMachineStatus(self, stream: Stream[GetMachineStatusRequest, GetMachineStatusResponse]) -> None:
-        await stream.send_message(GetMachineStatusResponse(state: GetMachineStatusResponse.STATE_RUNNING))
-
-
 async def main(*, host: str = "127.0.0.1", port: int = 9092) -> None:
-    server = Server([MockData(), MockDataSync(), MockApp(), MockRobot()])
+    server = Server([MockData(), MockDataSync(), MockApp()])
     with graceful_exit([server]):
         await server.start(host, port)
         await server.wait_closed()

--- a/docs/examples/_server.py
+++ b/docs/examples/_server.py
@@ -6,6 +6,11 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from grpclib.server import Server, Stream
 from grpclib.utils import graceful_exit
 
+from viam.proto.robot import (
+        UnimplementedRobotServiceBase,
+        GetMachineStatusRequest,
+        GetMachineStatusResponse
+)
 from viam.app.data_client import DataClient
 from viam.proto.app import (
     AddRoleRequest,
@@ -593,6 +598,11 @@ class MockApp(UnimplementedAppServiceBase):
 
     async def GetRegistryItem(self, stream: Stream[GetRegistryItemRequest, GetRegistryItemResponse]) -> None:
         raise NotImplementedError()
+
+
+class MockRobot(UnimplementedRobotServiceBase):
+    async def GetMachineStatus(self, stream: Stream[GetMachineStatusRequest, GetMachineStatusResponse]) -> None:
+        await stream.send_message(GetMachineStatusResponse(state: GetMachineStatusResponse.STATE_RUNNING))
 
 
 async def main(*, host: str = "127.0.0.1", port: int = 9092) -> None:

--- a/docs/examples/_server.py
+++ b/docs/examples/_server.py
@@ -606,7 +606,7 @@ class MockRobot(UnimplementedRobotServiceBase):
 
 
 async def main(*, host: str = "127.0.0.1", port: int = 9092) -> None:
-    server = Server([MockData(), MockDataSync(), MockApp()])
+    server = Server([MockData(), MockDataSync(), MockApp(), MockRobot()])
     with graceful_exit([server]):
         await server.start(host, port)
         await server.wait_closed()

--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -318,7 +318,7 @@ class RobotClient:
         For more information, see `Machine Management API <https://docs.viam.com/appendix/apis/robot/>`_.
         """
         with self._lock:
-            self._refresh_inner()
+            await self._refresh_inner()
 
     async def _refresh_inner(self):
         response: ResourceNamesResponse = await self._client.ResourceNames(ResourceNamesRequest())
@@ -385,7 +385,7 @@ class RobotClient:
                 # and therefore that the robot got an incorrect response from the `ResourceNames` call.
                 # So, we should refresh right now to make sure everything is correct, before we release
                 # the lock.
-                self._refresh_inner()
+                await self._refresh_inner()
 
     async def _refresh_every(self, interval: int):
         while True:

--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -264,7 +264,8 @@ class RobotClient:
         )
 
         try:
-            if options.dial_options.with_synchronous_connect:
+            synchronous_connect = options.dial_options.with_synchronous_connect if options.dial_options else False
+            if synchronous_connect:
                 # the user has asked for a synchronous connect, so delay returning the robot
                 # client until it is running.
                 await self.wait_until_ready()
@@ -448,7 +449,7 @@ class RobotClient:
             # there isn't a programmatic way for a user to detect this and therefore call
             # expect changes in status or call `wait_until_ready`. So, let's make sure the machine
             # is ready.
-            self.wait_until_ready()
+            await self.wait_until_ready()
 
     def get_component(self, name: ResourceName) -> ComponentBase:
         """Get a component using its ResourceName.

--- a/src/viam/robot/service.py
+++ b/src/viam/robot/service.py
@@ -8,6 +8,8 @@ from viam.components.sensor import Sensor
 from viam.errors import ViamGRPCError
 from viam.proto.common import ResourceName
 from viam.proto.robot import (
+    GetMachineStatusRequest,
+    GetMachineStatusResponse,
     ResourceNamesRequest,
     ResourceNamesResponse,
     StopAllRequest,
@@ -32,6 +34,11 @@ class RobotService(UnimplementedRobotServiceBase, ResourceRPCServiceBase):
             md.update(resource_names_for_resource(resource))
 
         return list(md)
+
+    async def GetMachineStatus(self, stream: Stream[GetMachineStatusRequest, GetMachineStatusResponse]) -> None:
+        request = await stream.recv_message()
+        assert request is not None
+        await stream.send_message(GetMachineStatusResponse(state=GetMachineStatusResponse.STATE_RUNNING))
 
     async def ResourceNames(self, stream: Stream[ResourceNamesRequest, ResourceNamesResponse]) -> None:
         request = await stream.recv_message()

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -74,6 +74,9 @@ class DialOptions:
     """Number of seconds before the dial connection times out
     Set to 20sec to match _defaultOfferDeadline in goutils/rpc/wrtc_call_queue.go"""
 
+    with_synchronous_connect: bool = False
+    """If detected, delays return of a RobotClient until the machine status is running"""
+
     def __init__(
         self,
         *,
@@ -84,6 +87,7 @@ class DialOptions:
         allow_insecure_downgrade: bool = False,
         allow_insecure_with_creds_downgrade: bool = False,
         max_reconnect_attempts: int = 3,
+        with_synchronous_connect: bool = False,
         timeout: float = 20,
     ) -> None:
         self.disable_webrtc = disable_webrtc
@@ -94,6 +98,7 @@ class DialOptions:
         self.allow_insecure_with_creds_downgrade = allow_insecure_with_creds_downgrade
         self.max_reconnect_attempts = max_reconnect_attempts
         self.timeout = timeout
+        self.with_synchronous_connect = with_synchronous_connect
 
     @classmethod
     def with_api_key(cls, api_key: str, api_key_id: str) -> Self:


### PR DESCRIPTION
- Ensures machine status is ready when initially creating a robot client.
- Adds a background loop to the robot client that checks machine status, and takes the lock when status is initializing.