### PR TITLE
DOCS-4691: Fix incorrect threshold in get_robot_part sample code

### DIFF
--- a/src/viam/app/app_client.py
+++ b/src/viam/app/app_client.py
@@ -1286,7 +1286,7 @@ class AppClient:
             # Get the part's address
             address = my_robot_part.fqdn
             # Check if machine is live (last access time less than 10 sec ago)
-            if (time.time() - my_robot_part.last_access.timestamp()) <= 10000:
+            if (time.time() - my_robot_part.last_access.timestamp()) <= 10:
                 print("Machine is live.")
 
         Args:


### PR DESCRIPTION
The comment said "less than 10 sec ago" but the comparison used 10000 (milliseconds) instead of 10 (seconds). Since time.time() and .timestamp() both return values in seconds, the threshold should be 10.