### PR TITLE
Bump claude-ci-workflows to v1.17.3

### DIFF
--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -21,8 +21,8 @@ jobs:
         github.event.workflow_run.conclusion == 'failure' &&
         startsWith(github.event.workflow_run.head_branch, 'claude/')
       )
-    # viamrobotics/claude-ci-workflows@v1.17.1
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@9c5197c7a93debf019a5a899c24c2c5d6504415e
+    # viamrobotics/claude-ci-workflows@v1.17.3
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@3ad96b0ccbb5ee0d7e2cde98653fae0c453e68bb
     with:
       run_id: ${{ github.event.workflow_run.id || inputs.run_id }}
       branch: ${{ github.event.workflow_run.head_branch || inputs.branch }}

--- a/.github/workflows/claude-dependabot-sweep.yml
+++ b/.github/workflows/claude-dependabot-sweep.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   sweep:
-    # viamrobotics/claude-ci-workflows@v1.17.1
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-dependabot-sweep.yml@9c5197c7a93debf019a5a899c24c2c5d6504415e
+    # viamrobotics/claude-ci-workflows@v1.17.3
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-dependabot-sweep.yml@3ad96b0ccbb5ee0d7e2cde98653fae0c453e68bb
     with:
       install_command: 'pip install uv && make install'
       allowed_tools: 'Edit,Read,Write,Glob,Grep,Bash(uv add*),Bash(uv lock*),Bash(uv sync*),Bash(uv run make format*),Bash(uv run make lint*),Bash(uv pip *),Bash(curl -s https://pypi.org/pypi/*),Bash(pip install uv*),Bash(make install*),Bash(git config *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr create*),Bash(gh pr list*),Bash(gh api repos/*/pulls/*/comments*)'
@@ -23,12 +23,6 @@ jobs:
         - Do NOT edit `uv.lock` directly — always regenerate it with `uv lock`.
         - Run `uv run make format` to format code before committing.
         - Run `uv run make lint` to check for lint issues. Fix any errors.
-        - Dependency placement — determine the dependency chain, then:
-          1. Direct dependency → update its constraint in `[project] dependencies`.
-          2. Transitive via dev/doc only (`[dependency-groups]`) → use `[tool.uv] constraint-dependencies`.
-          3. Transitive via production dependency (`[project] dependencies`) → add to `[project] dependencies`
-             with minimum secure version so downstream users get the fix.
-          - In the PR description, explain the dependency chain and placement rationale.
         - TOML section ordering in `pyproject.toml`:
           - If a `[tool.uv]` section already exists, add to it. Do NOT create a duplicate section.
           - If creating a new `[tool.uv]` section, place it at the END of the file.

--- a/.github/workflows/claude-jira.yml
+++ b/.github/workflows/claude-jira.yml
@@ -50,8 +50,8 @@ on:
 
 jobs:
   call-jira:
-    # viamrobotics/claude-ci-workflows@v1.17.1
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@9c5197c7a93debf019a5a899c24c2c5d6504415e
+    # viamrobotics/claude-ci-workflows@v1.17.3
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@3ad96b0ccbb5ee0d7e2cde98653fae0c453e68bb
     with:
       ticket_id: ${{ github.event.client_payload.ticket_id || inputs.ticket_id }}
       summary: ${{ github.event.client_payload.summary || inputs.summary }}

--- a/.github/workflows/claude-pr-assistant.yml
+++ b/.github/workflows/claude-pr-assistant.yml
@@ -55,8 +55,8 @@ jobs:
   auto-review:
     needs: resolve-pr
     if: needs.resolve-pr.outputs.pr_found == 'true'
-    # viamrobotics/claude-ci-workflows@v1.17.1
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-auto-review.yml@9c5197c7a93debf019a5a899c24c2c5d6504415e
+    # viamrobotics/claude-ci-workflows@v1.17.3
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-auto-review.yml@3ad96b0ccbb5ee0d7e2cde98653fae0c453e68bb
     with:
       pr_number: ${{ needs.resolve-pr.outputs.pr_number }}
       pr_title: ${{ needs.resolve-pr.outputs.pr_title }}
@@ -79,8 +79,8 @@ jobs:
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
       )
-    # viamrobotics/claude-ci-workflows@v1.17.1
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@9c5197c7a93debf019a5a899c24c2c5d6504415e
+    # viamrobotics/claude-ci-workflows@v1.17.3
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@3ad96b0ccbb5ee0d7e2cde98653fae0c453e68bb
     with:
       install_command: 'pip install uv && make install'
       allowed_tools: 'Edit,Read,Write,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(uv run make format*),Bash(uv run make lint*),Bash(uv run make typecheck*),Bash(uv run make test*),Bash(uv run pytest*),Bash(uv run python -m pytest*),Bash(uv pip *),Bash(curl -s https://pypi.org/pypi/*),Bash(git config *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git -C * diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr diff*),Bash(gh pr view*),Bash(gh api repos/*/pulls/*/comments*)'


### PR DESCRIPTION
Bug fixes in v1.17.1–v1.17.3:
- Fall back to title search when branch_name output is empty
- Bump claude-code-action to v1.0.90, enable display_report
- Prevent dependabot sweep from promoting transitive deps to direct

Remove redundant dependency-placement instructions from the dependabot-sweep extra_prompt since the upstream workflow now handles transitive vs direct dependency routing natively.