### PR TITLE
Unmask Jira release page link in sync workflow logs

### DIFF
--- a/.github/workflows/sync-release-to-jira.yml
+++ b/.github/workflows/sync-release-to-jira.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run Jira sync
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_BASE_URL: ${{ vars.JIRA_BASE_URL }}
           JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
           # Pass version via env var to prevent shell injection


### PR DESCRIPTION
## Summary
- `JIRA_BASE_URL` was pulled from `secrets.*`, which causes GitHub Actions to mask it (and any URL containing it) as `***` in logs. The resulting \"release page\" link printed by `etc/sync_jira_release.py` came out as `***/projects/RSDK/versions/<id>/...` — unclickable.
- Switched to `vars.JIRA_BASE_URL`, matching the pattern used by [`viamrobotics/rdk`'s sync workflow](https://github.com/viamrobotics/rdk/blob/main/.github/workflows/sync-release-to-jira.yml). The base URL is not sensitive — it's already visible in every RDK run's logs.

## Required follow-up (manual, cannot be done in this PR)
Before merging, add the repository variable:
- Settings → Secrets and variables → Actions → **Variables** tab → New repository variable
- Name: `JIRA_BASE_URL`
- Value: `https://viam.atlassian.net`

Without this, the workflow's env var will be empty and the script will fail its env-var assertion.

The existing `JIRA_BASE_URL` secret becomes unused after this change and can optionally be deleted.

## Test plan
- [ ] Add the `JIRA_BASE_URL` repository variable (see above)
- [ ] Manually dispatch the `Sync Release to Jira` workflow with an existing version (e.g., `v0.74.0`)
- [ ] Confirm the logs print `Release page: https://viam.atlassian.net/projects/RSDK/versions/<id>/tab/release-report-all-issues` instead of `***/projects/...`
- [ ] Click the link and verify it loads the Jira version page

🤖 Generated with [Claude Code](https://claude.com/claude-code)