### PR TITLE
Widen RGBADecoder.decode buffer type for Pillow 12.3

### DIFF
--- a/src/viam/media/utils/pil/viam_rgba_plugin.py
+++ b/src/viam/media/utils/pil/viam_rgba_plugin.py
@@ -62,7 +62,8 @@ class RGBAImage(ImageFile):
 class RGBADecoder(PyDecoder):
     _pulls_fd = True
 
-    def decode(self, buffer: bytes | Image.SupportsArrayInterface) -> tuple[int, int]:
+    # Image.DecoderInput spelled out for Pillow < 12.3 compatibility
+    def decode(self, buffer: bytes | bytearray | memoryview | Image.SupportsArrayInterface) -> tuple[int, int]:
         assert self.im is not None
         assert self.fd is not None
         width, height = self.im.size


### PR DESCRIPTION
## What

Widens the `buffer` parameter of `RGBADecoder.decode` from `bytes | Image.SupportsArrayInterface` to `bytes | bytearray | memoryview | Image.SupportsArrayInterface`.

## Why

Pillow 12.3.0 changed `PyDecoder.decode`'s buffer parameter to `Image.DecoderInput`, an alias for that four-member union. Our narrower override now fails pyright's `reportIncompatibleMethodOverride` on the max-versions CI job, which has kept main red since [this run](https://github.com/viamrobotics/viam-python-sdk/actions/runs/30025993020/job/89270471288).

The union is spelled out instead of naming `Image.DecoderInput` so the file still type-checks against Pillow < 12.3, where the alias doesn't exist. The method body never touches `buffer` (`_pulls_fd = True`; it reads from `self.fd`), so behavior is unchanged.

## Verification

pyright reports 0 errors on the file against both Pillow 12.3.0 and 12.1.1 (the repo's minimum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)