### PR TITLE
RSDK-12467: Add and test historical module data

### DIFF
--- a/src/viam/module/resource_data_consumer.py
+++ b/src/viam/module/resource_data_consumer.py
@@ -12,14 +12,8 @@ class ResourceDataConsumer:
     """
 
     @classmethod
-    async def query_tabular_data(cls, resource_name: str, time_back: datetime.timedelta, **kwargs) -> List[Dict[str, Any]]:
-        """Return historical data for this module, queried with MQL."""
-        viam_client = await ViamClient.create_from_env_vars()
-
-        org_id = os.environ["VIAM_PRIMARY_ORG_ID"]
-        part_id = os.environ["VIAM_MACHINE_PART_ID"]
-
-        query = [
+    def construct_query(cls, part_id: str, resource_name: str, time_back: datetime.timedelta):
+        return [
             {
                 "$match": {
                     "part_id": part_id,
@@ -29,4 +23,13 @@ class ResourceDataConsumer:
             }
         ]
 
+    @classmethod
+    async def query_tabular_data(cls, resource_name: str, time_back: datetime.timedelta, **kwargs) -> List[Dict[str, Any]]:
+        """Return historical data for this module, queried with MQL."""
+        viam_client = await ViamClient.create_from_env_vars()
+
+        org_id = os.environ["VIAM_PRIMARY_ORG_ID"]
+        part_id = os.environ["VIAM_MACHINE_PART_ID"]
+
+        query = cls.construct_query(part_id=part_id, resource_name=resource_name, time_back=time_back)
         return await viam_client.data_client.tabular_data_by_mql(org_id, query)


### PR DESCRIPTION
Implements and tests a ResourceDataConsumer class that can be used as a base to obtain historical module data

Not sure if I did the mocking correctly, this seemed to be what I had to copy from other unit tests to make `ViamClient` construction work. Also maybe I did the patch calls wrong because it would not let me `await` the method I'm testing