### PR TITLE
Fix win platform tag

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -44,7 +44,7 @@ jobs:
           - arch: linux_armv6l
             ext: so
             whl: linux_armv7l
-          - arch: win32
+          - arch: win_amd64
             ext: dll
             whl: windows_x86_64
     steps:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -44,7 +44,7 @@ jobs:
           - arch: linux_armv6l
             ext: so
             whl: linux_armv7l
-          - arch: windows_x86_64
+          - arch: win32
             ext: dll
             whl: windows_x86_64
     steps:


### PR DESCRIPTION
Untested (not sure how to test without actually doing a release). logic for why I think this is correct: we're building rust utils on x86_64, the platform name for that is win_amd64 per [docs](https://docs.python.org/3/library/sysconfig.html#sysconfig.get_platform), which is what we're supposed to use per this [python forum post](https://discuss.python.org/t/wheel-platform-tag-for-windows/9025).