### PR TITLE
Updating documentation about how to contribute without github issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,15 +13,15 @@ If you are reporting a bug, please include:
 - Any details about your local setup that might be helpful in troubleshooting.
 - Detailed steps to reproduce the bug.
 
+Link to submit <>
+
 ### Fix Bugs
 
-Look through the GitHub issues for bugs. Anything tagged with "bug" and "help
-wanted" is open to whoever wants to implement it.
+Find bugs and fix them!
 
 ### Implement Features
 
-Look through the GitHub issues for features. Anything tagged with "enhancement"
-and "help wanted" is open to whoever wants to implement it.
+Add whatever features you would like to see!
 
 ### Write Documentation
 


### PR DESCRIPTION
Hey team! 

I am new to the project but it looks like yall don't use github issues anymore. Looks more like Jira tickets? If they are public jira boards I would be happy to add a link or maybe just leave it as is?

Do y'all have a link to report bugs anywhere?