### PR TITLE
Fix release workflow: download native lib before tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Install Package
         run: uv sync --all-extras
 
+      - name: Download Native Library
+        run: bash etc/postinstall.sh
+
       - name: Clean Format Test
         run: uv run make clean format typecheck test
 


### PR DESCRIPTION
The release workflow ran `uv sync` + tests but never downloaded libviam_rust_utils, which uv sync does not fetch (only make install / etc/postinstall.sh does). The new spatialmath FFI tests load the native lib at runtime, so the release job failed with OSError (exit code 2). Add a postinstall step to download the lib, matching test.yml.