### PR TITLE
Add imports

### DIFF
--- a/examples/optionaldepsmodule/module.py
+++ b/examples/optionaldepsmodule/module.py
@@ -64,7 +64,7 @@ class Foo(Generic, Reconfigurable):
 
         optional_motor = Motor.get_resource_name(cfg_optional_motor)
         if optional_motor not in dependencies:
-            print(f'could not get optional motor {cfg_optional_motor} from dependencies; continuing')
+            print(f"could not get optional motor {cfg_optional_motor} from dependencies; continuing")
         else:
             self.optional_motor = optional_motor
 

--- a/examples/optionaldepsmodule/requirements.txt
+++ b/examples/optionaldepsmodule/requirements.txt
@@ -1,0 +1,6 @@
+# Uncomment the following line if you would like to use a release version of the SDK
+# viam-sdk
+
+# This line points to the version of the SDK that lives at this project's root.
+# In production, you would likely want to use the above `viam-sdk` requirement.
+../..

--- a/src/viam/module/module.py
+++ b/src/viam/module/module.py
@@ -44,7 +44,7 @@ from ..components.button import Button  # noqa: F401
 from ..components.camera import Camera  # noqa: F401
 from ..components.encoder import Encoder  # noqa: F401
 from ..components.gantry import Gantry  # noqa: F401
-from ..components.generic import Generic  # noqa: F401
+from ..components.generic import Generic as GenericComponent  # noqa: F401
 from ..components.gripper import Gripper  # noqa: F401
 from ..components.input import Controller  # noqa: F401
 from ..components.motor import Motor  # noqa: F401
@@ -55,7 +55,7 @@ from ..components.sensor import Sensor  # noqa: F401
 from ..components.servo import Servo  # noqa: F401
 from ..components.switch import Switch  # noqa: F401
 from ..services.discovery import Discovery  # noqa: F401
-from ..services.generic import Generic  # noqa: F401
+from ..services.generic import Generic as GenericService  # noqa: F401
 from ..services.mlmodel import MLModel  # noqa: F401
 from ..services.motion import Motion  # noqa: F401
 from ..services.navigation import Navigation  # noqa: F401

--- a/src/viam/module/module.py
+++ b/src/viam/module/module.py
@@ -35,6 +35,33 @@ from viam.robot.client import RobotClient
 from viam.rpc.dial import DialOptions
 from viam.rpc.server import Server
 
+# These imports are required to register build-in resources with the registry
+from ..components.arm import Arm  # noqa: F401
+from ..components.audio_input import AudioInput  # noqa: F401
+from ..components.base import Base  # noqa: F401
+from ..components.board import Board  # noqa: F401
+from ..components.button import Button  # noqa: F401
+from ..components.camera import Camera  # noqa: F401
+from ..components.encoder import Encoder  # noqa: F401
+from ..components.gantry import Gantry  # noqa: F401
+from ..components.generic import Generic  # noqa: F401
+from ..components.gripper import Gripper  # noqa: F401
+from ..components.input import Controller  # noqa: F401
+from ..components.motor import Motor  # noqa: F401
+from ..components.movement_sensor import MovementSensor  # noqa: F401
+from ..components.pose_tracker import PoseTracker  # noqa: F401
+from ..components.power_sensor import PowerSensor  # noqa: F401
+from ..components.sensor import Sensor  # noqa: F401
+from ..components.servo import Servo  # noqa: F401
+from ..components.switch import Switch  # noqa: F401
+from ..services.discovery import Discovery  # noqa: F401
+from ..services.generic import Generic  # noqa: F401
+from ..services.mlmodel import MLModel  # noqa: F401
+from ..services.motion import Motion  # noqa: F401
+from ..services.navigation import Navigation  # noqa: F401
+from ..services.slam import SLAM  # noqa: F401
+from ..services.vision import Vision  # noqa: F401
+
 from .service import ModuleRPCService
 from .types import Reconfigurable, Stoppable
 


### PR DESCRIPTION
This PR imports all built-in resource types on module startup so that modules can build all dependencies without needing to import them themselves