### PR TITLE
Update CameraMimeType to allow for custom mimes

### DIFF
--- a/src/viam/components/camera/camera.py
+++ b/src/viam/components/camera/camera.py
@@ -1,6 +1,6 @@
 import abc
 import sys
-from typing import Any, Dict, Final, List, Optional, Tuple
+from typing import Any, Dict, Final, Optional, Sequence, Tuple
 
 from viam.media.video import NamedImage, ViamImage
 from viam.proto.common import ResponseMetadata
@@ -66,11 +66,11 @@ class Camera(ComponentBase):
     async def get_images(
         self,
         *,
-        filter_source_names: Optional[List[str]] = None,
+        filter_source_names: Optional[Sequence[str]] = None,
         extra: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = None,
         **kwargs,
-    ) -> Tuple[List[NamedImage], ResponseMetadata]:
+    ) -> Tuple[Sequence[NamedImage], ResponseMetadata]:
         """Get simultaneous images from different imagers, along with associated metadata.
         This should not be used for getting a time series of images from the same imager.
 
@@ -82,9 +82,13 @@ class Camera(ComponentBase):
             first_image = images[0]
             timestamp = metadata.captured_at
 
+        Args:
+            filter_source_names (List[str]): The filter_source_names parameter can be used to filter only the images from the specified
+                source names. When unspecified, all images are returned.
+
         Returns:
-            Tuple[List[NamedImage], ResponseMetadata]: A tuple containing two values; the first [0] a list of images
-            returned from the camera system, and the second [1] the metadata associated with this response.
+            Tuple[Sequence[NamedImage], ResponseMetadata]: A tuple containing two values; the first [0] a list of images
+                returned from the camera system, and the second [1] the metadata associated with this response.
 
         For more information, see `Camera component <https://docs.viam.com/dev/reference/apis/components/camera/#getimages>`_.
         """

--- a/src/viam/components/camera/camera.py
+++ b/src/viam/components/camera/camera.py
@@ -83,7 +83,7 @@ class Camera(ComponentBase):
             timestamp = metadata.captured_at
 
         Args:
-            filter_source_names (List[str]): The filter_source_names parameter can be used to filter only the images from the specified
+            filter_source_names (Sequence[str]): The filter_source_names parameter can be used to filter only the images from the specified
                 source names. When unspecified, all images are returned.
 
         Returns:

--- a/src/viam/components/camera/service.py
+++ b/src/viam/components/camera/service.py
@@ -7,7 +7,6 @@ from viam.media.video import CameraMimeType
 from viam.proto.common import DoCommandRequest, DoCommandResponse, GetGeometriesRequest, GetGeometriesResponse
 from viam.proto.component.camera import (
     CameraServiceBase,
-    Format,
     GetImageRequest,
     GetImageResponse,
     GetImagesRequest,
@@ -54,16 +53,13 @@ class CameraRPCService(CameraServiceBase, ResourceRPCServiceBase[Camera]):
             timeout=timeout,
             metadata=stream.metadata,
             extra=struct_to_dict(request.extra),
-            filter_source_names=list(request.filter_source_names),
+            filter_source_names=request.filter_source_names,
         )
         img_bytes_lst = []
         for img in images:
-            try:
-                mime_type = CameraMimeType.from_string(img.mime_type)  # this can ValueError if the mime_type is not a CameraMimeType
-                fmt = mime_type.to_proto()
-            except ValueError:
-                # TODO(RSDK-11728): remove this once we deleted the format field
-                fmt = Format.FORMAT_UNSPECIFIED
+            mime_type = CameraMimeType.from_string(img.mime_type)
+            # TODO(RSDK-11728): remove this fmt logic once we deleted the format field
+            fmt = mime_type.to_proto()  # Will be Format.FORMAT_UNSPECIFIED if an unsupported/custom mime type is set
 
             img_bytes = img.data
             img_bytes_lst.append(Image(source_name=name, mime_type=img.mime_type, format=fmt, image=img_bytes))

--- a/src/viam/components/component_base.py
+++ b/src/viam/components/component_base.py
@@ -1,6 +1,6 @@
 import abc
 from logging import Logger
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Mapping, Optional, SupportsBytes, SupportsFloat, Union, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Mapping, Optional, Sequence, SupportsBytes, SupportsFloat, Union, cast
 
 from typing_extensions import Self
 
@@ -46,7 +46,7 @@ class ComponentBase(abc.ABC, ResourceBase):
     async def do_command(self, command: Mapping[str, ValueTypes], *, timeout: Optional[float] = None, **kwargs) -> Mapping[str, ValueTypes]:
         raise NotImplementedError()
 
-    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> List[Geometry]:
+    async def get_geometries(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None) -> Sequence[Geometry]:
         """
         Get all geometries associated with the component, in their current configuration, in the
         `frame <https://docs.viam.com/operate/mobility/define-geometry/>`__ of the component.

--- a/src/viam/media/utils/pil/__init__.py
+++ b/src/viam/media/utils/pil/__init__.py
@@ -39,6 +39,10 @@ def pil_to_viam_image(image: Image.Image, mime_type: CameraMimeType) -> ViamImag
     Returns:
         ViamImage: The resulting ViamImage
     """
+    # Make sure at runtime the mime_type string is actually a CameraMimeType
+    if not isinstance(mime_type, CameraMimeType):
+        raise ValueError(f"Cannot encode to unsupported mimetype: {mime_type}")
+
     if mime_type.name in LIBRARY_SUPPORTED_FORMATS:
         buf = BytesIO()
         if image.mode == "RGBA" and mime_type == CameraMimeType.JPEG:
@@ -46,6 +50,6 @@ def pil_to_viam_image(image: Image.Image, mime_type: CameraMimeType) -> ViamImag
         image.save(buf, format=mime_type.name)
         data = buf.getvalue()
     else:
-        raise ValueError(f"Cannot encode image to {mime_type}")
+        raise ValueError(f"Cannot encode to unsupported mimetype: {mime_type}")
 
     return ViamImage(data, mime_type)

--- a/src/viam/media/video.py
+++ b/src/viam/media/video.py
@@ -1,7 +1,7 @@
 from array import array
 from typing import Any, List, Optional, Tuple
 
-from typing_extensions import Self
+from typing_extensions import Self, ClassVar
 
 from viam.errors import NotSupportedError
 from viam.proto.component.camera import Format
@@ -24,11 +24,11 @@ class _FrozenClassAttributesMeta(type):
 
 
 class CameraMimeType(str, metaclass=_FrozenClassAttributesMeta):
-    VIAM_RGBA: Self
-    VIAM_RAW_DEPTH: Self
-    JPEG: Self
-    PNG: Self
-    PCD: Self
+    VIAM_RGBA: ClassVar[Self]
+    VIAM_RAW_DEPTH: ClassVar[Self]
+    JPEG: ClassVar[Self]
+    PNG: ClassVar[Self]
+    PCD: ClassVar[Self]
 
     @property
     def name(self) -> str:

--- a/src/viam/media/video.py
+++ b/src/viam/media/video.py
@@ -1,7 +1,7 @@
 from array import array
 from typing import Any, List, Optional, Tuple
 
-from typing_extensions import Self, ClassVar
+from typing_extensions import ClassVar, Self
 
 from viam.errors import NotSupportedError
 from viam.proto.component.camera import Format
@@ -24,6 +24,12 @@ class _FrozenClassAttributesMeta(type):
 
 
 class CameraMimeType(str, metaclass=_FrozenClassAttributesMeta):
+    """
+    The compatible mime-types for cameras and vision services.
+
+    You can use the `CameraMimeType.CUSTOM(...)` method to use an unlisted mime-type.
+    """
+
     VIAM_RGBA: ClassVar[Self]
     VIAM_RAW_DEPTH: ClassVar[Self]
     JPEG: ClassVar[Self]
@@ -82,7 +88,8 @@ class CameraMimeType(str, metaclass=_FrozenClassAttributesMeta):
         }
         return cls(mimetypes.get(format, cls.JPEG))
 
-    def to_proto(self) -> Format.ValueType:
+    @property
+    def proto(self) -> Format.ValueType:
         """Returns the mimetype in a proto enum.
 
         Returns:
@@ -95,6 +102,12 @@ class CameraMimeType(str, metaclass=_FrozenClassAttributesMeta):
             self.PNG: Format.FORMAT_PNG,
         }
         return formats.get(self, Format.FORMAT_UNSPECIFIED)
+
+    def to_proto(self) -> Format.ValueType:
+        """
+        DEPRECATED: Use `CameraMimeType.proto`
+        """
+        return self.proto
 
 
 CameraMimeType.VIAM_RGBA = CameraMimeType.from_string("image/vnd.viam.rgba")

--- a/src/viam/services/vision/client.py
+++ b/src/viam/services/vision/client.py
@@ -69,7 +69,11 @@ class VisionClient(Vision, ReconfigurableResourceRPCClientBase):
         result = CaptureAllResult()
         result.extra = struct_to_dict(response.extra)
         if return_image:
-            mime_type = CameraMimeType.from_proto(response.image.format)
+            # TODO(RSDK-11728): remove this branching logic once we deleted the format field
+            if response.image.mime_type:
+                mime_type = CameraMimeType.from_string(response.image.mime_type)
+            else:
+                mime_type = CameraMimeType.from_proto(response.image.format)
             img = ViamImage(response.image.image, mime_type)
             result.image = img
         if return_classifications:

--- a/src/viam/services/worldstatestore/__init__.py
+++ b/src/viam/services/worldstatestore/__init__.py
@@ -1,9 +1,9 @@
+from viam.proto.service.worldstatestore import StreamTransformChangesResponse, TransformChangeType
 from viam.resource.registry import Registry, ResourceRegistration
 
 from .client import WorldStateStoreClient
 from .service import WorldStateStoreService
 from .worldstatestore import WorldStateStore
-from viam.proto.service.worldstatestore import StreamTransformChangesResponse, TransformChangeType
 
 __all__ = [
     "WorldStateStore",

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -13,6 +13,7 @@ from viam.proto.common import DoCommandRequest, DoCommandResponse, GetGeometries
 from viam.proto.component.camera import (
     CameraServiceStub,
     DistortionParameters,
+    Format,
     GetImageRequest,
     GetImageResponse,
     GetImagesRequest,
@@ -158,6 +159,7 @@ class TestService:
             request = GetImagesRequest(name="camera")
             response: GetImagesResponse = await client.GetImages(request, timeout=18.1)
             raw_img = response.images[0]
+            assert raw_img.format == Format.FORMAT_PNG
             assert raw_img.mime_type == CameraMimeType.PNG
             assert raw_img.source_name == camera.name
             assert response.response_metadata == metadata

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -7,7 +7,7 @@ from PIL import Image
 
 from viam.errors import NotSupportedError
 from viam.media.utils.pil import pil_to_viam_image, viam_to_pil_image
-from viam.media.video import CameraMimeType, NamedImage, ViamImage
+from viam.media.video import CameraMimeType, Format, NamedImage, ViamImage
 
 
 class TestViamImage:
@@ -112,6 +112,52 @@ class TestCameraMimeType:
 
         mime_type = CameraMimeType.CUSTOM("SOME CUSTOM MIME TYPE")
         assert mime_type.value == "SOME CUSTOM MIME TYPE"
+
+    def test_from_proto(self):
+        format = Format.FORMAT_RAW_RGBA
+        mime_type = CameraMimeType.from_proto(format)
+        assert mime_type == CameraMimeType.VIAM_RGBA
+
+        format = Format.FORMAT_RAW_DEPTH
+        mime_type = CameraMimeType.from_proto(format)
+        assert mime_type == CameraMimeType.VIAM_RAW_DEPTH
+
+        format = Format.FORMAT_JPEG
+        mime_type = CameraMimeType.from_proto(format)
+        assert mime_type == CameraMimeType.JPEG
+
+        format = Format.FORMAT_PNG
+        mime_type = CameraMimeType.from_proto(format)
+        assert mime_type == CameraMimeType.PNG
+
+        format = Format.FORMAT_UNSPECIFIED
+        mime_type = CameraMimeType.from_proto(format)
+        assert mime_type == CameraMimeType.JPEG  # unspecified defaults to jpeg
+
+    def test_to_proto(self):
+        mime_type = CameraMimeType.VIAM_RGBA
+        format = mime_type.proto
+        assert format == Format.FORMAT_RAW_RGBA
+
+        mime_type = CameraMimeType.VIAM_RAW_DEPTH
+        format = mime_type.proto
+        assert format == Format.FORMAT_RAW_DEPTH
+
+        mime_type = CameraMimeType.JPEG
+        format = mime_type.proto
+        assert format == Format.FORMAT_JPEG
+
+        mime_type = CameraMimeType.PNG
+        format = mime_type.proto
+        assert format == Format.FORMAT_PNG
+
+        mime_type = CameraMimeType.PCD
+        format = mime_type.proto
+        assert format == Format.FORMAT_UNSPECIFIED
+
+        mime_type = CameraMimeType.CUSTOM("some custom mime")
+        format = mime_type.proto
+        assert format == Format.FORMAT_UNSPECIFIED
 
 
 def test_image_conversion():

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -11,6 +11,8 @@ from viam.media.video import CameraMimeType, NamedImage, ViamImage
 
 
 class TestViamImage:
+    UNSUPPORTED_MIME_TYPE = "unsupported_string_mime_type"
+
     def test_supported_image(self):
         i = Image.new("RGBA", (100, 100), "#AABBCCDD")
         b = BytesIO()
@@ -41,6 +43,10 @@ class TestViamImage:
         assert img4.width is None
         assert img4.height is None
 
+        img5 = ViamImage(b"data", CameraMimeType.CUSTOM(self.UNSUPPORTED_MIME_TYPE))
+        assert img5.width is None
+        assert img5.height is None
+
     def test_bytes_to_depth_array(self):
         with open(f"{os.path.dirname(__file__)}/data/fakeDM.vnd.viam.dep", "rb") as depth_map:
             img = ViamImage(depth_map.read(), CameraMimeType.VIAM_RAW_DEPTH)
@@ -68,6 +74,46 @@ class TestNamedImage:
         assert img.name == name
 
 
+class TestCameraMimeType:
+    def test_name(self):
+        mime_type = CameraMimeType.VIAM_RGBA
+        assert mime_type.name == "VIAM_RGBA"
+
+        mime_type = CameraMimeType.VIAM_RAW_DEPTH
+        assert mime_type.name == "VIAM_RAW_DEPTH"
+
+        mime_type = CameraMimeType.JPEG
+        assert mime_type.name == "JPEG"
+
+        mime_type = CameraMimeType.PNG
+        assert mime_type.name == "PNG"
+
+        mime_type = CameraMimeType.PCD
+        assert mime_type.name == "PCD"
+
+        mime_type = CameraMimeType.CUSTOM("SOME CUSTOM MIME TYPE")
+        assert mime_type.name == "CUSTOM"
+
+    def test_value(self):
+        mime_type = CameraMimeType.VIAM_RGBA
+        assert mime_type.value == "image/vnd.viam.rgba"
+
+        mime_type = CameraMimeType.VIAM_RAW_DEPTH
+        assert mime_type.value == "image/vnd.viam.dep"
+
+        mime_type = CameraMimeType.JPEG
+        assert mime_type.value == "image/jpeg"
+
+        mime_type = CameraMimeType.PNG
+        assert mime_type.value == "image/png"
+
+        mime_type = CameraMimeType.PCD
+        assert mime_type.value == "pointcloud/pcd"
+
+        mime_type = CameraMimeType.CUSTOM("SOME CUSTOM MIME TYPE")
+        assert mime_type.value == "SOME CUSTOM MIME TYPE"
+
+
 def test_image_conversion():
     i = Image.new("RGBA", (100, 100), "#AABBCCDD")
 
@@ -78,3 +124,6 @@ def test_image_conversion():
     pil_img = viam_to_pil_image(v_img)
     v_img2 = pil_to_viam_image(pil_img, CameraMimeType.JPEG)
     assert v_img2.data == v_img.data
+
+    with pytest.raises(ValueError, match=f"Cannot encode to unsupported mimetype: {TestViamImage.UNSUPPORTED_MIME_TYPE}"):
+        pil_to_viam_image(i, CameraMimeType.CUSTOM(TestViamImage.UNSUPPORTED_MIME_TYPE))

--- a/tests/test_vision_service.py
+++ b/tests/test_vision_service.py
@@ -206,6 +206,7 @@ class TestService:
             )
             response: CaptureAllFromCameraResponse = await client.CaptureAllFromCamera(request)
             assert response.image.image == VISION_IMAGE.data
+            assert response.image.mime_type == VISION_IMAGE.mime_type
             assert response.image.format == VISION_IMAGE.mime_type.to_proto()
             assert response.classifications == CLASSIFICATIONS
             assert response.detections == []


### PR DESCRIPTION
This PR should supersede https://github.com/viamrobotics/viam-python-sdk/pull/993 and https://github.com/viamrobotics/viam-python-sdk/pull/982

Change the functionality of `CameraMimeType` so that it is not limited only to predetermined values, but has the ability to add `CUSTOM` values of `CameraMimeType` that can be used everywhere in the code. 

`CameraMimeType` continues to behave as a `str` everywhere `str` is accepted, while having additional properties and methods, including `name` and `value` properties, which give it the same properties as the previous `Enum`-type. 

This should prevent the mime-type changes from being a breaking change. 