### PR TITLE
RSDK-10294 & RSDK-9902 - automatically merge proto PRs when tests pass

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,6 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-        run: |
+      - run: |
           echo Python tests: ${{ needs.test.result }}
           [ "${{ needs.test.result }}" == "success" ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,6 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - name: Check Results
         run: |
           echo Python tests: ${{ needs.test.result }}
           [ "${{ needs.test.result }}" == "success" ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   test:
-    #if: github.repository_owner == 'viamrobotics'
+    if: github.repository_owner == 'viamrobotics'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -56,10 +56,11 @@ jobs:
         run: uv run make test_docs
 
   test_passing:
-    #if: github.repository_owner == 'viamrobotics'
+    if: github.repository_owner == 'viamrobotics'
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - run: |
+      - name: Check Results
+        run: |
           echo Python tests: ${{ needs.test.result }}
           [ "${{ needs.test.result }}" == "success" ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,8 +57,8 @@ jobs:
 
   test_passing:
     name: All Tests Passing
-    needs: [test]
-    runs-on: [ubuntu-latest]
+    needs: test
+    runs-on: ubuntu-latest
     steps:
       - name: Check Results
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   test:
-    if: github.repository_owner == 'viamrobotics'
+    #if: github.repository_owner == 'viamrobotics'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -56,7 +56,7 @@ jobs:
         run: uv run make test_docs
 
   test_passing:
-    if: github.repository_owner == 'viamrobotics'
+    #if: github.repository_owner == 'viamrobotics'
     needs: test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
         run: uv run make test_docs
 
   test_passing:
-    name: All Tests Passing
+    if: github.repository_owner == 'viamrobotics'
     needs: test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,3 +54,13 @@ jobs:
 
       - name: Test Documentation
         run: uv run make test_docs
+
+  test_passing:
+    name: All Tests Passing
+    needs: [test]
+    runs-on: [ubuntu-latest]
+    steps:
+      - name: Check Results
+        run: |
+          echo Python tests: ${{ needs.test.result }}
+          [ "${{ needs.test.result }}" == "success" ]

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -44,15 +44,35 @@ jobs:
         run: uv run make format
 
       - name: Add + Commit + Open PR
-        shell: bash
-        run: |
-          git checkout -b workflow/update-protos || git checkout workflow/update-protos
-          git add --all
-          git -c author.name=viambot -c author.email=viambot@users.noreply.github.com -c committer.name=GitHub -c committer.email=noreply@github.com commit -m "[WORKFLOW] Updating protos from ${{ github.event.client_payload.repo_name }}, commit: ${{ github.event.client_payload.sha }}"
-          git -c pull.ff=only pull origin workflow/update-protos || true  # do not fail if the branch doesn't exist
-          git push -f origin workflow/update-protos
-          gh pr view workflow/update-protos && gh pr reopen workflow/update-protos || gh pr create -B main -H workflow/update-protos -t "Automated Protos Update" -b "This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes" -a njooma -r njooma
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: '[WORKFLOW] Updating protos from ${{ github.event.client_payload.repo_name }}, commit: ${{ github.event.client_payload.sha }}'
+          branch: 'workflow/update-protos'
+          delete-branch: true
+          title: Automated Protos Update
+          body: This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes
+          assignees: njooma
+          reviewers: njooma
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
+
+      - name: Enable Pull Request Automerge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash
+
+      - name: Auto approve
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        run: gh pr review --approve "${{ stps.cpr.outputs.pull-request-number }}"
         env:
+          # (TODO ethan) hard to test for sure but it's possible this is insufficient. it's unclear
+          # to me whether an approval from `viambot` is sufficient to satisfy merge requirements.
+          # if not, then this won't work. but that's not particularly bad! it just means we'll still
+          # have to merge by hand, but then we can add `viambot` as a code owner and then automatic
+          # merging will start to work.
           GH_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Notify slack of failure


### PR DESCRIPTION
* Creates a parent test to check so we don't have to mark 10 separate tests as required
* Switches to using the `peter-evans` workflow for 
* Provides support for automatic approval and merging of these PRs when all tests pass

Note to reviewers: see inline notes for thoughts/explanations on the code and how it was tested (or why I believe leaving it untested is acceptable)

TODO:
* once this is merged, update the required status checks to only include the umbrella `test`, rather than all the individual ones