### PR TITLE
RSDK-14517 Reject non-string motion resource names with an explicit TypeError

### DIFF
--- a/src/viam/services/motion/client.py
+++ b/src/viam/services/motion/client.py
@@ -50,7 +50,7 @@ def _validate_name(value: str, param_name: str) -> str:
     if isinstance(value, str):
         return value
     resource = param_name.removesuffix("_name").replace("_", " ")
-    raise TypeError(f"{param_name} must be the {resource}'s name as a string, e.g. 'pick-grip' (got {type(value).__name__})")
+    raise TypeError(f"{param_name} must be the {resource}'s name as a string, e.g. 'pick-grip'")
 
 
 class MotionClient(Motion, ReconfigurableResourceRPCClientBase):

--- a/src/viam/services/motion/client.py
+++ b/src/viam/services/motion/client.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Optional, Sequence, Union
+from typing import Any, Mapping, Optional, Sequence
 
 from grpclib.client import Channel
 
@@ -12,7 +12,6 @@ from viam.proto.common import (
     GetStatusResponse,
     Pose,
     PoseInFrame,
-    ResourceName,
     Transform,
     WorldState,
 )
@@ -42,14 +41,16 @@ from viam.utils import ValueTypes, dict_to_struct, struct_to_dict
 from .motion import Motion
 
 
-def _resource_name_to_str(value: Union[str, ResourceName], param_name: str) -> str:
-    """Coerce a ``ResourceName``, which older SDK releases accepted, into the name string this API expects."""
+def _validate_name(value: str, param_name: str) -> str:
+    """Reject non-string names here, where the field and the expected type can be named.
+
+    Passing a ``ResourceName``, as older SDK releases required, otherwise fails inside the protobuf extension with
+    "TypeError: bad argument type for built-in operation".
+    """
     if isinstance(value, str):
         return value
-    name = getattr(value, "name", None)
-    if isinstance(name, str):
-        return name
-    raise TypeError(f"{param_name} must be the resource's name as a string, e.g. 'pick-grip' (got {type(value).__name__})")
+    resource = param_name.removesuffix("_name").replace("_", " ")
+    raise TypeError(f"{param_name} must be the {resource}'s name as a string, e.g. 'pick-grip' (got {type(value).__name__})")
 
 
 class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
@@ -66,7 +67,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
 
     async def move(
         self,
-        component_name: Union[str, ResourceName],
+        component_name: str,
         destination: PoseInFrame,
         world_state: Optional[WorldState] = None,
         constraints: Optional[Constraints] = None,
@@ -79,7 +80,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
         request = MoveRequest(
             name=self.name,
             destination=destination,
-            component_name=_resource_name_to_str(component_name, "component_name"),
+            component_name=_validate_name(component_name, "component_name"),
             world_state=world_state,
             constraints=constraints,
             extra=dict_to_struct(extra),
@@ -89,9 +90,9 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
 
     async def move_on_globe(
         self,
-        component_name: Union[str, ResourceName],
+        component_name: str,
         destination: GeoPoint,
-        movement_sensor_name: Union[str, ResourceName],
+        movement_sensor_name: str,
         obstacles: Optional[Sequence[GeoGeometry]] = None,
         heading: Optional[float] = None,
         configuration: Optional[MotionConfiguration] = None,
@@ -104,9 +105,9 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
         md = kwargs.get("metadata", self.Metadata()).proto
         request = MoveOnGlobeRequest(
             name=self.name,
-            component_name=_resource_name_to_str(component_name, "component_name"),
+            component_name=_validate_name(component_name, "component_name"),
             destination=destination,
-            movement_sensor_name=_resource_name_to_str(movement_sensor_name, "movement_sensor_name"),
+            movement_sensor_name=_validate_name(movement_sensor_name, "movement_sensor_name"),
             obstacles=obstacles,
             heading=heading,
             motion_configuration=configuration,
@@ -118,9 +119,9 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
 
     async def move_on_map(
         self,
-        component_name: Union[str, ResourceName],
+        component_name: str,
         destination: Pose,
-        slam_service_name: Union[str, ResourceName],
+        slam_service_name: str,
         configuration: Optional[MotionConfiguration] = None,
         obstacles: Optional[Sequence[Geometry]] = None,
         *,
@@ -132,8 +133,8 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
         request = MoveOnMapRequest(
             name=self.name,
             destination=destination,
-            component_name=_resource_name_to_str(component_name, "component_name"),
-            slam_service_name=_resource_name_to_str(slam_service_name, "slam_service_name"),
+            component_name=_validate_name(component_name, "component_name"),
+            slam_service_name=_validate_name(slam_service_name, "slam_service_name"),
             motion_configuration=configuration,
             obstacles=obstacles,
             extra=dict_to_struct(extra),
@@ -143,7 +144,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
 
     async def stop_plan(
         self,
-        component_name: Union[str, ResourceName],
+        component_name: str,
         *,
         extra: Optional[Mapping[str, ValueTypes]] = None,
         timeout: Optional[float] = None,
@@ -153,7 +154,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
 
         request = StopPlanRequest(
             name=self.name,
-            component_name=_resource_name_to_str(component_name, "component_name"),
+            component_name=_validate_name(component_name, "component_name"),
             extra=dict_to_struct(extra),
         )
         _: StopPlanResponse = await self.client.StopPlan(request, timeout=timeout, metadata=md)
@@ -161,7 +162,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
 
     async def get_plan(
         self,
-        component_name: Union[str, ResourceName],
+        component_name: str,
         last_plan_only: bool = False,
         execution_id: Optional[str] = None,
         *,
@@ -173,7 +174,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
 
         request = GetPlanRequest(
             name=self.name,
-            component_name=_resource_name_to_str(component_name, "component_name"),
+            component_name=_validate_name(component_name, "component_name"),
             last_plan_only=last_plan_only,
             execution_id=execution_id,
             extra=dict_to_struct(extra),
@@ -201,7 +202,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
 
     async def get_pose(
         self,
-        component_name: Union[str, ResourceName],
+        component_name: str,
         destination_frame: str,
         supplemental_transforms: Optional[Sequence[Transform]] = None,
         *,
@@ -212,7 +213,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
         md = kwargs.get("metadata", self.Metadata()).proto
         request = GetPoseRequest(
             name=self.name,
-            component_name=_resource_name_to_str(component_name, "component_name"),
+            component_name=_validate_name(component_name, "component_name"),
             destination_frame=destination_frame,
             supplemental_transforms=supplemental_transforms,
             extra=dict_to_struct(extra),

--- a/src/viam/services/motion/client.py
+++ b/src/viam/services/motion/client.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence, Union
 
 from grpclib.client import Channel
 
@@ -12,6 +12,7 @@ from viam.proto.common import (
     GetStatusResponse,
     Pose,
     PoseInFrame,
+    ResourceName,
     Transform,
     WorldState,
 )
@@ -41,6 +42,16 @@ from viam.utils import ValueTypes, dict_to_struct, struct_to_dict
 from .motion import Motion
 
 
+def _resource_name_to_str(value: Union[str, ResourceName], param_name: str) -> str:
+    """Coerce a ``ResourceName``, which older SDK releases accepted, into the name string this API expects."""
+    if isinstance(value, str):
+        return value
+    name = getattr(value, "name", None)
+    if isinstance(name, str):
+        return name
+    raise TypeError(f"{param_name} must be the resource's name as a string, e.g. 'pick-grip' (got {type(value).__name__})")
+
+
 class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
     """
     gRPC client for the Motion service.
@@ -55,7 +66,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
 
     async def move(
         self,
-        component_name: str,
+        component_name: Union[str, ResourceName],
         destination: PoseInFrame,
         world_state: Optional[WorldState] = None,
         constraints: Optional[Constraints] = None,
@@ -68,7 +79,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
         request = MoveRequest(
             name=self.name,
             destination=destination,
-            component_name=component_name,
+            component_name=_resource_name_to_str(component_name, "component_name"),
             world_state=world_state,
             constraints=constraints,
             extra=dict_to_struct(extra),
@@ -78,9 +89,9 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
 
     async def move_on_globe(
         self,
-        component_name: str,
+        component_name: Union[str, ResourceName],
         destination: GeoPoint,
-        movement_sensor_name: str,
+        movement_sensor_name: Union[str, ResourceName],
         obstacles: Optional[Sequence[GeoGeometry]] = None,
         heading: Optional[float] = None,
         configuration: Optional[MotionConfiguration] = None,
@@ -93,9 +104,9 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
         md = kwargs.get("metadata", self.Metadata()).proto
         request = MoveOnGlobeRequest(
             name=self.name,
-            component_name=component_name,
+            component_name=_resource_name_to_str(component_name, "component_name"),
             destination=destination,
-            movement_sensor_name=movement_sensor_name,
+            movement_sensor_name=_resource_name_to_str(movement_sensor_name, "movement_sensor_name"),
             obstacles=obstacles,
             heading=heading,
             motion_configuration=configuration,
@@ -107,9 +118,9 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
 
     async def move_on_map(
         self,
-        component_name: str,
+        component_name: Union[str, ResourceName],
         destination: Pose,
-        slam_service_name: str,
+        slam_service_name: Union[str, ResourceName],
         configuration: Optional[MotionConfiguration] = None,
         obstacles: Optional[Sequence[Geometry]] = None,
         *,
@@ -121,8 +132,8 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
         request = MoveOnMapRequest(
             name=self.name,
             destination=destination,
-            component_name=component_name,
-            slam_service_name=slam_service_name,
+            component_name=_resource_name_to_str(component_name, "component_name"),
+            slam_service_name=_resource_name_to_str(slam_service_name, "slam_service_name"),
             motion_configuration=configuration,
             obstacles=obstacles,
             extra=dict_to_struct(extra),
@@ -132,7 +143,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
 
     async def stop_plan(
         self,
-        component_name: str,
+        component_name: Union[str, ResourceName],
         *,
         extra: Optional[Mapping[str, ValueTypes]] = None,
         timeout: Optional[float] = None,
@@ -142,7 +153,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
 
         request = StopPlanRequest(
             name=self.name,
-            component_name=component_name,
+            component_name=_resource_name_to_str(component_name, "component_name"),
             extra=dict_to_struct(extra),
         )
         _: StopPlanResponse = await self.client.StopPlan(request, timeout=timeout, metadata=md)
@@ -150,7 +161,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
 
     async def get_plan(
         self,
-        component_name: str,
+        component_name: Union[str, ResourceName],
         last_plan_only: bool = False,
         execution_id: Optional[str] = None,
         *,
@@ -162,7 +173,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
 
         request = GetPlanRequest(
             name=self.name,
-            component_name=component_name,
+            component_name=_resource_name_to_str(component_name, "component_name"),
             last_plan_only=last_plan_only,
             execution_id=execution_id,
             extra=dict_to_struct(extra),
@@ -190,7 +201,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
 
     async def get_pose(
         self,
-        component_name: str,
+        component_name: Union[str, ResourceName],
         destination_frame: str,
         supplemental_transforms: Optional[Sequence[Transform]] = None,
         *,
@@ -201,7 +212,7 @@ class MotionClient(Motion, ReconfigurableResourceRPCClientBase):
         md = kwargs.get("metadata", self.Metadata()).proto
         request = GetPoseRequest(
             name=self.name,
-            component_name=component_name,
+            component_name=_resource_name_to_str(component_name, "component_name"),
             destination_frame=destination_frame,
             supplemental_transforms=supplemental_transforms,
             extra=dict_to_struct(extra),

--- a/tests/test_motion_service.py
+++ b/tests/test_motion_service.py
@@ -17,9 +17,10 @@ from viam.gen.service.motion.v1.motion_pb2 import (
     PlanStep,
     PlanWithStatus,
 )
-from viam.proto.common import GeoGeometry, Geometry, GeoPoint, Pose, PoseInFrame, Transform, WorldState
+from viam.proto.common import GeoGeometry, Geometry, GeoPoint, Pose, PoseInFrame, ResourceName, Transform, WorldState
 from viam.proto.service.motion import Constraints, LinearConstraint, MotionConfiguration
 from viam.resource.manager import ResourceManager
+from viam.resource.types import RESOURCE_NAMESPACE_RDK, RESOURCE_TYPE_COMPONENT
 from viam.services.motion import MotionClient
 from viam.services.motion.motion import Motion
 from viam.services.motion.service import MotionRPCService
@@ -161,6 +162,51 @@ class TestMotionService:
                 assert patched_method.call_args.args[2] == transforms
                 assert patched_method.call_args.kwargs["extra"] == extra
                 assert patched_method.call_args.kwargs["timeout"] == expected_grpc_timeout(timeout)
+
+    async def test_move_accepts_resource_name(self, motion: Motion, service: MotionRPCService):
+        with patch.object(motion, "move") as patched_method:
+            patched_method.return_value = True
+            async with ChannelFor([service]) as channel:
+                client = MotionClient(MOTION_SERVICE_NAME, channel)
+                resource_name = ResourceName(
+                    namespace=RESOURCE_NAMESPACE_RDK, type=RESOURCE_TYPE_COMPONENT, subtype="gripper", name="pick-grip"
+                )
+                success = await client.move(resource_name, PoseInFrame(reference_frame="refframe"))
+                assert success is True
+                patched_method.assert_called_once()
+                assert patched_method.call_args.args[0] == "pick-grip"
+
+    async def test_get_pose_accepts_resource_name(self, motion: Motion, service: MotionRPCService):
+        with patch.object(motion, "get_pose") as patched_method:
+            patched_method.return_value = PoseInFrame(reference_frame="arm")
+            async with ChannelFor([service]) as channel:
+                client = MotionClient(MOTION_SERVICE_NAME, channel)
+                resource_name = ResourceName(
+                    namespace=RESOURCE_NAMESPACE_RDK, type=RESOURCE_TYPE_COMPONENT, subtype="gripper", name="pick-grip"
+                )
+                await client.get_pose(resource_name, "world")
+                patched_method.assert_called_once()
+                assert patched_method.call_args.args[0] == "pick-grip"
+
+    async def test_move_on_globe_accepts_resource_names(self, motion: Motion, service: MotionRPCService):
+        with patch.object(motion, "move_on_globe") as patched_method:
+            patched_method.return_value = "Move On Globe Response"
+            async with ChannelFor([service]) as channel:
+                client = MotionClient(MOTION_SERVICE_NAME, channel)
+                base_rn = ResourceName(namespace=RESOURCE_NAMESPACE_RDK, type=RESOURCE_TYPE_COMPONENT, subtype="base", name="my-base")
+                sensor_rn = ResourceName(
+                    namespace=RESOURCE_NAMESPACE_RDK, type=RESOURCE_TYPE_COMPONENT, subtype="movement_sensor", name="my-sensor"
+                )
+                await client.move_on_globe(base_rn, GeoPoint(latitude=1, longitude=2), sensor_rn)
+                patched_method.assert_called_once()
+                assert patched_method.call_args.args[0] == "my-base"
+                assert patched_method.call_args.args[2] == "my-sensor"
+
+    async def test_component_name_rejects_unusable_type(self, motion: Motion, service: MotionRPCService):
+        async with ChannelFor([service]) as channel:
+            client = MotionClient(MOTION_SERVICE_NAME, channel)
+            with pytest.raises(TypeError, match="component_name must be the resource's name as a string"):
+                await client.move(1234, PoseInFrame(reference_frame="refframe"))  # pyright: ignore [reportArgumentType]
 
     async def test_move_on_map(self, motion: Motion, service: MotionRPCService):
         with patch.object(motion, "move_on_map") as patched_method:

--- a/tests/test_motion_service.py
+++ b/tests/test_motion_service.py
@@ -163,50 +163,32 @@ class TestMotionService:
                 assert patched_method.call_args.kwargs["extra"] == extra
                 assert patched_method.call_args.kwargs["timeout"] == expected_grpc_timeout(timeout)
 
-    async def test_move_accepts_resource_name(self, motion: Motion, service: MotionRPCService):
-        with patch.object(motion, "move") as patched_method:
-            patched_method.return_value = True
-            async with ChannelFor([service]) as channel:
-                client = MotionClient(MOTION_SERVICE_NAME, channel)
-                resource_name = ResourceName(
-                    namespace=RESOURCE_NAMESPACE_RDK, type=RESOURCE_TYPE_COMPONENT, subtype="gripper", name="pick-grip"
-                )
-                success = await client.move(resource_name, PoseInFrame(reference_frame="refframe"))
-                assert success is True
-                patched_method.assert_called_once()
-                assert patched_method.call_args.args[0] == "pick-grip"
-
-    async def test_get_pose_accepts_resource_name(self, motion: Motion, service: MotionRPCService):
-        with patch.object(motion, "get_pose") as patched_method:
-            patched_method.return_value = PoseInFrame(reference_frame="arm")
-            async with ChannelFor([service]) as channel:
-                client = MotionClient(MOTION_SERVICE_NAME, channel)
-                resource_name = ResourceName(
-                    namespace=RESOURCE_NAMESPACE_RDK, type=RESOURCE_TYPE_COMPONENT, subtype="gripper", name="pick-grip"
-                )
-                await client.get_pose(resource_name, "world")
-                patched_method.assert_called_once()
-                assert patched_method.call_args.args[0] == "pick-grip"
-
-    async def test_move_on_globe_accepts_resource_names(self, motion: Motion, service: MotionRPCService):
-        with patch.object(motion, "move_on_globe") as patched_method:
-            patched_method.return_value = "Move On Globe Response"
-            async with ChannelFor([service]) as channel:
-                client = MotionClient(MOTION_SERVICE_NAME, channel)
-                base_rn = ResourceName(namespace=RESOURCE_NAMESPACE_RDK, type=RESOURCE_TYPE_COMPONENT, subtype="base", name="my-base")
-                sensor_rn = ResourceName(
-                    namespace=RESOURCE_NAMESPACE_RDK, type=RESOURCE_TYPE_COMPONENT, subtype="movement_sensor", name="my-sensor"
-                )
-                await client.move_on_globe(base_rn, GeoPoint(latitude=1, longitude=2), sensor_rn)
-                patched_method.assert_called_once()
-                assert patched_method.call_args.args[0] == "my-base"
-                assert patched_method.call_args.args[2] == "my-sensor"
-
-    async def test_component_name_rejects_unusable_type(self, motion: Motion, service: MotionRPCService):
+    async def test_move_rejects_resource_name(self, motion: Motion, service: MotionRPCService):
         async with ChannelFor([service]) as channel:
             client = MotionClient(MOTION_SERVICE_NAME, channel)
-            with pytest.raises(TypeError, match="component_name must be the resource's name as a string"):
-                await client.move(1234, PoseInFrame(reference_frame="refframe"))  # pyright: ignore [reportArgumentType]
+            gripper = ResourceName(namespace=RESOURCE_NAMESPACE_RDK, type=RESOURCE_TYPE_COMPONENT, subtype="gripper", name="pick-grip")
+            with pytest.raises(TypeError, match="component_name must be the component's name as a string, e.g. 'pick-grip'"):
+                await client.move(gripper, PoseInFrame(reference_frame="refframe"))  # pyright: ignore [reportArgumentType]
+
+    async def test_get_pose_rejects_resource_name(self, motion: Motion, service: MotionRPCService):
+        async with ChannelFor([service]) as channel:
+            client = MotionClient(MOTION_SERVICE_NAME, channel)
+            gripper = ResourceName(namespace=RESOURCE_NAMESPACE_RDK, type=RESOURCE_TYPE_COMPONENT, subtype="gripper", name="pick-grip")
+            with pytest.raises(TypeError, match="component_name must be the component's name as a string, e.g. 'pick-grip'"):
+                await client.get_pose(gripper, "world")  # pyright: ignore [reportArgumentType]
+
+    async def test_move_on_globe_names_the_rejected_param(self, motion: Motion, service: MotionRPCService):
+        async with ChannelFor([service]) as channel:
+            client = MotionClient(MOTION_SERVICE_NAME, channel)
+            sensor = ResourceName(
+                namespace=RESOURCE_NAMESPACE_RDK, type=RESOURCE_TYPE_COMPONENT, subtype="movement_sensor", name="my-sensor"
+            )
+            with pytest.raises(TypeError, match="movement_sensor_name must be the movement sensor's name as a string"):
+                await client.move_on_globe(
+                    "my-base",
+                    GeoPoint(latitude=1, longitude=2),
+                    sensor,  # pyright: ignore [reportArgumentType]
+                )
 
     async def test_move_on_map(self, motion: Motion, service: MotionRPCService):
         with patch.object(motion, "move_on_map") as patched_method:


### PR DESCRIPTION
## Problem

`MotionClient.move` and `MotionClient.get_pose` take `component_name` as a plain string. Older SDK releases took a `ResourceName`, and that is the form older examples (and agents trained on them) still use. Passing a `ResourceName` today fails inside the protobuf C extension with a message that names neither the field nor the expected type:

```
TypeError: bad argument type for built-in operation
```

This was observed in 12 of 12 cold agent runs against a Viam machine: every run's first `Move`/`GetPose` call passed a `ResourceName`, hit that error, and then burned time inspecting the signature before retrying with a string.

## Change

Per the second option in the Jira item, the parameters stay string-only and the client rejects anything else up front with the error text from the ticket:

```
TypeError: component_name must be the component's name as a string, e.g. 'pick-grip'
```

Applied to every parameter in the motion client that took a `ResourceName` in older releases, so a copied old call site does not just fail one argument later:

- `move`, `get_pose`, `stop_plan`, `get_plan` — `component_name`
- `move_on_globe` — `component_name`, `movement_sensor_name`
- `move_on_map` — `component_name`, `slam_service_name`

No signature, type-hint, or wire-format changes: valid string calls behave exactly as before, and the `Motion` abstract interface and service side are untouched.

One deliberate deviation from the ticket's wording: the check is an explicit `isinstance` test on the parameter rather than a `try/except TypeError` around the request construction. Catching there would also swallow type errors raised by other fields (for example a bad `destination`) and mislabel them as a bad `component_name`. The observable behavior for the reported case is identical. Happy to switch to the literal catch if you prefer it.

## Tests

Added to `tests/test_motion_service.py`: `move` and `get_pose` raise the new message when handed a `ResourceName`, and `move_on_globe` names `movement_sensor_name` when that is the bad argument. Existing tests cover the string path.

`pytest`, `ruff check`, `ruff format`, and `pyright` pass. (`tests/test_native.py`, `tests/test_rpc.py` and `tests/test_spatialmath.py` fail in this sandbox only because `libviam_rust_utils.so` could not be downloaded; unrelated to this change.)

## Note

Companion TypeScript fix: viamrobotics/viam-typescript-sdk#1001. There the same call is not rejected by protobuf-es at all — a `ResourceName` is serialized as `'[object Object]'` and sent to the machine as the component name.

Key: RSDK-14517

Co-authored by Claude agent for Jira.