### PR TITLE
Move link check to be weekly

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -8,7 +8,7 @@ name: run-htmltest-external
 on:
   schedule:
     # 10am UTC on weekdays
-    - cron: "0 10 * * 1,2,3,4,5"
+    - cron: "0 10 * * 1"
 jobs:
   htmltest:
     runs-on: ubuntu-latest

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -7,7 +7,7 @@
 name: run-htmltest-external
 on:
   schedule:
-    # 10am UTC on weekdays
+    # 10am UTC on Mondays
     - cron: "0 10 * * 1"
 jobs:
   htmltest:


### PR DESCRIPTION
Getting lots of duplicate tickets that we don't need. Moving to test once on mondays