### PR TITLE
[RSDK-13427] Add packaging is a dependency for MLModel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ Repository = "https://github.com/viamrobotics/viam-python-sdk"
 
 [project.optional-dependencies]
 mlmodel = [
-	"numpy"
+	"numpy",
+	"packaging",
 ]
 
 [build-system]

--- a/src/viam/services/mlmodel/utils.py
+++ b/src/viam/services/mlmodel/utils.py
@@ -44,7 +44,6 @@ def flat_tensors_to_ndarrays(flat_tensors: FlatTensors) -> Dict[str, NDArray]:
         # Creating our array as a uint32 array initially and then casting to int16 solves this.
         if Version(np.__version__) >= Version("2") and dtype == np.int16:
             arr = np.astype(make_array(flat_data, np.uint32), np.int16)  # pyright: ignore [reportAttributeAccessIssue]
-
         else:
             arr = make_array(flat_data, dtype)
         return arr.reshape(shape)

--- a/tests/mocks/__init__.py
+++ b/tests/mocks/__init__.py
@@ -1,5 +1,4 @@
 import inspect
-from typing import Dict, List, Sequence, Set, Tuple, Union, get_args, get_origin, get_type_hints
 from unittest.mock import AsyncMock, create_autospec
 
 


### PR DESCRIPTION
Looks like `packaging` isn't auto-installed (perhaps this is a UV thing? haven't done enough research), and it's used in MLModel Utils. So, add it as a dep for MLModel
