### PR TITLE
[RSDK-13658] Expose force_relay/force_p2p/turn_uri DialOptions

### DIFF
--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -263,7 +263,7 @@ class _Runtime:
         self._lib.viam_init_rust_runtime.argtypes = ()
         self._lib.viam_init_rust_runtime.restype = ctypes.c_void_p
 
-        self._lib.viam_dial.argtypes = (
+        self._lib.viam_dial_with_opts.argtypes = (
             ctypes.c_char_p,
             ctypes.c_char_p,
             ctypes.c_char_p,
@@ -271,11 +271,24 @@ class _Runtime:
             ctypes.c_bool,
             ctypes.c_float,
             ctypes.c_void_p,
-            ctypes.c_bool,
-            ctypes.c_bool,
-            ctypes.c_char_p,
+            ctypes.c_void_p,
         )
-        self._lib.viam_dial.restype = ctypes.c_void_p
+        self._lib.viam_dial_with_opts.restype = ctypes.c_void_p
+
+        self._lib.viam_dial_opts_new.argtypes = ()
+        self._lib.viam_dial_opts_new.restype = ctypes.c_void_p
+
+        self._lib.viam_dial_opts_free.argtypes = (ctypes.c_void_p,)
+        self._lib.viam_dial_opts_free.restype = None
+
+        self._lib.viam_dial_opts_set_force_relay.argtypes = (ctypes.c_void_p, ctypes.c_bool)
+        self._lib.viam_dial_opts_set_force_relay.restype = None
+
+        self._lib.viam_dial_opts_set_force_p2p.argtypes = (ctypes.c_void_p, ctypes.c_bool)
+        self._lib.viam_dial_opts_set_force_p2p.restype = None
+
+        self._lib.viam_dial_opts_set_turn_uri.argtypes = (ctypes.c_void_p, ctypes.c_char_p)
+        self._lib.viam_dial_opts_set_turn_uri.restype = None
 
         self._lib.viam_free_rust_runtime.argtypes = (ctypes.c_void_p,)
         self._lib.viam_free_rust_runtime.restype = None
@@ -295,19 +308,25 @@ class _Runtime:
         )
 
         LOGGER.debug(f"Dialing {address} using viam-rust-utils library")
-        path_ptr = await to_thread(
-            self._lib.viam_dial,
-            address.encode("utf-8"),
-            options.auth_entity.encode("utf-8") if options.auth_entity else None,
-            type.encode("utf-8") if type else None,
-            payload.encode("utf-8") if payload else None,
-            insecure,
-            ctypes.c_float(options.timeout),
-            self._ptr,
-            options.force_relay,
-            options.force_p2p,
-            options.turn_uri.encode("utf-8") if options.turn_uri else None,
-        )
+        opts_handle = self._lib.viam_dial_opts_new()
+        try:
+            self._lib.viam_dial_opts_set_force_relay(opts_handle, options.force_relay)
+            self._lib.viam_dial_opts_set_force_p2p(opts_handle, options.force_p2p)
+            if options.turn_uri:
+                self._lib.viam_dial_opts_set_turn_uri(opts_handle, options.turn_uri.encode("utf-8"))
+            path_ptr = await to_thread(
+                self._lib.viam_dial_with_opts,
+                address.encode("utf-8"),
+                options.auth_entity.encode("utf-8") if options.auth_entity else None,
+                type.encode("utf-8") if type else None,
+                payload.encode("utf-8") if payload else None,
+                insecure,
+                ctypes.c_float(options.timeout),
+                self._ptr,
+                opts_handle,
+            )
+        finally:
+            self._lib.viam_dial_opts_free(opts_handle)
         path = ctypes.cast(path_ptr, ctypes.c_char_p).value
         path = path.decode("utf-8") if path else ""
         return (path, path_ptr)

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -82,6 +82,24 @@ class DialOptions:
     """Number of seconds before the dial connection times out
     Set to 20sec to match _defaultOfferDeadline in goutils/rpc/wrtc_call_queue.go"""
 
+    force_relay: bool = False
+    """Force ICE transport policy to relay-only so only TURN candidates are used.
+    Useful for testing relay connectivity through a TURN server. Mutually exclusive
+    with ``force_p2p``: if both are set the connection will fail because ``force_p2p``
+    strips the very TURN servers ``force_relay`` requires."""
+
+    force_p2p: bool = False
+    """Strip TURN servers from the ICE config so only host and server-reflexive
+    candidates are used. Useful for testing direct connectivity without relay
+    fallback. Setting this alongside ``turn_uri`` is a no-op for the filter, since
+    TURN servers are removed before any filtering happens."""
+
+    turn_uri: Optional[str] = None
+    """Filter the signaling server's TURN list to only the server whose parsed URI
+    matches (compared by scheme, host, port, and transport — transport defaults to
+    UDP if unspecified). An empty host (e.g. ``"turns::443?transport=tcp"``) matches
+    any TURN provider. Example: ``"turn:turn.viam.com:443"``."""
+
     def __init__(
         self,
         *,
@@ -95,6 +113,9 @@ class DialOptions:
         timeout: float = 20,
         initial_connection_attempts: int = 3,
         initial_connection_attempt_timeout: Optional[float] = None,
+        force_relay: bool = False,
+        force_p2p: bool = False,
+        turn_uri: Optional[str] = None,
     ) -> None:
         self.disable_webrtc = disable_webrtc
         self.auth_entity = auth_entity
@@ -106,6 +127,9 @@ class DialOptions:
         self.timeout = timeout
         self.initial_connection_attempts = initial_connection_attempts
         self.initial_connection_attempt_timeout = initial_connection_attempt_timeout if initial_connection_attempt_timeout else timeout
+        self.force_relay = force_relay
+        self.force_p2p = force_p2p
+        self.turn_uri = turn_uri
 
     @classmethod
     def with_api_key(cls, api_key: str, api_key_id: str) -> Self:
@@ -236,27 +260,30 @@ class _Runtime:
         LOGGER.debug("Creating new viam-rust-utils runtime")
         libname = pathlib.Path(__file__).parent.absolute() / f"libviam_rust_utils.{suffix}"
         self._lib = ctypes.CDLL(libname.__str__())
-        self._lib.init_rust_runtime.argtypes = ()
-        self._lib.init_rust_runtime.restype = ctypes.c_void_p
+        self._lib.viam_init_rust_runtime.argtypes = ()
+        self._lib.viam_init_rust_runtime.restype = ctypes.c_void_p
 
-        self._lib.dial.argtypes = (
+        self._lib.viam_dial.argtypes = (
             ctypes.c_char_p,
             ctypes.c_char_p,
             ctypes.c_char_p,
             ctypes.c_char_p,
             ctypes.c_bool,
             ctypes.c_float,
+            ctypes.c_bool,
+            ctypes.c_bool,
+            ctypes.c_char_p,
             ctypes.c_void_p,
         )
-        self._lib.dial.restype = ctypes.c_void_p
+        self._lib.viam_dial.restype = ctypes.c_void_p
 
-        self._lib.free_rust_runtime.argtypes = (ctypes.c_void_p,)
-        self._lib.free_rust_runtime.restype = None
+        self._lib.viam_free_rust_runtime.argtypes = (ctypes.c_void_p,)
+        self._lib.viam_free_rust_runtime.restype = None
 
-        self._lib.free_string.argtypes = (ctypes.c_void_p,)
-        self._lib.free_string.restype = None
+        self._lib.viam_free_string.argtypes = (ctypes.c_void_p,)
+        self._lib.viam_free_string.restype = None
 
-        self._ptr = self._lib.init_rust_runtime()
+        self._ptr = self._lib.viam_init_rust_runtime()
 
     async def dial(self, address: str, options: DialOptions) -> Tuple[Optional[str], ctypes.c_void_p]:
         type = options.credentials.type if options.credentials else ""
@@ -267,15 +294,29 @@ class _Runtime:
             or (not type and not payload and options.allow_insecure_downgrade)
         )
 
+        if options.force_relay and options.force_p2p:
+            LOGGER.warning(
+                "force_relay and force_p2p are both set; force_p2p strips TURN servers that "
+                "force_relay requires so the connection will fail"
+            )
+        if options.force_p2p and options.turn_uri:
+            LOGGER.warning(
+                "force_p2p is set alongside turn_uri; the TURN filter will have no effect since "
+                "TURN servers were already stripped"
+            )
+
         LOGGER.debug(f"Dialing {address} using viam-rust-utils library")
         path_ptr = await to_thread(
-            self._lib.dial,
+            self._lib.viam_dial,
             address.encode("utf-8"),
             options.auth_entity.encode("utf-8") if options.auth_entity else None,
             type.encode("utf-8") if type else None,
             payload.encode("utf-8") if payload else None,
             insecure,
             ctypes.c_float(options.timeout),
+            options.force_relay,
+            options.force_p2p,
+            options.turn_uri.encode("utf-8") if options.turn_uri else None,
             self._ptr,
         )
         path = ctypes.cast(path_ptr, ctypes.c_char_p).value
@@ -284,11 +325,11 @@ class _Runtime:
 
     def release(self):
         LOGGER.debug("Freeing viam-rust-utils runtime")
-        self._lib.free_rust_runtime(self._ptr)
+        self._lib.viam_free_rust_runtime(self._ptr)
 
     def free_str(self, ptr: ctypes.c_void_p):
         LOGGER.debug("Freeing socket string")
-        self._lib.free_string(ptr)
+        self._lib.viam_free_string(ptr)
 
 
 async def dial(address: str, options: Optional[DialOptions] = None) -> ViamChannel:

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -97,8 +97,8 @@ class DialOptions:
     turn_uri: Optional[str] = None
     """Filter the signaling server's TURN list to only the server whose parsed URI
     matches (compared by scheme, host, port, and transport — transport defaults to
-    UDP if unspecified). An empty host (e.g. ``"turns::443?transport=tcp"``) matches
-    any TURN provider. Example: ``"turn:turn.viam.com:443"``."""
+    UDP if unspecified). Set to ``None`` to use all TURN servers.
+    Example: ``"turn:turn.viam.com:443"``."""
 
     def __init__(
         self,

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -270,10 +270,10 @@ class _Runtime:
             ctypes.c_char_p,
             ctypes.c_bool,
             ctypes.c_float,
+            ctypes.c_void_p,
             ctypes.c_bool,
             ctypes.c_bool,
             ctypes.c_char_p,
-            ctypes.c_void_p,
         )
         self._lib.viam_dial.restype = ctypes.c_void_p
 
@@ -303,10 +303,10 @@ class _Runtime:
             payload.encode("utf-8") if payload else None,
             insecure,
             ctypes.c_float(options.timeout),
+            self._ptr,
             options.force_relay,
             options.force_p2p,
             options.turn_uri.encode("utf-8") if options.turn_uri else None,
-            self._ptr,
         )
         path = ctypes.cast(path_ptr, ctypes.c_char_p).value
         path = path.decode("utf-8") if path else ""

--- a/src/viam/rpc/dial.py
+++ b/src/viam/rpc/dial.py
@@ -294,17 +294,6 @@ class _Runtime:
             or (not type and not payload and options.allow_insecure_downgrade)
         )
 
-        if options.force_relay and options.force_p2p:
-            LOGGER.warning(
-                "force_relay and force_p2p are both set; force_p2p strips TURN servers that "
-                "force_relay requires so the connection will fail"
-            )
-        if options.force_p2p and options.turn_uri:
-            LOGGER.warning(
-                "force_p2p is set alongside turn_uri; the TURN filter will have no effect since "
-                "TURN servers were already stripped"
-            )
-
         LOGGER.debug(f"Dialing {address} using viam-rust-utils library")
         path_ptr = await to_thread(
             self._lib.viam_dial,


### PR DESCRIPTION
## Summary
- Adds `force_relay`, `force_p2p`, `turn_uri` kwargs to `DialOptions` so callers can drive ICE relay/P2P testing and TURN-server filtering. The user-facing API is unchanged from prior iterations of this branch — the FFI wiring underneath is what changed.
- Switches `_Runtime` to the new opaque-opts FFI introduced in viamrobotics/rust-utils#176: `viam_dial_with_opts` + `viam_dial_opts_new` / `_free` / 3 setters, instead of a 10-arg `viam_dial`, with explicit alloc/free memory management around the opts handle in `LibraryHandle.dial`.

## Won't merge until
- rust-utils tagged release containing viamrobotics/rust-utils#176 is published and the bundled `libviam_rust_utils.*` artifacts are updated.

## Test plan
- [x] Bundled the locally built rust-utils dylib from PR #176 and confirmed `LibraryHandle()` resolves every new symbol (`viam_dial_opts_new/_free/_set_force_relay/_set_force_p2p/_set_turn_uri`, `viam_dial_with_opts`)
- [x] FFI smoke test: alloc opts → setters with valid string / NULL / empty / non-UTF8 → free; NULL inputs to setters & free safely no-op
- [x] `ruff check`, `ruff format`, `pyright` all clean on `src/viam/rpc/dial.py`
- [x] (manual, paired with rust-utils dylib) `force_relay` pins ICE to relay candidates against coturn; `force_p2p` pins to host/srflx/prflx only; `turn_uri` filters the TURN list
