### PR TITLE
DOCS-3603: Fix get_pose example

### DIFF
--- a/src/viam/services/motion/motion.py
+++ b/src/viam/services/motion/motion.py
@@ -47,7 +47,7 @@ class Motion(ServiceBase):
         technique allows for planning and moving the frame itself to the ``destination``. To do so, simply create a resource name with
         originating ReferenceFrame's name. Then pass in the resource name into ``component_name``. Ex::
 
-            resource_name = Arm.get_resource_name("externalFrame")
+            resource_name = Gripper.get_resource_name("externalFrame")
             success = await MotionServiceClient.move(resource_name, ...)
 
         ::
@@ -347,11 +347,11 @@ class Motion(ServiceBase):
 
         ::
 
-            # Note that the example uses the ``Arm`` class, but any component class that inherits from ``ComponentBase`` will work
-            # (``Base``, ``Gripper``, etc).
+            # Note that the example uses the ``Gripper`` class, but any component class that inherits from ``ComponentBase`` will work
+            # (``Arm``, ``Base``, etc).
 
             # Create a `component_name`:
-            component_name = Arm.get_resource_name("arm")
+            component_name = Gripper.get_resource_name("my_gripper")
 
             from viam.components.gripper import Gripper
             from viam.services.motion import MotionClient


### PR DESCRIPTION
Example switches from arm to gripper incorrectly. Fix to make it all gripper.