### PR TITLE
add new constructor to ViamClient docstring

### DIFF
--- a/src/viam/app/viam_client.py
+++ b/src/viam/app/viam_client.py
@@ -20,9 +20,10 @@ class ViamClient:
     """gRPC client for all communication and interaction with app.
 
     `ViamClient` class for creating and managing specialized client instances.
-    There is currently 1 way to instantiate a `ViamClient` object::
+    There are currently 2 ways to instantiate a `ViamClient` object::
 
         ViamClient.create_from_dial_options(...)
+        ViamClient.create_from_env_vars()
     """
 
     @classmethod


### PR DESCRIPTION
## What changed
It looks like there's a second constructor for `ViamClient` now? Updating docstring for discoverability.