### PR TITLE
Update requirements-test.txt pillow version to non-CVE version 

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
   grpclib~=0.4.6
   googleapis-common-protos~=1.63.2
   typing-extensions~=4.8.0
-  Pillow~=10.0.0
+  Pillow~=10.4.0
   protobuf==5.28.2
   numpy~=1.21


### PR DESCRIPTION
this is the version in `pyproject.toml` and `uv.lock`