### PR TITLE
[RSDK-8424] Do not add modular resource if deadline has passed

### DIFF
--- a/src/viam/module/module.py
+++ b/src/viam/module/module.py
@@ -1,5 +1,4 @@
 import argparse
-import datetime
 import io
 import logging as pylogging
 import os

--- a/src/viam/module/module.py
+++ b/src/viam/module/module.py
@@ -1,4 +1,5 @@
 import argparse
+import datetime
 import io
 import logging as pylogging
 import os
@@ -7,6 +8,7 @@ from inspect import iscoroutinefunction
 from threading import Lock
 from typing import List, Mapping, Optional, Sequence, Tuple
 
+from grpclib.metadata import Deadline
 from grpclib.utils import _service_name
 from typing_extensions import Self
 
@@ -183,13 +185,15 @@ class Module:
         with self._lock:
             self._ready = ready
 
-    async def add_resource(self, request: AddResourceRequest):
+    async def add_resource(self, request: AddResourceRequest, *, deadline: Optional[Deadline] = None):
         dependencies = await self._get_dependencies(request.dependencies)
         config: ComponentConfig = request.config
         api = API.from_string(config.api)
         model = Model.from_string(config.model, ignore_errors=True)
         creator = Registry.lookup_resource_creator(api, model)
         resource = creator(config, dependencies)
+        if deadline is not None and deadline.time_remaining() <= 0:
+            raise TimeoutError("Deadline expired")
         update_log_level(resource.logger, config.log_configuration.level.upper())
         self.server.register(resource)
 


### PR DESCRIPTION
Tested this by adding a sleep to the example simple module to be over the deadline,  and then changing the sleep on the second go around to be less than the deadline. Without this change, we'd be stuck in a loop of forever trying to add. After, things are handled properly 