### PR TITLE
Add start and end datetime parameters to get_robot_part_logs

### DIFF
--- a/tests/mocks/services.py
+++ b/tests/mocks/services.py
@@ -1598,6 +1598,8 @@ class MockApp(UnimplementedAppServiceBase):
         self.filter = request.filter
         self.errors_only = request.errors_only
         self.levels = request.levels
+        self.start = request.start
+        self.end = request.end
         await stream.send_message(GetRobotPartLogsResponse(logs=[self.log_entry]))
 
     async def TailRobotPartLogs(self, stream: Stream[TailRobotPartLogsRequest, TailRobotPartLogsResponse]) -> None:

--- a/tests/test_app_client.py
+++ b/tests/test_app_client.py
@@ -456,6 +456,21 @@ class TestClient:
             assert service.levels == LOG_LEVELS
             assert [log_entry.proto for log_entry in log_entries] == LOG_ENTRIES
 
+    async def test_get_robot_part_logs_with_time_range(self, service: MockApp):
+        async with ChannelFor([service]) as channel:
+            client = AppClient(channel, METADATA)
+            start_time = datetime(2024, 1, 1, 0, 0, 0)
+            end_time = datetime(2024, 1, 2, 0, 0, 0)
+            log_entries = await client.get_robot_part_logs(
+                robot_part_id=ID, filter=FILTER, log_levels=LOG_LEVELS, num_log_entries=NUM, start=start_time, end=end_time
+            )
+            assert service.robot_part_id == ID
+            assert service.filter == FILTER
+            assert service.levels == LOG_LEVELS
+            assert service.start == datetime_to_timestamp(start_time)
+            assert service.end == datetime_to_timestamp(end_time)
+            assert [log_entry.proto for log_entry in log_entries] == LOG_ENTRIES
+
     async def test_tail_robot_part_logs(self, service: MockApp):
         async with ChannelFor([service]) as channel:
             client = AppClient(channel, METADATA)


### PR DESCRIPTION
No docs changes included here for now.  i just wanted to throw this up as a very quick "does this seem ok?" change.  Tests passing, but I don't quite have the time to build and manually test locally.

if OK, similar PR incoming for the TS SDK.

Obviously if I'm missing something critical here or if this is a waste of time, let me know!