### PR TITLE
fix(media): validate PNG headers

### DIFF
--- a/src/viam/media/video.py
+++ b/src/viam/media/video.py
@@ -204,13 +204,13 @@ def _getDimensionsFromPNG(image: bytes) -> Tuple[int, int]:
 
     # PNG will always start with this signature
     signature = image[:8]
-    if signature != [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]:
-        ValueError("Invalid PNG: Invalid signature")
+    if signature != bytes([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]):
+        raise ValueError("Invalid PNG: Invalid signature")
 
     header = image[12:24]
     chunk_type = header[:4].decode()
     if chunk_type != "IHDR":
-        ValueError("Invalid PNG: Invalid headers")
+        raise ValueError("Invalid PNG: Invalid headers")
 
     width = int.from_bytes(header[4:8], byteorder="big")
     height = int.from_bytes(header[8:], byteorder="big")

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -47,6 +47,19 @@ class TestViamImage:
         assert img5.width is None
         assert img5.height is None
 
+    @pytest.mark.parametrize(
+        "data",
+        [
+            b"INVALID!" + (13).to_bytes(4, "big") + b"IHDR" + (640).to_bytes(4, "big") + (480).to_bytes(4, "big"),
+            b"\x89PNG\r\n\x1a\n" + (13).to_bytes(4, "big") + b"IDAT" + (640).to_bytes(4, "big") + (480).to_bytes(4, "big"),
+        ],
+    )
+    def test_invalid_png_has_no_dimensions(self, data: bytes):
+        img = ViamImage(data, CameraMimeType.PNG)
+
+        assert img.width is None
+        assert img.height is None
+
     def test_bytes_to_depth_array(self):
         with open(f"{os.path.dirname(__file__)}/data/fakeDM.vnd.viam.dep", "rb") as depth_map:
             img = ViamImage(depth_map.read(), CameraMimeType.VIAM_RAW_DEPTH)


### PR DESCRIPTION
## Summary

While using `viam-sdk==0.80.0`, I found that `ViamImage` accepts PNG data with an invalid signature or a non-`IHDR` first chunk and reports dimensions from those bytes. For example, an invalid payload can be reported as `640x480`.

The PNG parser was constructing `ValueError` objects without raising them, and it compared a `bytes` signature with a list of integers. This change raises the validation errors and compares the signature with `bytes`, allowing `ViamImage` to fall back to unknown dimensions for malformed PNG data.

Regression coverage includes both an invalid signature with a plausible `IHDR` chunk and a valid signature with an invalid first chunk.

## Validation

* `uv run ruff format --check src/viam/media/video.py tests/test_media.py`
* `uv run ruff check src/viam/media/video.py tests/test_media.py`
* `uv run pyright` — 0 errors (1 existing warning in `src/viam/module/types.py`)
* `uv run pytest -q tests/test_media.py` — 9 passed
* `uv run pytest -q` — 866 passed, 5 skipped because `viam-server` is not installed
* `git diff --check`