### PR TITLE
add option to include markdown docs to get_registry_item

### DIFF
--- a/src/viam/app/app_client.py
+++ b/src/viam/app/app_client.py
@@ -2095,7 +2095,7 @@ class AppClient:
         response: CheckPermissionsResponse = await self._app_client.CheckPermissions(request, metadata=self._metadata)
         return list(response.authorized_permissions)
 
-    async def get_registry_item(self, item_id: str) -> RegistryItem:
+    async def get_registry_item(self, item_id: str, include_markdown_documentation: bool = False) -> RegistryItem:
         """Get registry item by ID.
 
         ::
@@ -2113,7 +2113,7 @@ class AppClient:
 
         For more information, see `Fleet Management API <https://docs.viam.com/dev/reference/apis/fleet/#getregistryitem>`_.
         """
-        request = GetRegistryItemRequest(item_id=item_id)
+        request = GetRegistryItemRequest(item_id=item_id, include_markdown_documentation=include_markdown_documentation)
         response: GetRegistryItemResponse = await self._app_client.GetRegistryItem(request, metadata=self._metadata)
         return response.item
 

--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -1698,6 +1698,7 @@ class MockApp(UnimplementedAppServiceBase):
     async def GetRegistryItem(self, stream: Stream[GetRegistryItemRequest, GetRegistryItemResponse]) -> None:
         request = await stream.recv_message()
         assert request is not None
+        self.include_markdown_documentation = request.include_markdown_documentation
         await stream.send_message(GetRegistryItemResponse(item=self.items[0]))
 
 

--- a/tests/test_app_client.py
+++ b/tests/test_app_client.py
@@ -655,7 +655,8 @@ class TestClient:
     async def test_get_registry_item(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA, ID)
-            item = await client.get_registry_item(ID)
+            item = await client.get_registry_item(ID, include_markdown_documentation=True)
+            assert service.include_markdown_documentation is True
             assert item.item_id == ITEM.item_id
             assert item.name == ITEM.name
             assert item.visibility == ITEM.visibility


### PR DESCRIPTION
Adds some parity to `get_registry_item` to optionally include markdown documentation for models and modules