### PR TITLE
[RSDK-9328] Exclude non-actuating methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "grpclib>=0.4.7",
     "protobuf==5.29.2",
     "typing-extensions>=4.12.2",
-	"pymongo>=4.10.1"
+    "pymongo>=4.10.1",
 ]
 
 [project.urls]

--- a/src/viam/robot/client.py
+++ b/src/viam/robot/client.py
@@ -52,7 +52,7 @@ from viam.resource.manager import ResourceManager
 from viam.resource.registry import Registry
 from viam.resource.rpc_client_base import ReconfigurableResourceRPCClientBase, ResourceRPCClientBase
 from viam.resource.types import API, RESOURCE_TYPE_COMPONENT, RESOURCE_TYPE_SERVICE
-from viam.rpc.dial import DialOptions, ViamChannel, dial, _dial_inner
+from viam.rpc.dial import DialOptions, ViamChannel, _dial_inner, dial
 from viam.services.service_base import ServiceBase
 from viam.sessions_client import SessionsClient
 from viam.utils import datetime_to_timestamp, dict_to_struct

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -308,7 +308,7 @@ async def dial(address: str, options: Optional[DialOptions] = None) -> ViamChann
             attempt_countdown -= 1
     # the only way we could get here is if we failed at least once which means we've set the
     # exception, so typechecker concerns about a possibly unbounded variable are unfounded
-    raise exception # type: ignore
+    raise exception  # type: ignore
 
 
 async def _dial_inner(address: str, options: Optional[DialOptions] = None) -> ViamChannel:

--- a/src/viam/sessions_client.py
+++ b/src/viam/sessions_client.py
@@ -38,20 +38,6 @@ HEARTBEAT_MONITORED_METHODS = frozenset(
     ]
 )
 
-EXEMPT_METADATA_METHODS = frozenset(
-    [
-        "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
-        "/proto.rpc.webrtc.v1.SignalingService/Call",
-        "/proto.rpc.webrtc.v1.SignalingService/CallUpdate",
-        "/proto.rpc.webrtc.v1.SignalingService/OptionalWebRTCConfig",
-        "/proto.rpc.v1.AuthService/Authenticate",
-        "/viam.robot.v1.RobotService/ResourceNames",
-        "/viam.robot.v1.RobotService/ResourceRPCSubtypes",
-        "/viam.robot.v1.RobotService/StartSession",
-        "/viam.robot.v1.RobotService/SendSessionHeartbeat",
-    ]
-)
-
 
 class _SupportedState(IntEnum):
     UNKNOWN = 0
@@ -110,9 +96,6 @@ class SessionsClient:
 
     async def _send_request(self, event: SendRequest):
         if self._disabled:
-            return
-
-        if event.method_name in EXEMPT_METADATA_METHODS:
             return
 
         if event.method_name not in HEARTBEAT_MONITORED_METHODS:

--- a/src/viam/sessions_client.py
+++ b/src/viam/sessions_client.py
@@ -18,6 +18,26 @@ from viam.rpc.dial import DialOptions, dial
 LOGGER = logging.getLogger(__name__)
 SESSION_METADATA_KEY = "viam-sid"
 
+HEARTBEAT_MONITORED_METHODS = frozenset(
+    [
+        "/viam.component.arm.v1.ArmService/MoveToPosition",
+        "/viam.component.arm.v1.ArmService/MoveToJointPositions",
+        "/viam.component.arm.v1.ArmService/MoveThroughJointPositions",
+        "/viam.component.base.v1.BaseService/MoveStraight",
+        "/viam.component.base.v1.BaseService/Spin",
+        "/viam.component.base.v1.BaseService/SetPower",
+        "/viam.component.base.v1.BaseService/SetVelocity",
+        "/viam.component.gantry.v1.GantryService/MoveToPosition",
+        "/viam.component.gripper.v1.GripperService/Open",
+        "/viam.component.gripper.v1.GripperService/Grab",
+        "/viam.component.motor.v1.MotorService/SetPower",
+        "/viam.component.motor.v1.MotorService/GoFor",
+        "/viam.component.motor.v1.MotorService/GoTo",
+        "/viam.component.motor.v1.MotorService/SetRPM",
+        "/viam.component.servo.v1.ServoService/Move",
+    ]
+)
+
 EXEMPT_METADATA_METHODS = frozenset(
     [
         "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
@@ -93,6 +113,9 @@ class SessionsClient:
             return
 
         if event.method_name in EXEMPT_METADATA_METHODS:
+            return
+
+        if event.method_name not in HEARTBEAT_MONITORED_METHODS:
             return
 
         event.metadata.update(await self.metadata)

--- a/src/viam/sessions_client.py
+++ b/src/viam/sessions_client.py
@@ -1,9 +1,11 @@
 import asyncio
+import importlib
+import pkgutil
 from copy import deepcopy
 from datetime import timedelta
 from enum import IntEnum
 from threading import Lock, Thread
-from typing import Optional
+from typing import MutableMapping, Optional
 
 from grpclib import Status
 from grpclib.client import Channel
@@ -12,31 +14,12 @@ from grpclib.exceptions import GRPCError, StreamTerminatedError
 from grpclib.metadata import _MetadataLike
 
 from viam import logging
+from viam.gen.common.v1.common_pb2 import safety_heartbeat_monitored
 from viam.proto.robot import RobotServiceStub, SendSessionHeartbeatRequest, StartSessionRequest, StartSessionResponse
 from viam.rpc.dial import DialOptions, dial
 
 LOGGER = logging.getLogger(__name__)
 SESSION_METADATA_KEY = "viam-sid"
-
-HEARTBEAT_MONITORED_METHODS = frozenset(
-    [
-        "/viam.component.arm.v1.ArmService/MoveToPosition",
-        "/viam.component.arm.v1.ArmService/MoveToJointPositions",
-        "/viam.component.arm.v1.ArmService/MoveThroughJointPositions",
-        "/viam.component.base.v1.BaseService/MoveStraight",
-        "/viam.component.base.v1.BaseService/Spin",
-        "/viam.component.base.v1.BaseService/SetPower",
-        "/viam.component.base.v1.BaseService/SetVelocity",
-        "/viam.component.gantry.v1.GantryService/MoveToPosition",
-        "/viam.component.gripper.v1.GripperService/Open",
-        "/viam.component.gripper.v1.GripperService/Grab",
-        "/viam.component.motor.v1.MotorService/SetPower",
-        "/viam.component.motor.v1.MotorService/GoFor",
-        "/viam.component.motor.v1.MotorService/GoTo",
-        "/viam.component.motor.v1.MotorService/SetRPM",
-        "/viam.component.servo.v1.ServoService/Move",
-    ]
-)
 
 
 class _SupportedState(IntEnum):
@@ -61,6 +44,8 @@ class SessionsClient:
     _heartbeat_interval: Optional[timedelta]
     _supported: _SupportedState
     _thread: Optional[Thread]
+
+    _HEARTBEAT_MONITORED_METHODS: MutableMapping[str, bool] = {}
 
     def __init__(self, channel: Channel, direct_dial_address: str, dial_options: Optional[DialOptions], *, disabled: bool = False):
         self.channel = channel
@@ -98,7 +83,7 @@ class SessionsClient:
         if self._disabled:
             return
 
-        if event.method_name not in HEARTBEAT_MONITORED_METHODS:
+        if not self._is_safety_heartbeat_monitored(event.method_name):
             return
 
         event.metadata.update(await self.metadata)
@@ -189,3 +174,49 @@ class SessionsClient:
             return {SESSION_METADATA_KEY: self._current_id}
 
         return {}
+
+    def _is_safety_heartbeat_monitored(self, method: str) -> bool:
+        if method in self._HEARTBEAT_MONITORED_METHODS:
+            return self._HEARTBEAT_MONITORED_METHODS[method]
+
+        parts = method.split("/")
+        if len(parts) != 3:
+            self._HEARTBEAT_MONITORED_METHODS[method] = False
+            return False
+        service_path = parts[1]
+        method_name = parts[2]
+
+        parts = service_path.split(".")
+        if len(parts) < 5:
+            self._HEARTBEAT_MONITORED_METHODS[method] = False
+            return False
+        if parts[0] != "viam":
+            self._HEARTBEAT_MONITORED_METHODS[method] = False
+            return False
+        resource_type = parts[1]
+        resource_subtype = parts[2]
+        version = parts[3]
+        service_name = parts[4]
+        try:
+            module = importlib.import_module(f"viam.gen.{resource_type}.{resource_subtype}.{version}")
+            submods = pkgutil.iter_modules(module.__path__)
+            for mod in submods:
+                if "_pb2" in mod.name:
+                    submod = getattr(module, mod.name)
+                    DESCRIPTOR = getattr(submod, "DESCRIPTOR")
+                    for service in DESCRIPTOR.services_by_name.values():
+                        if service.name == service_name:
+                            for method_actual in service.methods:
+                                if method_actual.name == method_name:
+                                    options = method_actual.GetOptions()
+                                    if options.HasExtension(safety_heartbeat_monitored):
+                                        is_monitored = options.Extensions[safety_heartbeat_monitored]
+                                        self._HEARTBEAT_MONITORED_METHODS[method] = is_monitored
+                                        return is_monitored
+                                    self._HEARTBEAT_MONITORED_METHODS[method] = False
+                                    return False
+            self._HEARTBEAT_MONITORED_METHODS[method] = False
+            return False
+        except Exception:
+            self._HEARTBEAT_MONITORED_METHODS[method] = False
+            return False

--- a/tests/test_sessions_client.py
+++ b/tests/test_sessions_client.py
@@ -123,3 +123,13 @@ async def test_sessions_disabled(service: MockRobot):
         assert await client.metadata == {}
         assert client._supported == _SupportedState.UNKNOWN
         assert not client._heartbeat_interval
+
+
+async def test_safete_heartbeat_monitored():
+    async with ChannelFor([]) as channel:
+        client = SessionsClient(channel, "", None, disabled=True)
+        is_monitored = client._is_safety_heartbeat_monitored("/viam.component.arm.v1.ArmService/MoveToPosition")
+        assert is_monitored is True
+
+        is_monitored = client._is_safety_heartbeat_monitored("/viam.component.camera.v1.CameraService/GetImage")
+        assert is_monitored is False


### PR DESCRIPTION
Only send heartbeats for actuating methods.

~I chose to do it this way because (having a list of actuating methods) rather than the opposite (exempting a list of non-actuating methods) because in the API protos, we already have an optional extension called `safety_heartbeat_monitored` on the RPCs. But there's no way to actually grab that value in the client SDKs, so I instead got all the `safety_heartbeat_monitored` from the API protos and listed those out here.~

Now gets actuating option from proto