### PR TITLE
RSDK-9901 - specify token for checkout

### DIFF
--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.REPO_READ_TOKEN }}
       - uses: bufbuild/buf-setup-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Sets the token for the `checkout` step for `update_protos` action, which per @abe-winter _should_ allow us to run tests automatically.

Untested; this is safe even if ineffective, and we can continue to iterate if this doesn't work.