### PR TITLE
Set attestations false to fix publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+          attestations: false
           verbose: true
 
       - name: Get Release URL


### PR DESCRIPTION
attestations defaults to true, which requires trusted publishing. But, setting a password explicitly disables trusted publishing. Can't have both, so set attestations to false.