### PR TITLE
RSDK-14103: Fix create_from_dial_options double authenticating

### DIFF
--- a/src/viam/app/viam_client.py
+++ b/src/viam/app/viam_client.py
@@ -89,10 +89,7 @@ class ViamClient:
         self._dial_options = dial_options
         if app_url is None:
             app_url = "app.viam.com"
-        # Forward connection options (insecure, timeout, …) so they're honored, but strip
-        # credentials so _dial_direct does NOT authenticate — ViamClient authenticates once
-        # below using auth_entity. Passing credentials here caused a double-Authenticate
-        # ("already authenticated; cannot re-authenticate"). See RSDK-13800.
+        # dial_app will authenticate again when given credentials in dial_options, so remove to prevent error
         dial_options_without_credentials = copy(dial_options)
         dial_options_without_credentials.credentials = None
         self._channel = await _dial_app(app_url, dial_options_without_credentials)

--- a/src/viam/app/viam_client.py
+++ b/src/viam/app/viam_client.py
@@ -1,4 +1,5 @@
 import os
+from copy import copy
 from typing import Any, Mapping, Optional
 
 from grpclib.client import Channel
@@ -88,7 +89,13 @@ class ViamClient:
         self._dial_options = dial_options
         if app_url is None:
             app_url = "app.viam.com"
-        self._channel = await _dial_app(app_url, dial_options)
+        # Forward connection options (insecure, timeout, …) so they're honored, but strip
+        # credentials so _dial_direct does NOT authenticate — ViamClient authenticates once
+        # below using auth_entity. Passing credentials here caused a double-Authenticate
+        # ("already authenticated; cannot re-authenticate"). See RSDK-13800.
+        dial_options_without_credentials = copy(dial_options)
+        dial_options_without_credentials.credentials = None
+        self._channel = await _dial_app(app_url, dial_options_without_credentials)
         access_token = await _get_access_token(self._channel, dial_options.auth_entity, dial_options)
         self._metadata = {"authorization": f"Bearer {access_token}"}
         return self

--- a/tests/test_viam_client.py
+++ b/tests/test_viam_client.py
@@ -1,6 +1,6 @@
 import os
 import random
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
@@ -56,7 +56,12 @@ class TestViamClient:
 
                     await ViamClient.create_from_dial_options(dial_options)
 
-                    patched_dial.assert_called_once_with("app.viam.com", dial_options)
+                    patched_dial.assert_called_once()
+                    url, forwarded = patched_dial.call_args.args
+                    assert url == "app.viam.com"
+                    assert forwarded.credentials is None
+                    assert forwarded.insecure == dial_options.insecure
+                    assert forwarded.auth_entity == dial_options.auth_entity
 
     async def test_passes_dial_options_with_custom_url(self):
         async with ChannelFor([]) as channel:
@@ -70,7 +75,25 @@ class TestViamClient:
 
                     await ViamClient.create_from_dial_options(dial_options, app_url="localhost:8080")
 
-                    patched_dial.assert_called_once_with("localhost:8080", dial_options)
+                    patched_dial.assert_called_once()
+                    url, forwarded = patched_dial.call_args.args
+                    assert url == "localhost:8080"
+                    assert forwarded.credentials is None
+
+    async def test_authenticates_exactly_once(self):
+        auth_mock = AsyncMock(return_value="FAKE_ACCESS_TOKEN")
+
+        creds = Credentials("api-key", "SOME_API_KEY")
+        # insecure=True so the real _dial_direct does not open a socket (the TLS-downgrade probe
+        # is skipped and the only RPC -- Authenticate -- is mocked below).
+        dial_options = DialOptions(credentials=creds, auth_entity=str(uuid4()), insecure=True)
+
+        with patch("viam.rpc.dial._get_access_token", auth_mock):
+            with patch("viam.app.viam_client._get_access_token", auth_mock):
+                client = await ViamClient.create_from_dial_options(dial_options, app_url="localhost:8080")
+
+        assert auth_mock.call_count == 1
+        assert client._metadata == {"authorization": "Bearer FAKE_ACCESS_TOKEN"}
 
     async def test_clients(self):
         async with ChannelFor([]) as channel:


### PR DESCRIPTION
This PR addresses a regression from [this PR](https://github.com/viamrobotics/viam-python-sdk/pull/1211) where passing dial_options with auth into dial_app will also authenticate there, causing it so authenticate twice and fail with `"machineId rejected: 972ffb48-1306-4e70-a754-778e1aecad6e err=(<Status.INVALID_ARGUMENT: 3>, 'already authenticated; cannot re-authenticate', None)"` 

Fix: I pass the dial a copy of dial_options with credentials stripped, so the dial still honors the other options (insecure, timeout, etc.) but no longer authenticates. create_from_dial_options still authenticates once itself, so we lose nothing — just the redundant second auth.

Rejected alternatives:
1. Remove auth from create_from_dial_options and let the dial do it — because credentials still reach the dial, it returns an AuthenticatedChannel (auto-attaches the bearer) instead of a normal Channel, which would double-attach the authorization header on every call; you'd also have to recover the token from the channel's private state.
2. Remove auth from _dial_direct (the shared dial core) — _dial_app calls _dial_direct, but so do machine/RobotClient connections and the public dial_direct, and they rely on it authenticating. Removing it would break them.
3. Don't error on re-auth (server side) — the server's "already authenticated" guard is intentional; it prevents a connection from changing identities mid-stream. The real defect is the client authenticating twice, so we fix the client, not the guard.