### PR TITLE
RSDK-5960 - initial connection options

### DIFF
--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -52,7 +52,7 @@ from viam.resource.manager import ResourceManager
 from viam.resource.registry import Registry
 from viam.resource.rpc_client_base import ReconfigurableResourceRPCClientBase, ResourceRPCClientBase
 from viam.resource.types import API, RESOURCE_TYPE_COMPONENT, RESOURCE_TYPE_SERVICE
-from viam.rpc.dial import DialOptions, ViamChannel, dial
+from viam.rpc.dial import DialOptions, ViamChannel, dial, _dial_inner
 from viam.services.service_base import ServiceBase
 from viam.sessions_client import SessionsClient
 from viam.utils import datetime_to_timestamp, dict_to_struct
@@ -403,7 +403,7 @@ class RobotClient:
                 try:
                     self._sessions_client.reset()
 
-                    channel = await dial(self._address, self._options.dial_options)
+                    channel = await _dial_inner(self._address, self._options.dial_options)
 
                     client: RobotServiceStub
                     if isinstance(channel, Channel):

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -306,7 +306,9 @@ async def dial(address: str, options: Optional[DialOptions] = None) -> ViamChann
         except Exception as e:
             exception = e
             attempt_countdown -= 1
-    raise exception
+    # the only way we could get here is if we failed at least once which means we've set the
+    # exception, so typechecker concerns about a possibly unbounded variable are unfounded
+    raise exception # type: ignore
 
 
 async def _dial_inner(address: str, options: Optional[DialOptions] = None) -> ViamChannel:

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -70,8 +70,9 @@ class DialOptions:
     max_reconnect_attempts: int = 3
     """Max number of times the client attempts to reconnect when connection is lost"""
 
-    initial_connection_attempts: int = 5
-    """Max number of times the client will attempt to establish an initial connection"""
+    initial_connection_attempts: int = 3
+    """Max number of times the client will attempt to establish an initial connection
+    If set to a non-positive integer, then there will be no limit to initial connection attempts"""
 
     initial_connection_attempt_timeout: int
     """Number of seconds before dial connection times out on initial connection attempts
@@ -92,7 +93,7 @@ class DialOptions:
         allow_insecure_with_creds_downgrade: bool = False,
         max_reconnect_attempts: int = 3,
         timeout: float = 20,
-        initial_connection_attempts: int = 5,
+        initial_connection_attempts: int = 3,
         initial_connection_attempt_timeout: Optional[float] = None,
     ) -> None:
         self.disable_webrtc = disable_webrtc
@@ -303,7 +304,6 @@ async def dial(address: str, options: Optional[DialOptions] = None) -> ViamChann
             options.timeout = timeout
             return chan
         except Exception as e:
-            nonlocal exception
             exception = e
             attempt_countdown -= 1
     raise exception

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -74,7 +74,7 @@ class DialOptions:
     """Max number of times the client will attempt to establish an initial connection
     If set to a non-positive integer, then there will be no limit to initial connection attempts"""
 
-    initial_connection_attempt_timeout: int
+    initial_connection_attempt_timeout: float
     """Number of seconds before dial connection times out on initial connection attempts
     Defaults to whatever value is set in the `timeout` field"""
 


### PR DESCRIPTION
Add initial connection attempt options such that we can set a number of attempts and a per-attempt timeout.

Note: This works, and we can see it work nicely if we set the timeout _below_ 10 seconds. If the timeout is above 10 seconds, it gets short-circuited by some upstream process that causes us to immediately end after 10 seconds (not even entering the retry loop!). Unclear what's going on here; likely a rust issue and so out of scope for this PR but there's a ticket for it [here](https://viam.atlassian.net/browse/RSDK-10064).