### PR TITLE
add None return type to close() in viam_client

### DIFF
--- a/src/viam/app/viam_client.py
+++ b/src/viam/app/viam_client.py
@@ -206,7 +206,7 @@ class ViamClient:
         """
         return ProvisioningClient(self._channel, self._metadata)
 
-    def close(self):
+    def close(self) -> None:
         """Close opened channels used for the various service stubs initialized."""
         if self._closed:
             LOGGER.debug("ViamClient is already closed.")


### PR DESCRIPTION
in viam_client this adds the return type to close()

    def close(self) -> None:

Otherwise type checkers like mypi throw errors during strict checking because a return type is not explicitly set.

<img width="644" height="55" alt="Screenshot 2025-08-04 at 5 33 09 PM" src="https://github.com/user-attachments/assets/3fc24006-5434-40b8-98ae-d507ac9ed391" />
