### PR TITLE
Do not pass --base when updating the stacked wrapper PR

### DIFF
--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -403,7 +403,6 @@ jobs:
             --body "$BODY" \
             --reviewer viamrobotics/sdk \
             || gh pr edit ${{ env.WRAPPER_BRANCH }} \
-              --base ${{ env.PROTO_BRANCH }} \
               --title "Automated Protos Update: Python wrappers" \
               --body "$BODY"
 


### PR DESCRIPTION
On a re-run, `gh pr create` fails because the PR already exists and the `gh pr edit` fallback takes over. That fallback passed --base, which GitHub now rejects:

    GraphQL: Cannot change the base branch because the pull request is part
    of a stack. (updatePullRequest)

The base is already correct -- gh pr create set it when the PR was opened, and GitHub manages retargeting within a stack itself -- so passing it again is both redundant and fatal. The bottom PR's fallback never passed --base, which is why only the wrapper PR hit this.