### PR TITLE
Bump claude-ci-workflows to v1.10.2 and increase sweep max_turns

### DIFF
--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -21,8 +21,8 @@ jobs:
         github.event.workflow_run.conclusion == 'failure' &&
         startsWith(github.event.workflow_run.head_branch, 'claude/')
       )
-    # viamrobotics/claude-ci-workflows@v1.10.1
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@380cb677633bdc378a17da1c372cb72272636f8e
+    # viamrobotics/claude-ci-workflows@v1.10.2
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@8cc3a93ff2acfe4db5109b435093814c19a4ff72
     with:
       run_id: ${{ github.event.workflow_run.id || inputs.run_id }}
       branch: ${{ github.event.workflow_run.head_branch || inputs.branch }}

--- a/.github/workflows/claude-dependabot-sweep.yml
+++ b/.github/workflows/claude-dependabot-sweep.yml
@@ -7,12 +7,13 @@ on:
 
 jobs:
   sweep:
-    # viamrobotics/claude-ci-workflows@v1.10.1
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-dependabot-sweep.yml@380cb677633bdc378a17da1c372cb72272636f8e
+    # viamrobotics/claude-ci-workflows@v1.10.2
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-dependabot-sweep.yml@8cc3a93ff2acfe4db5109b435093814c19a4ff72
     with:
       install_command: 'pip install uv && make install'
       allowed_tools: 'Edit,Read,Write,Glob,Grep,Bash(uv add*),Bash(uv lock*),Bash(uv sync*),Bash(uv run make format*),Bash(uv run make lint*),Bash(pip install uv*),Bash(make install*),Bash(git config *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr create*),Bash(gh pr list*)'
       alert_severity: 'critical,high,medium'
+      max_turns: 40
       extra_prompt: |
         - This project uses `uv` for dependency management with `pyproject.toml` and `uv.lock`.
         - To update a dependency: edit the version constraint in `pyproject.toml`, then run `uv lock` to regenerate the lockfile.

--- a/.github/workflows/claude-jira.yml
+++ b/.github/workflows/claude-jira.yml
@@ -50,8 +50,8 @@ on:
 
 jobs:
   call-jira:
-    # viamrobotics/claude-ci-workflows@v1.10.1
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@380cb677633bdc378a17da1c372cb72272636f8e
+    # viamrobotics/claude-ci-workflows@v1.10.2
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@8cc3a93ff2acfe4db5109b435093814c19a4ff72
     with:
       ticket_id: ${{ github.event.client_payload.ticket_id || inputs.ticket_id }}
       summary: ${{ github.event.client_payload.summary || inputs.summary }}

--- a/.github/workflows/claude-pr-fix.yml
+++ b/.github/workflows/claude-pr-fix.yml
@@ -12,8 +12,8 @@ jobs:
       github.repository_owner == 'viamrobotics' &&
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@claude-fix')
-    # viamrobotics/claude-ci-workflows@v1.10.1
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-fix.yml@380cb677633bdc378a17da1c372cb72272636f8e
+    # viamrobotics/claude-ci-workflows@v1.10.2
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-fix.yml@8cc3a93ff2acfe4db5109b435093814c19a4ff72
     with:
       install_command: 'pip install uv && make install'
       allowed_tools: 'Edit,Read,Write,Glob,Grep,Bash(uv run make format*),Bash(uv run make lint*),Bash(uv run make typecheck*),Bash(uv run make test*),Bash(uv run pytest*),Bash(uv run python -m pytest*),Bash(git config *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git -C * diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *)'

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -55,8 +55,8 @@ jobs:
   auto-review:
     needs: resolve-pr
     if: needs.resolve-pr.outputs.pr_found == 'true'
-    # viamrobotics/claude-ci-workflows@v1.10.1
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-auto-review.yml@380cb677633bdc378a17da1c372cb72272636f8e
+    # viamrobotics/claude-ci-workflows@v1.10.2
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-auto-review.yml@8cc3a93ff2acfe4db5109b435093814c19a4ff72
     with:
       pr_number: ${{ needs.resolve-pr.outputs.pr_number }}
       pr_title: ${{ needs.resolve-pr.outputs.pr_title }}
@@ -79,8 +79,8 @@ jobs:
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
       )
-    # viamrobotics/claude-ci-workflows@v1.10.1
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-on-demand-review.yml@380cb677633bdc378a17da1c372cb72272636f8e
+    # viamrobotics/claude-ci-workflows@v1.10.2
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-on-demand-review.yml@8cc3a93ff2acfe4db5109b435093814c19a4ff72
     with:
       install_command: 'pip install uv && make install'
       allowed_tools: 'Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(git diff*),Bash(git -C * diff*),Bash(git log*),Bash(git status*),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr diff*),Bash(gh pr view*)'


### PR DESCRIPTION
Bump all claude workflow references from v1.10.1 to v1.10.2 (paginated Dependabot alerts fix) and set max_turns: 40 on the dependabot sweep job (default is 30).