### PR TITLE
Bump all claude workflows to v1.10.0 with GitHub App auth for sweep

### DIFF
--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -21,8 +21,8 @@ jobs:
         github.event.workflow_run.conclusion == 'failure' &&
         startsWith(github.event.workflow_run.head_branch, 'claude/')
       )
-    # viamrobotics/claude-ci-workflows@v1.9.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@41c2182579d9039d9fd30b2a2a0976008b402b8b
+    # viamrobotics/claude-ci-workflows@v1.10.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@807ec984ba6a6e59815174a7730aedbf24fc78b5
     with:
       run_id: ${{ github.event.workflow_run.id || inputs.run_id }}
       branch: ${{ github.event.workflow_run.head_branch || inputs.branch }}

--- a/.github/workflows/claude-dependabot-sweep.yml
+++ b/.github/workflows/claude-dependabot-sweep.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   sweep:
-    # viamrobotics/claude-ci-workflows@v1.9.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-dependabot-sweep.yml@41c2182579d9039d9fd30b2a2a0976008b402b8b
+    # viamrobotics/claude-ci-workflows@v1.10.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-dependabot-sweep.yml@807ec984ba6a6e59815174a7730aedbf24fc78b5
     with:
       install_command: 'pip install uv && make install'
       allowed_tools: 'Edit,Read,Write,Glob,Grep,Bash(uv add*),Bash(uv lock*),Bash(uv sync*),Bash(uv run make format*),Bash(uv run make lint*),Bash(pip install uv*),Bash(make install*),Bash(git config *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr create*),Bash(gh pr list*)'
@@ -24,5 +24,6 @@ jobs:
         Only run make buf to regenerate src/viam/gen/. Do NOT run other make targets unless explicitly needed.
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
+      CI_GITHUB_APP_ID: ${{ secrets.CI_GITHUB_APP_ID }}
+      CI_GITHUB_APP_PRIVATE_KEY: ${{ secrets.CI_GITHUB_APP_PRIVATE_KEY }}
       SLACK_AI_WORKFLOW_ALERT_WEBHOOK_URL: ${{ secrets.SLACK_AI_WORKFLOW_ALERT_WEBHOOK_URL }}

--- a/.github/workflows/claude-jira.yml
+++ b/.github/workflows/claude-jira.yml
@@ -50,8 +50,8 @@ on:
 
 jobs:
   call-jira:
-    # viamrobotics/claude-ci-workflows@v1.9.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@41c2182579d9039d9fd30b2a2a0976008b402b8b
+    # viamrobotics/claude-ci-workflows@v1.10.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@807ec984ba6a6e59815174a7730aedbf24fc78b5
     with:
       ticket_id: ${{ github.event.client_payload.ticket_id || inputs.ticket_id }}
       summary: ${{ github.event.client_payload.summary || inputs.summary }}

--- a/.github/workflows/claude-pr-fix.yml
+++ b/.github/workflows/claude-pr-fix.yml
@@ -12,8 +12,8 @@ jobs:
       github.repository_owner == 'viamrobotics' &&
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@claude-fix')
-    # viamrobotics/claude-ci-workflows@v1.9.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-fix.yml@41c2182579d9039d9fd30b2a2a0976008b402b8b
+    # viamrobotics/claude-ci-workflows@v1.10.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-fix.yml@807ec984ba6a6e59815174a7730aedbf24fc78b5
     with:
       install_command: 'pip install uv && make install'
       allowed_tools: 'Edit,Read,Write,Glob,Grep,Bash(uv run make format*),Bash(uv run make lint*),Bash(uv run make typecheck*),Bash(uv run make test*),Bash(uv run pytest*),Bash(uv run python -m pytest*),Bash(git config *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git -C * diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *)'

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -55,8 +55,8 @@ jobs:
   auto-review:
     needs: resolve-pr
     if: needs.resolve-pr.outputs.pr_found == 'true'
-    # viamrobotics/claude-ci-workflows@v1.9.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-auto-review.yml@41c2182579d9039d9fd30b2a2a0976008b402b8b
+    # viamrobotics/claude-ci-workflows@v1.10.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-auto-review.yml@807ec984ba6a6e59815174a7730aedbf24fc78b5
     with:
       pr_number: ${{ needs.resolve-pr.outputs.pr_number }}
       pr_title: ${{ needs.resolve-pr.outputs.pr_title }}
@@ -79,8 +79,8 @@ jobs:
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
       )
-    # viamrobotics/claude-ci-workflows@v1.9.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-on-demand-review.yml@41c2182579d9039d9fd30b2a2a0976008b402b8b
+    # viamrobotics/claude-ci-workflows@v1.10.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-on-demand-review.yml@807ec984ba6a6e59815174a7730aedbf24fc78b5
     with:
       install_command: 'pip install uv && make install'
       allowed_tools: 'Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(git diff*),Bash(git -C * diff*),Bash(git log*),Bash(git status*),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr diff*),Bash(gh pr view*)'


### PR DESCRIPTION
Update all claude-ci-workflows references from v1.9.0 to v1.10.0. The dependabot sweep now uses CI_GITHUB_APP_ID and CI_GITHUB_APP_PRIVATE_KEY instead of GIT_ACCESS_TOKEN.