### PR TITLE
RSDK-13241: python log spam due to unclosed channel

### DIFF
--- a/src/viam/sessions_client.py
+++ b/src/viam/sessions_client.py
@@ -193,12 +193,15 @@ class SessionsClient:
         addr = self._get_local_addr()
         channel = await dial(address=addr, options=self._dial_options)
         client = RobotServiceStub(channel.channel)
-        while True:
-            async with self._acquire_lock_async():
-                if self._supported != _SupportedState.TRUE:
-                    return
-                await self._heartbeat_tick(client)
-            await asyncio.sleep(wait)
+        try:
+            while True:
+                async with self._acquire_lock_async():
+                    if self._supported != _SupportedState.TRUE:
+                        return
+                    await self._heartbeat_tick(client)
+                await asyncio.sleep(wait)
+        finally:
+            channel.close()
 
     @property
     def _metadata(self) -> _MetadataLike:


### PR DESCRIPTION
Before:
```
1/29/2026, 11:34:40 AM error rdk.modmanager.pythonmodule.StdErr   pexec/managed_process.go:442   \_ AssertionError


1/29/2026, 11:34:40 AM error rdk.modmanager.pythonmodule.StdErr   pexec/managed_process.go:442   \_ ^^^^^^^^^^^^^^^^^^^^


1/29/2026, 11:34:40 AM error rdk.modmanager.pythonmodule.StdErr   pexec/managed_process.go:442   \_ assert f is self._write_fut


1/29/2026, 11:34:40 AM error rdk.modmanager.pythonmodule.StdErr   pexec/managed_process.go:442   \_ File "C:\Users\admin\AppData\Local\Programs\Python\Python312\Lib\asyncio\proactor_events.py", line 382, in _loop_writing


1/29/2026, 11:34:40 AM error rdk.modmanager.pythonmodule.StdErr   pexec/managed_process.go:442   \_ self._context.run(self._callback, *self._args)


1/29/2026, 11:34:40 AM error rdk.modmanager.pythonmodule.StdErr   pexec/managed_process.go:442   \_ File "C:\Users\admin\AppData\Local\Programs\Python\Python312\Lib\asyncio\events.py", line 88, in _run


1/29/2026, 11:34:40 AM error rdk.modmanager.pythonmodule.StdErr   pexec/managed_process.go:442   \_ Traceback (most recent call last):


1/29/2026, 11:34:40 AM error rdk.modmanager.pythonmodule.StdErr   pexec/managed_process.go:442   \_ handle: <Handle _ProactorBaseWritePipeTransport._loop_writing(<_OverlappedF...ed result=338>)>


1/29/2026, 11:34:40 AM error rdk.modmanager.pythonmodule.StdErr   pexec/managed_process.go:442   \_ Exception in callback _ProactorBaseWritePipeTransport._loop_writing(<_OverlappedF...ed result=338>)

```

After:
None of those logs