### PR TITLE
RSDK-10426 Add world state store service impl (pre api changes)

### DIFF
--- a/src/viam/services/worldstatestore/__init__.py
+++ b/src/viam/services/worldstatestore/__init__.py
@@ -1,0 +1,12 @@
+from viam.resource.registry import Registry, ResourceRegistration
+from .worldstatestore import WorldStateStore
+from .client import WorldStateStoreClient
+from .service import WorldStateStoreService
+
+__all__ = [
+    "WorldStateStore",
+    "WorldStateStoreClient",
+    "WorldStateStoreService",
+]
+
+Registry.register_api(ResourceRegistration(WorldStateStore, WorldStateStoreService, lambda name, channel: WorldStateStoreClient(name, channel)))

--- a/src/viam/services/worldstatestore/client.py
+++ b/src/viam/services/worldstatestore/client.py
@@ -1,0 +1,94 @@
+from typing import Any, Mapping, Optional, AsyncIterator
+
+from grpclib.client import Channel
+
+from viam.proto.common import DoCommandRequest, DoCommandResponse, Transform
+from viam.proto.service.worldstatestore import (
+    ListUUIDsRequest,
+    ListUUIDsResponse,
+    GetTransformRequest,
+    GetTransformResponse,
+    StreamTransformChangesRequest,
+    StreamTransformChangesResponse,
+    WorldStateStoreServiceStub,
+)
+from viam.resource.rpc_client_base import ReconfigurableResourceRPCClientBase
+from viam.utils import ValueTypes, dict_to_struct, struct_to_dict
+
+from .worldstatestore import WorldStateStore
+
+
+class WorldStateStoreClient(WorldStateStore, ReconfigurableResourceRPCClientBase):
+    """
+    gRPC client for the WorldStateStore service.
+    """
+
+    client: WorldStateStoreServiceStub
+
+    def __init__(self, name: str, channel: Channel):
+        self.channel = channel
+        self.client = WorldStateStoreServiceStub(channel)
+        super().__init__(name)
+
+    async def list_uuids(
+        self,
+        *,
+        extra: Optional[Mapping[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> list[bytes]:
+        md = kwargs.get("metadata", self.Metadata()).proto
+        request = ListUUIDsRequest(
+            name=self.name,
+            extra=dict_to_struct(extra),
+        )
+        response: ListUUIDsResponse = await self.client.ListUUIDs(request, timeout=timeout, metadata=md)
+        return list(response.uuids)
+
+    async def get_transform(
+        self,
+        uuid: bytes,
+        *,
+        extra: Optional[Mapping[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> "Transform":
+        md = kwargs.get("metadata", self.Metadata()).proto
+        request = GetTransformRequest(
+            name=self.name,
+            uuid=uuid,
+            extra=dict_to_struct(extra),
+        )
+        response: GetTransformResponse = await self.client.GetTransform(request, timeout=timeout, metadata=md)
+        return response.transform
+
+    async def stream_transform_changes(
+        self,
+        *,
+        extra: Optional[Mapping[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> AsyncIterator[StreamTransformChangesResponse]:
+        md = kwargs.get("metadata", self.Metadata()).proto
+        request = StreamTransformChangesRequest(
+            name=self.name,
+            extra=dict_to_struct(extra),
+        )
+        responses = await self.client.StreamTransformChanges(request, timeout=timeout, metadata=md)
+        for response in responses:
+            yield response
+
+    async def do_command(
+        self,
+        command: Mapping[str, ValueTypes],
+        *,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> Mapping[str, ValueTypes]:
+        md = kwargs.get("metadata", self.Metadata()).proto
+        request = DoCommandRequest(
+            name=self.name,
+            command=dict_to_struct(command),
+        )
+        response: DoCommandResponse = await self.client.DoCommand(request, timeout=timeout, metadata=md)
+        return struct_to_dict(response.result)

--- a/src/viam/services/worldstatestore/service.py
+++ b/src/viam/services/worldstatestore/service.py
@@ -1,0 +1,55 @@
+from grpclib.server import Stream
+
+from viam.proto.common import DoCommandRequest, DoCommandResponse
+from viam.proto.service.worldstatestore import (
+    ListUUIDsRequest,
+    ListUUIDsResponse,
+    GetTransformRequest,
+    GetTransformResponse,
+    StreamTransformChangesRequest,
+    StreamTransformChangesResponse,
+    UnimplementedWorldStateStoreServiceBase,
+)
+from viam.resource.rpc_service_base import ResourceRPCServiceBase
+from viam.utils import dict_to_struct, struct_to_dict
+
+from .worldstatestore import WorldStateStore
+
+
+class WorldStateStoreService(UnimplementedWorldStateStoreServiceBase, ResourceRPCServiceBase[WorldStateStore]):
+    RESOURCE_TYPE = WorldStateStore
+
+    async def ListUUIDs(self, stream: Stream[ListUUIDsRequest, ListUUIDsResponse]) -> None:
+        request = await stream.recv_message()
+        assert request is not None
+        service = self.get_resource(request.name)
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        uuids = await service.list_uuids(extra=struct_to_dict(request.extra), timeout=timeout)
+        await stream.send_message(ListUUIDsResponse(uuids=uuids))
+
+    async def GetTransform(self, stream: Stream[GetTransformRequest, GetTransformResponse]) -> None:
+        request = await stream.recv_message()
+        assert request is not None
+        service = self.get_resource(request.name)
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        transform = await service.get_transform(uuid=request.uuid, extra=struct_to_dict(request.extra), timeout=timeout)
+        await stream.send_message(GetTransformResponse(transform=transform))
+
+    async def StreamTransformChanges(
+        self,
+        stream: Stream[StreamTransformChangesRequest, StreamTransformChangesResponse],
+    ) -> None:
+        request = await stream.recv_message()
+        assert request is not None
+        service = self.get_resource(request.name)
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        async for change in service.stream_transform_changes(extra=struct_to_dict(request.extra), timeout=timeout):
+            await stream.send_message(change)
+
+    async def DoCommand(self, stream: Stream[DoCommandRequest, DoCommandResponse]) -> None:
+        request = await stream.recv_message()
+        assert request is not None
+        vision = self.get_resource(request.name)
+        timeout = stream.deadline.time_remaining() if stream.deadline else None
+        result = await vision.do_command(struct_to_dict(request.command), timeout=timeout)
+        await stream.send_message(DoCommandResponse(result=dict_to_struct(result)))

--- a/src/viam/services/worldstatestore/worldstatestore.py
+++ b/src/viam/services/worldstatestore/worldstatestore.py
@@ -1,0 +1,91 @@
+import abc
+from typing import Any, AsyncIterator, Final, Mapping, Optional
+
+from viam.proto.common import Transform
+from viam.proto.service.worldstatestore import (
+    StreamTransformChangesResponse,
+)
+from viam.resource.types import API, RESOURCE_NAMESPACE_RDK, RESOURCE_TYPE_SERVICE
+
+from ..service_base import ServiceBase
+
+class WorldStateStore(ServiceBase):
+    """WorldStateStore is a Viam service that manages world state transforms.
+
+    The WorldStateStore service provides functionality to store, retrieve, and stream
+    changes to world state transforms, which represent the pose of objects in different
+    reference frames. This functionality can be used to create custom visualizations of the world state.
+
+    For more information, see `WorldStateStore service <https://docs.viam.com/dev/reference/apis/services/worldstatestore/>`_.
+    """
+
+    API: Final = API(  # pyright: ignore [reportIncompatibleVariableOverride]
+        RESOURCE_NAMESPACE_RDK, RESOURCE_TYPE_SERVICE, "worldstatestore"
+    )
+
+    @abc.abstractmethod
+    async def list_uuids(
+        self,
+        *,
+        extra: Optional[Mapping[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ) -> list[bytes]:
+        """List all world state transform UUIDs.
+
+        ::
+
+            worldstatestore = WorldStateStoreClient.from_robot(robot=machine, name="builtin")
+
+            uuids = await worldstatestore.list_uuids()
+
+        Returns:
+            list[bytes]: A list of transform UUIDs
+        """
+        ...
+
+    @abc.abstractmethod
+    async def get_transform(
+        self,
+        uuid: bytes,
+        *,
+        extra: Optional[Mapping[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ) -> Transform:
+        """Get a world state transform by UUID.
+
+        ::
+
+            worldstatestore = WorldStateStoreClient.from_robot(robot=machine, name="builtin")
+
+            transform = await worldstatestore.get_transform(uuid=b"some-uuid")
+
+        Args:
+            uuid (bytes): The UUID of the transform to retrieve
+
+        Returns:
+            Transform: The requested transform
+        """
+        ...
+
+    @abc.abstractmethod
+    async def stream_transform_changes(
+        self,
+        *,
+        extra: Optional[Mapping[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ) -> AsyncIterator[StreamTransformChangesResponse]:
+        """Stream changes to world state transforms.
+
+        ::
+
+            worldstatestore = WorldStateStoreClient.from_robot(robot=machine, name="builtin")
+
+            async for change in worldstatestore.stream_transform_changes():
+                print(f"Transform {change.transform.uuid} {change.change_type}")
+
+        Returns:
+            AsyncIterator[StreamTransformChangesResponse]: A stream of transform changes
+        """
+        ...
+
+

--- a/tests/test_worldstatestore.py
+++ b/tests/test_worldstatestore.py
@@ -1,0 +1,154 @@
+import pytest
+from grpclib.testing import ChannelFor
+
+
+from viam.proto.common import DoCommandRequest, DoCommandResponse
+
+from viam.proto.service.worldstatestore import (
+    ListUUIDsRequest,
+    GetTransformRequest,
+    ListUUIDsResponse,
+    GetTransformResponse,
+    WorldStateStoreServiceStub
+)
+from viam.resource.manager import ResourceManager
+from viam.services.worldstatestore import WorldStateStoreClient
+from viam.services.worldstatestore.service import WorldStateStoreService
+from viam.utils import dict_to_struct, struct_to_dict
+
+from .mocks.services import MockWorldStateStore
+
+WORLDSTATESTORE_SERVICE_NAME = "worldstatestore1"
+
+
+@pytest.fixture(scope="function")
+def worldstatestore() -> MockWorldStateStore:
+    return MockWorldStateStore(WORLDSTATESTORE_SERVICE_NAME)
+
+
+@pytest.fixture(scope="function")
+def service(worldstatestore: MockWorldStateStore) -> WorldStateStoreService:
+    return WorldStateStoreService(ResourceManager([worldstatestore]))
+
+
+class TestWorldStateStore:
+    async def test_list_uuids(self, worldstatestore: MockWorldStateStore):
+        extra = {"foo": "worldstatestore"}
+        timeout = 1.0
+        response = await worldstatestore.list_uuids(extra=extra, timeout=timeout)
+        assert worldstatestore.extra == extra
+        assert worldstatestore.timeout == timeout
+        assert response == [b"uuid1", b"uuid2", b"uuid3"]
+
+    async def test_get_transform(self, worldstatestore: MockWorldStateStore):
+        uuid = b"test_uuid"
+        extra = {"foo": "worldstatestore"}
+        timeout = 2.0
+        response = await worldstatestore.get_transform(uuid=uuid, extra=extra, timeout=timeout)
+        assert worldstatestore.uuid == uuid
+        assert worldstatestore.extra == extra
+        assert worldstatestore.timeout == timeout
+        assert response.uuid == uuid
+        assert response.reference_frame == "test_frame"
+
+    async def test_stream_transform_changes(self, worldstatestore: MockWorldStateStore):
+        extra = {"foo": "worldstatestore"}
+        timeout = 3.0
+        changes = []
+        async for change in worldstatestore.stream_transform_changes(extra=extra, timeout=timeout):
+            changes.append(change)
+        assert worldstatestore.extra == extra
+        assert worldstatestore.timeout == timeout
+        assert len(changes) == 2
+        assert changes[0].change_type == 1  # TRANSFORM_CHANGE_TYPE_ADDED
+        assert changes[1].change_type == 3  # TRANSFORM_CHANGE_TYPE_UPDATED
+
+    async def test_do_command(self, worldstatestore: MockWorldStateStore):
+        command = {"command": "args"}
+        timeout = 4.0
+        response = await worldstatestore.do_command(command, timeout=timeout)
+        assert worldstatestore.timeout == timeout
+        assert response["cmd"] == command
+
+
+class TestService:
+    async def test_list_uuids(self, worldstatestore: MockWorldStateStore, service: WorldStateStoreService):
+        async with ChannelFor([service]) as channel:
+            client = WorldStateStoreServiceStub(channel)
+            extra = {"cmd": "worldstatestore"}
+            request = ListUUIDsRequest(name=worldstatestore.name, extra=dict_to_struct(extra))
+            response: ListUUIDsResponse = await client.ListUUIDs(request)
+            assert worldstatestore.extra == extra
+            assert list(response.uuids) == [b"uuid1", b"uuid2", b"uuid3"]
+
+    async def test_get_transform(self, worldstatestore: MockWorldStateStore, service: WorldStateStoreService):
+        async with ChannelFor([service]) as channel:
+            client = WorldStateStoreServiceStub(channel)
+            uuid = b"test_uuid"
+            extra = {"cmd": "worldstatestore"}
+            request = GetTransformRequest(name=worldstatestore.name, uuid=uuid, extra=dict_to_struct(extra))
+            response: GetTransformResponse = await client.GetTransform(request)
+            assert worldstatestore.uuid == uuid
+            assert worldstatestore.extra == extra
+            assert response.transform.uuid == uuid
+            assert response.transform.reference_frame == "test_frame"
+
+    async def test_stream_transform_changes(self, worldstatestore: MockWorldStateStore, service: WorldStateStoreService):
+        async with ChannelFor([service]) as channel:
+            client = WorldStateStoreClient(WORLDSTATESTORE_SERVICE_NAME, channel)
+            extra = {"cmd": "worldstatestore"}
+            changes = []
+            async for change in client.stream_transform_changes(extra=extra):
+                changes.append(change)
+            assert worldstatestore.extra == extra
+            assert len(changes) == 2
+            assert changes[0].change_type == 1  # TRANSFORM_CHANGE_TYPE_ADDED
+            assert changes[1].change_type == 3  # TRANSFORM_CHANGE_TYPE_UPDATED
+
+    async def test_do_command(self, worldstatestore: MockWorldStateStore, service: WorldStateStoreService):
+        async with ChannelFor([service]) as channel:
+            client = WorldStateStoreServiceStub(channel)
+            command = {"command": "args"}
+            request = DoCommandRequest(name=worldstatestore.name, command=dict_to_struct(command))
+            response: DoCommandResponse = await client.DoCommand(request)
+            assert struct_to_dict(response.result)["cmd"] == command
+
+
+class TestClient:
+    async def test_list_uuids(self, worldstatestore: MockWorldStateStore, service: WorldStateStoreService):
+        async with ChannelFor([service]) as channel:
+            client = WorldStateStoreClient(WORLDSTATESTORE_SERVICE_NAME, channel)
+            extra = {"foo": "worldstatestore"}
+            response = await client.list_uuids(extra=extra)
+            assert response == [b"uuid1", b"uuid2", b"uuid3"]
+            assert worldstatestore.extra == extra
+
+    async def test_get_transform(self, worldstatestore: MockWorldStateStore, service: WorldStateStoreService):
+        async with ChannelFor([service]) as channel:
+            client = WorldStateStoreClient(WORLDSTATESTORE_SERVICE_NAME, channel)
+            uuid = b"test_uuid"
+            extra = {"foo": "worldstatestore"}
+            response = await client.get_transform(uuid=uuid, extra=extra)
+            assert response.uuid == uuid
+            assert response.reference_frame == "test_frame"
+            assert worldstatestore.uuid == uuid
+            assert worldstatestore.extra == extra
+
+    async def test_stream_transform_changes(self, worldstatestore: MockWorldStateStore, service: WorldStateStoreService):
+        async with ChannelFor([service]) as channel:
+            client = WorldStateStoreClient(WORLDSTATESTORE_SERVICE_NAME, channel)
+            extra = {"foo": "worldstatestore"}
+            changes = []
+            async for change in client.stream_transform_changes(extra=extra):
+                changes.append(change)
+            assert len(changes) == 2
+            assert changes[0].change_type == 1  # TRANSFORM_CHANGE_TYPE_ADDED
+            assert changes[1].change_type == 3  # TRANSFORM_CHANGE_TYPE_UPDATED
+            assert worldstatestore.extra == extra
+
+    async def test_do_command(self, worldstatestore: MockWorldStateStore, service: WorldStateStoreService):
+        async with ChannelFor([service]) as channel:
+            client = WorldStateStoreClient(WORLDSTATESTORE_SERVICE_NAME, channel)
+            command = {"command": "args"}
+            response = await client.do_command(command)
+            assert response["cmd"] == command


### PR DESCRIPTION
Adds the implementation for the `WorldStateStoreService`.

API PR: https://github.com/viamrobotics/api/pull/695
RDK changes: https://github.com/viamrobotics/rdk/pull/5149

Scope doc: https://docs.google.com/document/d/1ionvyBa7x3HZU_rwDPBvrAUrQjBrP6sJ10Z_xbBTue8/edit?tab=t.0#heading=h.tcicyojyqi6c