### PR TITLE
Run tests on pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,8 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-  pull_request_target:
+  # plain pull_request: fork runs get no secrets and a read-only token
+  pull_request:
     branches: [main, "rc-*"]
 
 jobs:
@@ -20,14 +21,8 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         requirements-version: ["min", "max"]
     steps:
-      - name: Checkout Push/Workflow Dispatch
-        if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+      - name: Checkout
         uses: actions/checkout@v6
-      - name: Checkout PR
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:


### PR DESCRIPTION
test.yml ran fork PRs under `pull_request_target` with no label gate: any fork PR executed untrusted code (`make test`, `make lint`) with access to repo secrets and a privileged `GITHUB_TOKEN` persisted in `.git/config` by checkout.

The test job uses no secrets, so plain `pull_request` does the same work while GitHub withholds secrets and issues a read-only token for fork runs. This also drops the split checkout: `pull_request` checks out the PR merge ref by default, so one unconditional checkout step covers every trigger.

This closes the last ungated `pull_request_target` head checkout among the SDK repos. The gated repos (api, goutils, rdk) keep the label machinery and already carry `allow-unsafe-pr-checkout: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)