### PR TITLE
Update metadata key from viam-client to viam_client

### DIFF
--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -323,7 +323,7 @@ def _create_chan(path: str) -> Channel:
 
 async def _dial_inner(address: str, options: Optional[DialOptions] = None) -> ViamChannel:
     async def send_request(event: SendRequest):
-        event.metadata["viam-client"] = f"python;v{SDK_VERSION};v{API_VERSION}"
+        event.metadata["viam_client"] = f"python;v{SDK_VERSION};v{API_VERSION}"
 
     opts = options if options else DialOptions()
     if opts.disable_webrtc:


### PR DESCRIPTION
python metadata is not coming through with grpc calls because it looks for viam_client, other sdks already have viam_client as well

see https://github.com/viamrobotics/viam-typescript-sdk/pull/710